### PR TITLE
Update/checkbox refactor #26

### DIFF
--- a/includes/admin/class-ur-admin-profile.php
+++ b/includes/admin/class-ur-admin-profile.php
@@ -158,7 +158,6 @@ if ( ! class_exists( 'UR_Admin_Profile', false ) ) :
 									<?php
 
 									$array = get_user_meta( $user->ID, $key, true );								
-									$array = unserialize($array);
 
 									if ( count( $field['choices'] ) > 1 && is_array( $field['choices'] ) ) {
 										foreach ( $field['choices'] as $choice ) {
@@ -246,15 +245,8 @@ if ( ! class_exists( 'UR_Admin_Profile', false ) ) :
 
 					if ( isset( $field['type'] ) && 'checkbox' === $field['type'] ) {
 						if ( isset( $_POST[ $key ] ) && is_array( $_POST[ $key ] ) ) {
-							$values = serialize( $_POST[ $key ] );
-							update_user_meta( $user_id, $key, $values );
+							update_user_meta( $user_id, $key, $_POST[ $key ] );
 						} 
-						elseif( isset( $field['type'] ) && 'radio' === $field['type'] ) {
-
-						}
-						else {
-							update_user_meta( $user_id, $key, isset( $_POST[ $key ] ) );
-						}
 					} elseif ( isset( $_POST[ $key ] ) ) {
 						update_user_meta( $user_id, $key, sanitize_text_field( $_POST[ $key ] ) );
 					}

--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -79,12 +79,10 @@ class UR_Form_Handler {
 			switch ( $field['type'] ) {
 				case 'checkbox' :
 				
-				if(isset($_POST[$key]) && is_array($_POST[$key])){
-
-					$_POST[$key] = serialize($_POST[$key]);
+				if( isset( $_POST[$key] ) && is_array( $_POST[$key] ) ) {
+					$_POST[$key] = $_POST[$key];
 				}
-				else{
-
+				else {
 					$_POST[ $key ] = (int) isset( $_POST[ $key ] );
 				}
 					break;

--- a/includes/frontend/class-ur-frontend-form-handler.php
+++ b/includes/frontend/class-ur-frontend-form-handler.php
@@ -186,8 +186,7 @@ class UR_Frontend_Form_Handler {
 					$field_key = 'user_registration_' . $field_key;
 				}
 				if( isset( $data->extra_params['field_key'] ) && $data->extra_params['field_key'] === 'checkbox' ) {
-					$data->value = json_decode( $data->value );
-					$data->value = serialize( $data->value );
+					$data->value = json_decode( $data->value );	
 				}
 				update_user_meta( $user_id, $field_key, $data->value );
 			}

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -182,12 +182,8 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 
 			if(isset($args['choices']) && count($args['choices'])>1 ){
 
-				$default = !empty($args['default']) ? unserialize( $args['default']  ) : array();
+				$default = !empty($args['default']) ? unserialize( $args['default'] ) : array();		
 
-				if ( is_string( $default ) ) {
-					$default = unserialize($default);
-				}
-				
 				$choices = isset( $args['choices'] ) ? $args['choices'] : array();
 
 				$field   = '<label class="checkbox ' . implode( ' ', $custom_attributes ) . '">';


### PR DESCRIPTION
Previously, `serialize()` function was used resulting in double serialization because wordpress automatically serializes an array.