### PR TITLE
User registration denied message for successful login too

### DIFF
--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -756,6 +756,8 @@ function ur_get_form_setting_by_key( $form_id, $meta_key, $default = '' ) {
  */
 function ur_get_user_approval_status( $user_id ) {
 
+   $user_status = 1;
+
 	$login_option = get_option( 'user_registration_general_setting_login_options', '' );
 
 	if ( 'admin_approval' === $login_option ) {
@@ -767,12 +769,12 @@ function ur_get_user_approval_status( $user_id ) {
 			return $user_status;
 		}
 
-		return true;
+		return $user_status;
 
 
 	}
 
-	return true;
+	return $user_status;
 
 }
 


### PR DESCRIPTION
It seems this if-else condition seems to be true
https://github.com/wpeverest/user-registration/blob/master/includes/class-ur-emailer.php#L90

When we do `return true` here https://github.com/wpeverest/user-registration/blob/master/includes/functions-ur-core.php#L775
Hence it seems whether the return value it true or -1, this condition seems to be triggered and although the user is successfully registered, the user gets the denied message
