### PR TITLE
Update postmeta instead of usermeta

### DIFF
--- a/includes/admin/class-ur-admin-profile.php
+++ b/includes/admin/class-ur-admin-profile.php
@@ -223,9 +223,7 @@ if ( ! class_exists( 'UR_Admin_Profile', false ) ) :
 												<?php echo esc_attr( $attribute_string ); ?>
 											/>
 
-										<?php } else {										
-											$this->show_undefined_fields( $key, $user->ID, $field, $extra_params );
-										}
+										<?php } 
 									} endif; ?>
 								<br/>
 								<span class="description"><?php echo wp_kses_post( $field['description'] ); ?></span>
@@ -239,109 +237,6 @@ if ( ! class_exists( 'UR_Admin_Profile', false ) ) :
 			endforeach;
 		}
 
-		/**
-		 * @param $key
-		 * @param $user_id
-		 * @param $field
-		 */
-		public function show_undefined_fields( $key, $user_id, $field, $extra_params ) {
-
-			$value     = $this->get_user_meta( $user_id, $key );
-			$field_key = $extra_params->field_key;
-		
-			$type      = 'hidden';
-			switch ( $field_key ) {
-				case "file":
-					$attachment_url = wp_get_attachment_thumb_url( $value );
-					if ( ! empty( $attachment_url ) ) {
-						echo '<img src="' . $attachment_url . '" width="80"/>';
-					} else {
-						echo __( 'Attachment not found.', 'user-registration' );
-					}
-					break;
-
-				case "privacy_policy":
-					echo '<input checked type="checkbox" disabled="disabled"/>';
-				break;
-
-				case "checkbox":
-
-					$checkbox_array = json_decode( $value, true );
-					if ( is_array( $checkbox_array ) && ! empty( $checkbox_array ) ) {
-
-						foreach ( $checkbox_array as $check ) {
-
-							echo '<label><input checked type="checkbox" disabled="disabled"/>' . esc_html($check) . '</label><br/>';
-						}
-					} else {
-						echo '<label><input checked type="checkbox" disabled="disabled"/></label>';
-
-					}
-
-					break;
-
-				case "select":
-				
-					$result = explode('__', $value);
-					if( is_array( $result ) && isset( $result[1] )){
-						$value = $result[1];
-					}
-
-					?>
-						<select name="<?php echo esc_attr( $key ); ?>"
-							    id="<?php echo esc_attr( $key );?>"
-							    class="<?php echo( ! empty( $field['class'] ) ? esc_attr( $field['class'] ) : 'regular-text' ); ?>"
-						disabled/>
-						<option><?php echo esc_attr( $value );?></option>
-					<?php
-					break;
-
-				case "radio":
-
-					$result = explode('__', $value);
-					if( is_array( $result ) && isset( $result[1] )){
-						$value = $result[1];
-					}
-					?>
-						<input type="radio" name="<?php echo esc_attr( $key ); ?>"
-			       id="<?php echo esc_attr( $key ); ?>"
-			       value="<?php echo esc_attr( $value ); ?>" checked="checked" disabled/> <?php echo esc_attr( $value );?>
-					<?php
-					break;
-
-				case "country":
-					
-					include_once( dirname( __FILE__ ) . '\..\form\class-ur-country.php' );
-
-					$country = new UR_Country;
-					$countries = $country->get_country();
-
-					if( is_array( $countries ) && array_key_exists( $value, $countries ) ){
-						?>
-							<select name="<?php echo esc_attr( $key ); ?>"
-								    id="<?php echo esc_attr( $key );?>"
-								    class="<?php echo( ! empty( $field['class'] ) ? esc_attr( $field['class'] ) : 'regular-text' ); ?>"
-							disabled/>
-							<option><?php echo esc_attr( $countries[$value] );?></option>
-						<?php
-					}
-					
-					break;
-				
-				default:
-					$type = 'text';
-			}
-
-			?>
-
-			<input type="<?php echo $type; ?>" name="<?php echo esc_attr( $key ); ?>"
-			       id="<?php echo esc_attr( $key ); ?>"
-			       value="<?php echo esc_attr( $value ); ?>"
-			       class="<?php echo( ! empty( $field['class'] ) ? esc_attr( $field['class'] ) : 'regular-text' ); ?>"
-			/>
-			<?php
-
-		}
 
 		/**
 		 * Save Address Fields on edit user pages.
@@ -579,27 +474,7 @@ if ( ! class_exists( 'UR_Admin_Profile', false ) ) :
 					}// End foreach().
 				}// End foreach().
 			}// End foreach().
-
-			foreach ( $all_meta_value_keys as $single_key ) {
-
-				$field_label_array = explode( '_', str_replace( 'user_registration_', '', $single_key ) );
-
-				$field_label = join( ' ', array_map( 'ucwords', $field_label_array ) );
-
-				if ( ! isset( $fields[ $single_key ] ) ) {
-
-					$fields[ $single_key ] = array(
-						'label'       => __( $field_label, 'user-registration' ),
-						'description' => '',
-						'attributes'  => array(
-							'disabled' => 'disabled',
-
-						),
-
-					);
-
-				}
-			}
+			
 			return $fields;
 		}
 

--- a/includes/frontend/class-ur-frontend-form-handler.php
+++ b/includes/frontend/class-ur-frontend-form-handler.php
@@ -186,10 +186,6 @@ class UR_Frontend_Form_Handler {
 				}
 
 				update_user_meta( $user_id, $field_key, $data->value );
-				if ( isset( $data->extra_params ) ) {
-
-				update_user_meta( $user_id, 'ur_' . $field_key_for_param . '_params', wp_json_encode( $data->extra_params, JSON_UNESCAPED_UNICODE ) );
-				}
 			}
 		}
 		update_user_meta( $user_id, 'ur_form_id', $form_id );

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -415,27 +415,7 @@ if ( ! function_exists( 'user_registration_form_data' ) ) {
 			}// End foreach().
 		}// End foreach().
 
-		foreach ( $all_meta_value_keys as $single_key ) {
-			if ( substr( $single_key, 0, strlen( 'user_registration_' ) ) == 'user_registration_' ) {
-				if ( ! isset( $fields[ $single_key ] ) ) {
-
-					$field_label_array     = explode( '_', str_replace( 'user_registration_', '', $single_key ) );
-					$field_label           = join( ' ', array_map( 'ucwords', $field_label_array ) );
-					$fields[ $single_key ] = array(
-						'label'             => __( $field_label, 'user-registration' ),
-						'description'       => '',
-						'type'              => 'text',
-						'field_key'         => 'text',
-						'required'          => false,
-						'custom_attributes' => array(
-							'disabled' => 'disabled',
-						),
-						'default'           => isset( $all_meta_value[ $single_key ][0] ) ? $all_meta_value[ $single_key ][0] : '',
-					);
-				}
-			}
-		}
-
+		
 		return $fields;
 	}
 }// End if().
@@ -500,97 +480,6 @@ if ( ! function_exists( 'user_registration_account_edit_account' ) ) {
 	}
 }
 
-if ( ! function_exists( 'show_undefined_frontend_fields' ) ) {
-
-	function show_undefined_frontend_fields( $key, $user_id, $field, $extra_params) {
-
-		$value     = get_user_meta( $user_id, $key, true );
-		$field_key = isset( $extra_params->field_key ) ? $extra_params->field_key : '';
-		$label = isset( $extra_params->label ) ? $extra_params->label : '';
-
-		switch ( $field_key ) {
-			case "checkbox":
-				$checkbox_array = json_decode( $value, true );
-				
-				if ( is_array( $checkbox_array ) && ! empty( $checkbox_array ) ) {
-					echo '<label>'. $label . '</label>';
-					foreach ( $checkbox_array as $check ) {
-
-						echo '<label><input checked value="'. trim( $check ) .'" type="checkbox" disabled="disabled"/>' . esc_html( $check ) . '</label>';
-					}
-				} else {
-
-					echo '<label><input checked type="checkbox" disabled="disabled"/>' . esc_html($label) .'</label>';
-				}
-			break;
-
-			case "select":
-			$old_value = $value;
-			$result = explode('__', $value);
-			if( is_array( $result ) && isset( $result[1] )){
-				$value = $result[1];
-			}
-				echo '<label>'. $label . '</label>';
-			?>	
-				<select name="<?php echo esc_attr( $key ); ?>"
-					    id="<?php echo esc_attr( $key );?>"
-
-					    class="<?php echo( ! empty( $field['class'] ) ? esc_attr( $field['class'] ) : 'regular-text' ); ?>"
-				disabled/>
-					<option value="<?php echo esc_attr( $old_value );?>"><?php echo esc_attr( $value );?></option>
-				</select>
-			<?php
-
-			break;
-
-			case "radio":
-			$old_value = $value;
-			$result = explode('__', $value);
-			if( is_array( $result ) && isset( $result[1] )){
-				$value = $result[1];
-			}
-				echo '<label>'. $label . '</label>';
-			?>
-				<label><input type="radio" name="<?php echo esc_attr( $key ); ?>"
-	       			id="<?php echo esc_attr( $key ); ?>"
-	       			value="<?php echo esc_attr( $old_value ); ?>" checked="checked" disabled/> <?php echo esc_attr( $value );?></label>
-			<?php
-			break;
-
-			case "country":
-		
-			include_once( UR_ABSPATH . 'includes/form/class-ur-country.php' );
-
-			$country = new UR_Country;
-			$countries = $country->get_country();
-
-			if( is_array( $countries ) && array_key_exists( $value, $countries ) ){
-					echo '<label>'. $label . '</label>';
-				?>
-					<select name="<?php echo esc_attr( $key ); ?>"
-						    id="<?php echo esc_attr( $key );?>"
-						    class="<?php echo( ! empty( $field['class'] ) ? esc_attr( $field['class'] ) : 'regular-text' ); ?>"
-					disabled/>
-					<option><?php echo esc_attr( $countries[$value] );?></option>
-				</select>
-				<?php
-			}
-			
-			break;
-
-			case "privacy_policy":
-			break;
-
-			default:
-			echo '<label>'. $label . '</label>';
-			?><input type="text" name="<?php echo esc_attr( $key ); ?>"
-	       			id="<?php echo esc_attr( $key ); ?>"
-	       			value="<?php echo esc_attr( $value ); ?>" disabled/>
-	       	<?php
-			
-		}
-	}
-}
 /**
  * Get logout endpoint.
  *


### PR DESCRIPTION
This PR utilizes postmeta instead of usermeta to store field key and label for for each form. Additionally, deleted form fields are now not rendered in user profile.