### PR TITLE
Remove js code and redirect using template_redirect hook

### DIFF
--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -33,6 +33,7 @@ function ur_template_redirect() {
 }
 
 add_action( 'template_redirect', 'ur_template_redirect' );
+add_action( 'template_redirect', 'ur_login_template_redirect' );
 
 /**
  * Handle redirects before content is output - hooked into template_redirect so is_page works.

--- a/includes/shortcodes/class-ur-shortcode-login.php
+++ b/includes/shortcodes/class-ur-shortcode-login.php
@@ -51,11 +51,6 @@ class UR_Shortcode_Login {
 				ur_get_template( 'myaccount/form-login.php' );
 			}
 
-		}else if(is_user_logged_in() && !empty(trim($redirect_url)) ){
-			?>	<script>
-				window.location = "<?php echo trim($redirect_url);?>";
-			</script>
-			<?php
 		}
 		else
 		{


### PR DESCRIPTION
With js code in use, due the theme it may be too heavy and takes a while to render the JS to work. So removed the js and `template_redirect` hook instead is used.