### PR TITLE
Refactor - Install scripts to run updates callback per version

### DIFF
--- a/includes/class-ur-install.php
+++ b/includes/class-ur-install.php
@@ -2,22 +2,22 @@
 /**
  * Installation related functions and actions.
  *
- * @class    UR_Install
- * @version  1.0.0
- * @package  UserRegistration/Classes
- * @category Admin
- * @author   WPEverest
+ * @package UserRegistration\Classes
+ * @since   1.2.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
  * UR_Install Class.
  */
 class UR_Install {
-	/** @var array DB updates and callbacks that need to be run per version */
+
+	/**
+	 * DB updates and callbacks that need to be run per version.
+	 *
+	 * @var array
+	 */
 	private static $db_updates = array(
 		'1.0.0' => array(
 			'ur_update_100_db_version',
@@ -28,7 +28,11 @@ class UR_Install {
 		),
 	);
 
-	/** @var object Background update class */
+	/**
+	 * Background update class.
+	 *
+	 * @var object
+	 */
 	private static $background_updater;
 
 	/**
@@ -41,13 +45,14 @@ class UR_Install {
 		add_action( 'in_plugin_update_message-user-registration/user-registration.php', array( __CLASS__, 'in_plugin_update_message' ) );
 		add_filter( 'plugin_action_links_' . UR_PLUGIN_BASENAME, array( __CLASS__, 'plugin_action_links' ) );
 		add_filter( 'plugin_row_meta', array( __CLASS__, 'plugin_row_meta' ), 10, 2 );
+		add_filter( 'wpmu_drop_tables', array( __CLASS__, 'wpmu_drop_tables' ) );
 	}
 
 	/**
 	 * Init background updates.
 	 */
 	public static function init_background_updater() {
-		include_once( 'class-ur-background-updater.php' );
+		include_once dirname( __FILE__ ) . '/class-ur-background-updater.php';
 		self::$background_updater = new UR_Background_Updater();
 	}
 
@@ -57,7 +62,7 @@ class UR_Install {
 	 * This check is done on all requests and runs if the versions do not match.
 	 */
 	public static function check_version() {
-		if ( ! defined( 'IFRAME_REQUEST' ) && get_option( 'user_registration_version' ) !== UR()->version ) {
+		if ( ! defined( 'IFRAME_REQUEST' ) && version_compare( get_option( 'user_registration_version' ), UM()->version, '<' ) ) {
 			self::install();
 			do_action( 'user_registration_updated' );
 		}
@@ -69,15 +74,16 @@ class UR_Install {
 	 * This function is hooked into admin_init to affect admin only.
 	 */
 	public static function install_actions() {
-		if ( ! empty( $_GET['do_update_user_registration'] ) ) {
+		if ( ! empty( $_GET['do_update_user_registration'] ) ) { // WPCS: input var okay, CSRF ok.
 			self::update();
 			UR_Admin_Notices::add_notice( 'update' );
 		}
-		if ( ! empty( $_GET['force_update_user_registration'] ) ) {
-			do_action( 'wp_ur_updater_cron' );
+		if ( ! empty( $_GET['force_update_user_registration'] ) ) { // WPCS: input var okay, CSRF ok.
+			do_action( 'wp_' . get_current_blog_id() . '_ur_updater_cron' );
 			wp_safe_redirect( admin_url( 'admin.php?page=user-registration-settings' ) );
+			exit;
 		}
-		if ( ! empty( $_GET['install_user_registration_pages'] ) ) {
+		if ( ! empty( $_GET['install_user_registration_pages'] ) ) { // WPCS: input var okay, CSRF ok.
 			self::create_pages();
 			UR_Admin_Notices::remove_notice( 'install' );
 		}
@@ -87,8 +93,6 @@ class UR_Install {
 	 * Install UR.
 	 */
 	public static function install() {
-
-		global $wpdb;
 		if ( ! is_blog_installed() ) {
 			return;
 		}
@@ -100,103 +104,94 @@ class UR_Install {
 
 		// If we made it till here nothing is running yet, lets set the transient now.
 		set_transient( 'ur_installing', 'yes', MINUTE_IN_SECONDS * 10 );
+		ur_maybe_define_constant( 'UR_INSTALLING', true );
 
-		if ( ! defined( 'UR_INSTALLING' ) ) {
-			define( 'UR_INSTALLING', true );
-		}
-
-		// Ensure needed classes are loaded
-		include_once( dirname( __FILE__ ) . '/admin/class-ur-admin-notices.php' );
-
+		self::remove_admin_notices();
 		self::create_options();
 		self::create_tables();
 		self::create_roles();
-
-		// Register post types
-		UR_Post_Types::register_post_types();
-
-		// Create default form
+		self::setup_environment();
 		self::create_form();
-
-		// Also register endpoints - this needs to be done prior to rewrite rule flush
-		UR()->query->init_query_vars();
-		UR()->query->add_endpoints();
-
-		// Queue upgrades wizard
-		$current_ur_version = get_option( 'user_registration_version', null );
-		$current_db_version = get_option( 'user_registration_db_version', null );
-
 		self::create_files();
-
-		UR_Admin_Notices::remove_all_notices();
-
-		// No versions? This is a new install :)
-		if ( is_null( $current_ur_version ) && is_null( $current_db_version ) && apply_filters( 'user_registration_enable_setup_wizard', true ) ) {
-			UR_Admin_Notices::add_notice( 'install' );
-			set_transient( '_ur_activation_redirect', 1, 30 );
-
-			// No page? Let user run wizard again..
-		} elseif ( ! get_option( 'user_registration_myaccount_page_id' ) ) {
-			UR_Admin_Notices::add_notice( 'install' );
-		}
-
-		if ( ! is_null( $current_db_version ) && version_compare( $current_db_version, max( array_keys( self::$db_updates ) ), '<' ) ) {
-			UR_Admin_Notices::add_notice( 'update' );
-		} else {
-			self::update_db_version();
-		}
-
+		self::maybe_enable_setup_wizard();
 		self::update_ur_version();
+		self::maybe_update_db_version();
 
 		delete_transient( 'ur_installing' );
 
-		// Flush rules after install
 		do_action( 'user_registration_flush_rewrite_rules' );
-
-		/*
-		 * Deletes all expired transients. The multi-table delete syntax is used
-		 * to delete the transient record from table a, and the corresponding
-		 * transient_timeout record from table b.
-		 *
-		 * Based on code inside core's upgrade_network() function.
-		 */
-		$sql = "DELETE a, b FROM $wpdb->options a, $wpdb->options b
-			WHERE a.option_name LIKE %s
-			AND a.option_name NOT LIKE %s
-			AND b.option_name = CONCAT( '_transient_timeout_', SUBSTRING( a.option_name, 12 ) )
-			AND b.option_value < %d";
-		$wpdb->query( $wpdb->prepare( $sql, $wpdb->esc_like( '_transient_' ) . '%', $wpdb->esc_like( '_transient_timeout_' ) . '%', time() ) );
-
-		// Trigger action
 		do_action( 'user_registration_installed' );
 	}
 
 	/**
-	 * Create files/directories.
+	 * Reset any notices added to admin.
+	 *
+	 * @since 1.2.0
 	 */
-	private static function create_files() {
-		// Install files and folders for uploading files and prevent hotlinking
-		$upload_dir = wp_upload_dir();
+	private static function remove_admin_notices() {
+		include_once dirname( __FILE__ ) . '/admin/class-ur-admin-notices.php';
+		UR_Admin_Notices::remove_all_notices();
+	}
 
-		$files = array(
-			array(
-				'base'    => UR_LOG_DIR,
-				'file'    => '.htaccess',
-				'content' => 'deny from all',
-			),
-			array(
-				'base'    => UR_LOG_DIR,
-				'file'    => 'index.html',
-				'content' => '',
-			),
-		);
-		foreach ( $files as $file ) {
-			if ( wp_mkdir_p( $file['base'] ) && ! file_exists( trailingslashit( $file['base'] ) . $file['file'] ) ) {
-				if ( $file_handle = @fopen( trailingslashit( $file['base'] ) . $file['file'], 'w' ) ) {
-					fwrite( $file_handle, $file['content'] );
-					fclose( $file_handle );
-				}
+	/**
+	 * Setup UR environment - post types, taxonomies, endpoints.
+	 *
+	 * @since 1.2.0
+	 */
+	private static function setup_environment() {
+		UR_Post_Types::register_post_types();
+		UR()->query->init_query_vars();
+		UR()->query->add_endpoints();
+	}
+
+	/**
+	 * Is this a brand new UR install?
+	 *
+	 * @since  1.2.0
+	 * @return boolean
+	 */
+	private static function is_new_install() {
+		return is_null( get_option( 'user_registration_version', null ) ) && is_null( get_option( 'user_registration_db_version', null ) );
+	}
+
+	/**
+	 * Is a DB update needed?
+	 *
+	 * @since  1.2.0
+	 * @return boolean
+	 */
+	private static function needs_db_update() {
+		$current_db_version = get_option( 'user_registration_db_version', null );
+		$updates            = self::get_db_update_callbacks();
+
+		return ! is_null( $current_db_version ) && version_compare( $current_db_version, max( array_keys( $updates ) ), '<' );
+	}
+
+	/**
+	 * See if we need the wizard or not.
+	 */
+	private static function maybe_enable_setup_wizard() {
+		if ( apply_filters( 'user_registration_enable_setup_wizard', self::is_new_install() ) ) {
+			UR_Admin_Notices::add_notice( 'install' );
+			set_transient( '_ur_activation_redirect', 1, 30 );
+		}
+	}
+
+	/**
+	 * See if we need to show or run database updates during install.
+	 *
+	 * @since 1.2.0
+	 */
+	private static function maybe_update_db_version() {
+		if ( self::needs_db_update() ) {
+			if ( apply_filters( 'user_registration_enable_auto_update_db', false ) ) {
+				self::init_background_updater();
+				self::update();
+			} else {
+				UR_Admin_Notices::add_notice( 'update' );
 			}
+		} else {
+			self::update_db_version();
 		}
 	}
 
@@ -209,14 +204,23 @@ class UR_Install {
 	}
 
 	/**
+	 * Get list of DB update callbacks.
+	 *
+	 * @since  1.2.0
+	 * @return array
+	 */
+	public static function get_db_update_callbacks() {
+		return self::$db_updates;
+	}
+
+	/**
 	 * Push all needed DB updates to the queue for processing.
 	 */
 	private static function update() {
 		$current_db_version = get_option( 'user_registration_db_version' );
 		$update_queued      = false;
-		$get_admin_notices  = get_option( 'user_registration_admin_notices' );
 
-		foreach ( self::$db_updates as $version => $update_callbacks ) {
+		foreach ( self::get_db_update_callbacks() as $version => $update_callbacks ) {
 			if ( version_compare( $current_db_version, $version, '<' ) ) {
 				foreach ( $update_callbacks as $update_callback ) {
 					self::$background_updater->push_to_queue( $update_callback );
@@ -227,18 +231,74 @@ class UR_Install {
 
 		if ( $update_queued ) {
 			self::$background_updater->save()->dispatch();
-			update_option('user_registration_admin_notices', $get_admin_notices);
 		}
 	}
 
 	/**
 	 * Update DB version to current.
 	 *
-	 * @param string $version
+	 * @param string|null $version New UserRegistration DB version or null.
 	 */
 	public static function update_db_version( $version = null ) {
 		delete_option( 'user_registration_db_version' );
 		add_option( 'user_registration_db_version', is_null( $version ) ? UR()->version : $version );
+	}
+
+	/**
+	 * Create pages that the plugin relies on, storing page IDs in variables.
+	 */
+	public static function create_pages() {
+		include_once dirname( __FILE__ ) . '/admin/functions-ur-admin.php';
+
+		$pages = apply_filters(
+			'user_registration_create_pages', array(
+				'myaccount' => array(
+					'name'    => _x( 'my-account', 'Page slug', 'user-registration' ),
+					'title'   => _x( 'My Account', 'Page title', 'user-registration' ),
+					'content' => '[' . apply_filters( 'user_registration_my_account_shortcode_tag', 'user_registration_my_account' ) . ']',
+				),
+			)
+		);
+
+		if ( $default_form_page_id = get_option( 'user_registration_default_form_page_id' ) ) {
+			$pages['registration'] = array(
+				'name'    => _x( 'registration', 'Page slug', 'user-registration' ),
+				'title'   => _x( 'Registration', 'Page title', 'user-registration' ),
+				'content' => '[' . apply_filters( 'user_registration_form_shortcode_tag', 'user_registration_form' ) . ' id="' . $default_form_page_id . '"]',
+			);
+		}
+
+		foreach ( $pages as $key => $page ) {
+			ur_create_page( esc_sql( $page['name'] ), 'user_registration_' . $key . '_page_id', $page['title'], $page['content'] );
+		}
+	}
+
+	/**
+	 * Default options.
+	 *
+	 * Sets up the default options used on the settings page.
+	 */
+	private static function create_options() {
+		// Include settings so that we can run through defaults.
+		include_once( dirname( __FILE__ ) . '/admin/class-ur-admin-settings.php' );
+
+		$settings = UR_Admin_Settings::get_settings_pages();
+
+		foreach ( $settings as $section ) {
+			if ( ! method_exists( $section, 'get_settings' ) ) {
+				continue;
+			}
+			$subsections = array_unique( array_merge( array( '' ), array_keys( $section->get_sections() ) ) );
+
+			foreach ( $subsections as $subsection ) {
+				foreach ( $section->get_settings( $subsection ) as $value ) {
+					if ( isset( $value['default'] ) && isset( $value['id'] ) ) {
+						$autoload = isset( $value['autoload'] ) ? (bool) $value['autoload'] : true;
+						add_option( $value['id'], $value['default'], '', ( $autoload ? 'yes' : 'no' ) );
+					}
+				}
+			}
+		}
 	}
 
 	/**
@@ -265,80 +325,9 @@ class UR_Install {
 	}
 
 	/**
-	 * Create pages that the plugin relies on, storing page IDs in variables.
-	 */
-	public static function create_pages() {
-		include_once( dirname( __FILE__ ) . '/admin/functions-ur-admin.php' );
-
-		$pages = apply_filters( 'user_registration_create_pages', array(
-			'myaccount' => array(
-				'name'    => _x( 'my-account', 'Page slug', 'user-registration' ),
-				'title'   => _x( 'My Account', 'Page title', 'user-registration' ),
-				'content' => '[' . apply_filters( 'user_registration_my_account_shortcode_tag', 'user_registration_my_account' ) . ']',
-			),
-		) );
-
-		if ( $default_form_page_id = get_option( 'user_registration_default_form_page_id' ) ) {
-			$pages['registration'] = array(
-				'name'    => _x( 'registration', 'Page slug', 'user-registration' ),
-				'title'   => _x( 'Registration', 'Page title', 'user-registration' ),
-				'content' => '[' . apply_filters( 'user_registration_form_shortcode_tag', 'user_registration_form' ) . ' id="' . $default_form_page_id . '"]',
-			);
-		}
-
-		foreach ( $pages as $key => $page ) {
-			ur_create_page( esc_sql( $page['name'] ), 'user_registration_' . $key . '_page_id', $page['title'], $page['content'] );
-		}
-	}
-
-	/**
-	 * Default options.
-	 *
-	 * Sets up the default options used on the settings page.
-	 */
-	private static function create_options() {
-		// Include settings so that we can run through defaults
-		include_once( dirname( __FILE__ ) . '/admin/class-ur-admin-settings.php' );
-
-		$settings = UR_Admin_Settings::get_settings_pages();
-
-		foreach ( $settings as $section ) {
-			if ( ! method_exists( $section, 'get_settings' ) ) {
-				continue;
-			}
-			$subsections = array_unique( array_merge( array( '' ), array_keys( $section->get_sections() ) ) );
-
-			foreach ( $subsections as $subsection ) {
-				foreach ( $section->get_settings( $subsection ) as $value ) {
-					if ( isset( $value['default'] ) && isset( $value['id'] ) ) {
-						$autoload = isset( $value['autoload'] ) ? (bool) $value['autoload'] : true;
-						add_option( $value['id'], $value['default'], '', ( $autoload ? 'yes' : 'no' ) );
-					}
-				}
-			}
-		}
-	}
-
-	/**
-	 * Show plugin changes. Code adapted from W3 Total Cache.
-	 */
-	public static function in_plugin_update_message( $args ) {
-		$transient_name = 'ur_upgrade_notice_' . $args['Version'];
-
-		if ( false === ( $upgrade_notice = get_transient( $transient_name ) ) ) {
-			$response = wp_safe_remote_get( 'https://plugins.svn.wordpress.org/user-registration/trunk/readme.txt' );
-
-			if ( ! is_wp_error( $response ) && ! empty( $response['body'] ) ) {
-				$upgrade_notice = self::parse_update_notice( $response['body'], $args['new_version'] );
-				set_transient( $transient_name, $upgrade_notice, DAY_IN_SECONDS );
-			}
-		}
-
-		echo wp_kses_post( $upgrade_notice );
-	}
-
-	/**
 	 * Set up the database tables which the plugin needs to function.
+	 *
+	 * When adding or removing a table, make sure to update the list of tables in UR_Install::get_tables().
 	 *
 	 * Tables:
 	 *        user_registration_sessions - Table for storing sessions data.
@@ -371,6 +360,45 @@ CREATE TABLE {$wpdb->prefix}user_registration_sessions (
 	}
 
 	/**
+	 * Return a list of UserRegistration tables. Used to make sure all UR tables are dropped when uninstalling the plugin
+	 * in a single site or multi site environment.
+	 *
+	 * @return array UR tables.
+	 */
+	public static function get_tables() {
+		global $wpdb;
+
+		$tables = array(
+			"{$wpdb->prefix}user_registration_sessions",
+		);
+
+		return $tables;
+	}
+
+	/**
+	 * Drop UsageMonitor tables.
+	 */
+	public static function drop_tables() {
+		global $wpdb;
+
+		$tables = self::get_tables();
+
+		foreach ( $tables as $table ) {
+			$wpdb->query( "DROP TABLE IF EXISTS {$table}" ); // WPCS: unprepared SQL ok.
+		}
+	}
+
+	/**
+	 * Uninstall tables when MU blog is deleted.
+	 *
+	 * @param  array $tables List of tables that will be deleted by WP.
+	 * @return string[]
+	 */
+	public static function wpmu_drop_tables( $tables ) {
+		return array_merge( $tables, self::get_tables() );
+	}
+
+	/**
 	 * Create roles and capabilities.
 	 */
 	public static function create_roles() {
@@ -381,7 +409,7 @@ CREATE TABLE {$wpdb->prefix}user_registration_sessions (
 		}
 
 		if ( ! isset( $wp_roles ) ) {
-			$wp_roles = new WP_Roles();
+			$wp_roles = new WP_Roles(); // @codingStandardsIgnoreLine
 		}
 
 		$capabilities = self::get_core_capabilities();
@@ -393,28 +421,8 @@ CREATE TABLE {$wpdb->prefix}user_registration_sessions (
 		}
 	}
 
-	public static function remove_roles() {
-		global $wp_roles;
-
-		if ( ! class_exists( 'WP_Roles' ) ) {
-			return;
-		}
-
-		if ( ! isset( $wp_roles ) ) {
-			$wp_roles = new WP_Roles();
-		}
-
-		$capabilities = self::get_core_capabilities();
-
-		foreach ( $capabilities as $cap_group ) {
-			foreach ( $cap_group as $cap ) {
-				$wp_roles->remove_cap( 'administrator', $cap );
-			}
-		}
-	}
-
 	/**
-	 * Get capabilities for User Registration.
+	 * Get capabilities for UserRegistration.
 	 *
 	 * @return array
 	 */
@@ -457,6 +465,82 @@ CREATE TABLE {$wpdb->prefix}user_registration_sessions (
 	}
 
 	/**
+	 * Remove UserRegistration roles.
+	 */
+	public static function remove_roles() {
+		global $wp_roles;
+
+		if ( ! class_exists( 'WP_Roles' ) ) {
+			return;
+		}
+
+		if ( ! isset( $wp_roles ) ) {
+			$wp_roles = new WP_Roles();
+		}
+
+		$capabilities = self::get_core_capabilities();
+
+		foreach ( $capabilities as $cap_group ) {
+			foreach ( $cap_group as $cap ) {
+				$wp_roles->remove_cap( 'administrator', $cap );
+			}
+		}
+	}
+
+	/**
+	 * Create files/directories.
+	 */
+	private static function create_files() {
+		// Bypass if filesystem is read-only and/or non-standard upload system is used.
+		if ( apply_filters( 'user_registration_install_skip_create_files', false ) ) {
+			return;
+		}
+
+		// Install files and folders for uploading files and prevent hotlinking
+		$upload_dir = wp_upload_dir();
+
+		$files = array(
+			array(
+				'base'    => UR_LOG_DIR,
+				'file'    => '.htaccess',
+				'content' => 'deny from all',
+			),
+			array(
+				'base'    => UR_LOG_DIR,
+				'file'    => 'index.html',
+				'content' => '',
+			),
+		);
+
+		foreach ( $files as $file ) {
+			if ( wp_mkdir_p( $file['base'] ) && ! file_exists( trailingslashit( $file['base'] ) . $file['file'] ) ) {
+				if ( $file_handle = @fopen( trailingslashit( $file['base'] ) . $file['file'], 'w' ) ) {
+					fwrite( $file_handle, $file['content'] );
+					fclose( $file_handle );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Show plugin changes. Code adapted from W3 Total Cache.
+	 */
+	public static function in_plugin_update_message( $args ) {
+		$transient_name = 'ur_upgrade_notice_' . $args['Version'];
+
+		if ( false === ( $upgrade_notice = get_transient( $transient_name ) ) ) {
+			$response = wp_safe_remote_get( 'https://plugins.svn.wordpress.org/user-registration/trunk/readme.txt' );
+
+			if ( ! is_wp_error( $response ) && ! empty( $response['body'] ) ) {
+				$upgrade_notice = self::parse_update_notice( $response['body'], $args['new_version'] );
+				set_transient( $transient_name, $upgrade_notice, DAY_IN_SECONDS );
+			}
+		}
+
+		echo wp_kses_post( $upgrade_notice );
+	}
+
+	/**
 	 * Parse update notice from readme file
 	 *
 	 * @param  string $content
@@ -493,13 +577,12 @@ CREATE TABLE {$wpdb->prefix}user_registration_sessions (
 	/**
 	 * Display action links in the Plugins list table.
 	 *
-	 * @param  array $actions
-	 *
+	 * @param  array $actions Plugin Action links.
 	 * @return array
 	 */
 	public static function plugin_action_links( $actions ) {
 		$new_actions = array(
-			'settings' => '<a href="' . admin_url( 'admin.php?page=user-registration-settings' ) . '" title="' . esc_attr( __( 'View User Registration Settings', 'user-registration' ) ) . '">' . __( 'Settings', 'user-registration' ) . '</a>',
+			'settings' => '<a href="' . admin_url( 'admin.php?page=user-registration-settings' ) . '" aria-label="' . esc_attr__( 'View User Registration settings', 'user-registration' ) . '">' . esc_html__( 'Settings', 'user-registration' ) . '</a>',
 		);
 
 		return array_merge( $new_actions, $actions );
@@ -508,16 +591,15 @@ CREATE TABLE {$wpdb->prefix}user_registration_sessions (
 	/**
 	 * Display row meta in the Plugins list table.
 	 *
-	 * @param  array  $plugin_meta
-	 * @param  string $plugin_file
-	 *
+	 * @param  array  $plugin_meta Plugin Row Meta.
+	 * @param  string $plugin_file Plugin Row Meta.
 	 * @return array
 	 */
 	public static function plugin_row_meta( $plugin_meta, $plugin_file ) {
-		if ( $plugin_file == UR_PLUGIN_BASENAME ) {
+		if ( UR_PLUGIN_BASENAME === $plugin_file ) {
 			$new_plugin_meta = array(
-				'docs'    => '<a href="' . esc_url( apply_filters( 'user_registration_docs_url', 'https://docs.wpeverest.com/user-registration/' ) ) . '" title="' . esc_attr( __( 'View User Registration Documentation', 'user-registration' ) ) . '">' . __( 'Docs', 'user-registration' ) . '</a>',
-				'support' => '<a href="' . esc_url( apply_filters( 'user_registration_support_url', 'https://wpeverest.com/support-forum/' ) ) . '" title="' . esc_attr( __( 'Visit Free Customer Support Forum', 'user-registration' ) ) . '">' . __( 'Free Support', 'user-registration' ) . '</a>',
+				'docs'    => '<a href="' . esc_url( apply_filters( 'user_registration_docs_url', 'https://docs.wpeverest.com/user-registration/' ) ) . '" area-label="' . esc_attr__( 'View User Registration documentation', 'user-registration' ) . '">' . esc_html__( 'Docs', 'user-registration' ) . '</a>',
+				'support' => '<a href="' . esc_url( apply_filters( 'user_registration_support_url', 'https://wpeverest.com/support-forum/' ) ) . '" area-label="' . esc_attr__( 'Visit free customer support', 'user-registration' ) . '">' . __( 'Free support', 'user-registration' ) . '</a>',
 			);
 
 			return array_merge( $plugin_meta, $new_plugin_meta );

--- a/includes/class-ur-post-types.php
+++ b/includes/class-ur-post-types.php
@@ -25,6 +25,7 @@ class UR_Post_Types {
 	 */
 	public static function init() {
 		add_action( 'init', array( __CLASS__, 'register_post_types' ), 5 );
+		add_action( 'user_registration_after_register_post_type', array( __CLASS__, 'maybe_flush_rewrite_rules' ) );
 		add_action( 'user_registration_flush_rewrite_rules', array( __CLASS__, 'flush_rewrite_rules' ) );
 	}
 
@@ -32,6 +33,12 @@ class UR_Post_Types {
 	 * Register core post types.
 	 */
 	public static function register_post_types() {
+		if ( ! is_blog_installed() || post_type_exists( 'user_registration' ) ) {
+			return;
+		}
+
+		do_action( 'user_registration_register_post_type' );
+
 		register_post_type( 'user_registration',
 			apply_filters( 'user_registration_post_type',
 				array(
@@ -67,6 +74,20 @@ class UR_Post_Types {
 				)
 			)
 		);
+
+		do_action( 'user_registration_after_register_post_type' );
+	}
+
+	/**
+	 * Flush rules if the event is queued.
+	 *
+	 * @since 1.2.0
+	 */
+	public static function maybe_flush_rewrite_rules() {
+		if ( 'yes' === get_option( 'user_registration_queue_flush_rewrite_rules' ) ) {
+			update_option( 'user_registration_queue_flush_rewrite_rules', 'no' );
+			self::flush_rewrite_rules();
+		}
 	}
 
 	/**


### PR DESCRIPTION
All updates between versions are ran. So if you update from 1.0 to 1.3, all functions in-between, including 1.2 one, will be ran too. Additionally this PR fixes more stuffs like dropping tables in multisite upon plugin uninstallation and PHPCS fixes.

CC @rabinstha @sanzeeb3 