### PR TITLE
Refactor - How meta values are stored in usermeta

### DIFF
--- a/includes/abstracts/abstract-ur-form-field.php
+++ b/includes/abstracts/abstract-ur-form-field.php
@@ -129,9 +129,7 @@ abstract class UR_Form_Field {
 			if ( is_array( $option_data ) ) {
 
 				foreach ( $option_data as $index_data => $option ) {
-
-					$form_data['options'][ $index_data . '__' . $option ] = $option;
-
+					$form_data['options'][ $option ] = $option;				
 				}
 			}
 		}
@@ -142,9 +140,7 @@ abstract class UR_Form_Field {
 			if ( is_array( $option_data ) ) {
 
 				foreach ( $option_data as $index_data => $option ) {
-
-					$form_data['options'][ $index_data . '__' . $option ] = $option;
-
+					$form_data['options'][ $option ] = $option;
 				}
 			}
 		}
@@ -155,9 +151,7 @@ abstract class UR_Form_Field {
 			if ( is_array( $choices ) ) {
 
 				foreach ( $choices as $index_data => $choice ) {
-
-					$form_data['choices'][ $index_data . '__' . $choice ] = $choice;
-
+					$form_data['choices'][ $choice ] = $choice;
 				}
 			}
 		}

--- a/includes/admin/class-ur-admin-profile.php
+++ b/includes/admin/class-ur-admin-profile.php
@@ -67,6 +67,7 @@ if ( ! class_exists( 'UR_Admin_Profile', false ) ) :
 			$show_fields = $this->get_customer_meta_fields( $user->ID );
 
 			foreach ( $show_fields as $fieldset_key => $fieldset ) :
+
 				?>
 				<h2><?php echo $fieldset['title']; ?></h2>
 				<table class="form-table" id="<?php echo esc_attr( 'fieldset-' . $fieldset_key ); ?>">
@@ -80,6 +81,7 @@ if ( ! class_exists( 'UR_Admin_Profile', false ) ) :
 						'radio'
 					);
 					foreach ( $fieldset['fields'] as $key => $field ) :
+					
 						$field['label'] = isset( $field['label'] ) ? $field['label'] : '';
 						$field['description'] = isset( $field['description'] ) ? $field['description'] : '';
 						$attributes           = isset( $field['attributes'] ) ? $field['attributes'] : array();
@@ -118,9 +120,8 @@ if ( ! class_exists( 'UR_Admin_Profile', false ) ) :
 										<option><?php echo __( 'Select', 'user-registration' ); ?></option>
 										<?php
 										$selected = esc_attr( get_user_meta( $user->ID, $key, true ) );
-										foreach ( $field['options'] as $option_key => $option_value ) : ?>
-											<option data-val="<?php echo $selected; ?>"
-											        value="<?php echo esc_attr( $option_key ); ?>" <?php selected( $selected, $option_key, true ); ?>><?php echo esc_attr( $option_value ); ?></option>
+										foreach ( $field['options'] as $option_key => $option_value ) : ?>						
+											<option value="<?php echo esc_attr( $option_key ); ?>" <?php selected( $selected, $option_key, true ); ?>><?php echo esc_attr( $option_value ); ?></option>
 										<?php endforeach; ?>
 									</select>
 								
@@ -139,9 +140,6 @@ if ( ! class_exists( 'UR_Admin_Profile', false ) ) :
 								<?php elseif ( ! empty( $field['type'] ) && 'radio' === $field['type'] ) : ?>
 									<?php 
 									$db_value = get_user_meta( $user->ID, $key, true );
-									$db_value = explode("__", $db_value);
-									$db_value = isset( $db_value[1] ) ? $db_value[1] : '';
-
 									if( is_array( $field['options'] ) ) {
 										foreach( $field['options'] as $option_key => $option_value ) {
 											?>
@@ -407,7 +405,7 @@ if ( ! class_exists( 'UR_Admin_Profile', false ) ) :
 
 										foreach ( $option_data as $index_data => $option ) {
 
-											$fields[ $field_index ]['options'][ $index_data . '__' . $option ] = $option;
+											$fields[ $field_index ]['options'][ $option ] = $option;
 										}
 										$fields[ $field_index ]['type']  = 'select';
 										$fields[ $field_index ]['class'] = '';
@@ -421,7 +419,7 @@ if ( ! class_exists( 'UR_Admin_Profile', false ) ) :
 
 										foreach ( $option_data as $index_data => $option ) {
 
-											$fields[ $field_index ]['options'][ $index_data . '__' . $option ] = $option;
+											$fields[ $field_index ]['options'][ $option ] = $option;
 										}
 										$fields[ $field_index ]['type']  = 'radio';
 

--- a/includes/frontend/class-ur-frontend-form-handler.php
+++ b/includes/frontend/class-ur-frontend-form-handler.php
@@ -47,7 +47,8 @@ class UR_Frontend_Form_Handler {
 				'role'     => $user_role,
 			);
 
-				self::$valid_form_data = apply_filters( 'user_registration_before_register_user_filter', self::$valid_form_data, $form_id );
+			self::$valid_form_data = apply_filters( 'user_registration_before_register_user_filter', self::$valid_form_data, $form_id );
+
 			do_action( 'user_registration_before_register_user_action', self::$valid_form_data, $form_id );
 			$user_id = wp_insert_user( $userdata );
 

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -369,14 +369,14 @@ if ( ! function_exists( 'user_registration_form_data' ) ) {
 							case 'select':
 								$extra_params['options'] = explode( ',', $field->advance_setting->options );
 								foreach ($extra_params['options'] as $key => $value) {
-									$extra_params['options'][$key.'__'.$value] = $value;
+									$extra_params['options'][$value] = $value;
 									unset($extra_params['options'][$key]);
 								}							
 								break;
 							case 'checkbox':
 								$extra_params['choices'] = explode( ',', $field->advance_setting->choices );
 								foreach ($extra_params['choices'] as $key => $value) {
-									$extra_params['choices'][$key.'__'.$value] = $value;
+									$extra_params['choices'][$value] = $value;
 									unset($extra_params['choices'][$key]);
 								}
 								break;


### PR DESCRIPTION
Previously data were saved in format like `0__Radio1` to retrieve deleted fields value. But since we are treating deleted fields not to display in user profile this values are now stored like `Radio1`. This scenerio is for radio and select fields which were changed as no need to save key and value pairs in usermeta :)
