### PR TITLE
lock install routine to only allow for one execution

### DIFF
--- a/includes/class-ur-install.php
+++ b/includes/class-ur-install.php
@@ -93,17 +93,16 @@ class UR_Install {
 		}
 
 		// Check if we are not already running this routine.
-		if ( 'yes' === get_transient( 'UR_INSTALLING' ) ) {
+		if ( 'yes' === get_transient( 'ur_installing' ) ) {
 			return;
 		}
 
 		// If we made it till here nothing is running yet, lets set the transient now.
-		set_transient( 'UR_INSTALLING', 'yes', MINUTE_IN_SECONDS * 10 );
+		set_transient( 'ur_installing', 'yes', MINUTE_IN_SECONDS * 10 );
 
 		if ( ! defined( 'UR_INSTALLING' ) ) {
 			define( 'UR_INSTALLING', true );
 		}
-
 
 		// Ensure needed classes are loaded
 		include_once( dirname( __FILE__ ) . '/admin/class-ur-admin-notices.php' );
@@ -148,7 +147,7 @@ class UR_Install {
 
 		self::update_ur_version();
 
-		delete_transient( 'UR_INSTALLING' );
+		delete_transient( 'ur_installing' );
 		
 		// Flush rules after install
 		do_action( 'user_registration_flush_rewrite_rules' );


### PR DESCRIPTION
Lock the install routine via a transient to prohibit race conditions due to firing on init hook