### PR TITLE
Feature to enter default value

### DIFF
--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -584,12 +584,26 @@ jQuery(function ( $ ) {
 		var advance_setting_data = {};
 
 		//Store default values
-		if( $single_item.find('.ur-field input').length != 0 ) {
-			var default_value = $single_item.find('.ur-field input').val();
-
-		} else if( $single_item.find('.ur-field select').length != 0 ) {
+		if( $single_item.find('.ur-field input:checkbox').length > 0 ) {
+			if( $single_item.find('.ur-field input:checkbox').length == 1  ){
+				var default_value = $single_item.find('.ur-field input:checkbox:checked').val();
+			}
+			else {
+				var checked_fields = $single_item.find('.ur-field input:checkbox:checked');
+				var default_value = [];
+				checked_fields.each( function( key, value) {
+					default_value[ key ] = jQuery(this).val();
+				});			
+			}
+	
+		} else if( $single_item.find('.ur-field input:radio').length > 0 ){
+			var default_value = $single_item.find('.ur-field input:radio:checked').val();
+		} else if( $single_item.find('.ur-field input').length > 0 ) {
+			var default_value = $single_item.find('.ur-field input').val();						
+		} 
+		 else if( $single_item.find('.ur-field select').length > 0 ) {
 			var default_value = $single_item.find('.ur-field select').find(':selected').attr('value');
-        } else if( $single_item.find('.ur-field textarea').length != 0 ){
+        } else if( $single_item.find('.ur-field textarea').length > 0 ){
 			var default_value = $single_item.find('.ur-field textarea').val();
         }
 

--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -573,6 +573,16 @@ jQuery(function ( $ ) {
 		var general_setting_field = $single_item.find('.ur-general-setting-block').find('.ur-general-setting-field');
 		var general_setting_data = {};
 
+		$.each(general_setting_field, function () {
+		        general_setting_data[ $(this).attr('data-field') ] = get_ur_data($(this));
+		});
+		return general_setting_data;
+	}
+
+	function get_field_advance_setting ( $single_item ) {
+		var advance_setting_field = $single_item.find('.ur-advance-setting-block').find('.ur_advance_setting');
+		var advance_setting_data = {};
+
 		//Store default values
 		if( $single_item.find('.ur-field input').length != 0 ) {
 			var default_value = $single_item.find('.ur-field input').val();
@@ -582,19 +592,10 @@ jQuery(function ( $ ) {
 			var default_value = $single_item.find('.ur-field textarea').val();
         }
 
-		$.each(general_setting_field, function () {
-		        general_setting_data[ $(this).attr('data-field') ] = get_ur_data($(this));
-		});
-		general_setting_data.default = default_value;
-		return general_setting_data;
-	}
-
-	function get_field_advance_setting ( $single_item ) {
-		var advance_setting_field = $single_item.find('.ur-advance-setting-block').find('.ur_advance_setting');
-		var advance_setting_data = {};
 		$.each(advance_setting_field, function () {
 			advance_setting_data[ $(this).attr('data-advance-field') ] = get_ur_data($(this));
 		});
+		advance_setting_data.default_value = default_value;
 		return advance_setting_data;
 	}
 

--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -572,9 +572,20 @@ jQuery(function ( $ ) {
 	function get_field_general_setting ( $single_item ) {
 		var general_setting_field = $single_item.find('.ur-general-setting-block').find('.ur-general-setting-field');
 		var general_setting_data = {};
+
+		//Store default values
+		if( $single_item.find('.ur-field input').length != 0 ) {
+			var default_value = $single_item.find('.ur-field input').val();
+		} else if( $single_item.find('.ur-field select').length != 0 ) {
+			var default_value = $single_item.find('.ur-field select').find(':selected').attr('value');
+        } else if( $single_item.find('.ur-field textarea').length != 0 ){
+			var default_value = $single_item.find('.ur-field textarea').val();
+        }
+
 		$.each(general_setting_field, function () {
-			general_setting_data[ $(this).attr('data-field') ] = get_ur_data($(this));
+		        general_setting_data[ $(this).attr('data-field') ] = get_ur_data($(this));
 		});
+		general_setting_data.default = default_value;
 		return general_setting_data;
 	}
 

--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -586,6 +586,7 @@ jQuery(function ( $ ) {
 		//Store default values
 		if( $single_item.find('.ur-field input').length != 0 ) {
 			var default_value = $single_item.find('.ur-field input').val();
+
 		} else if( $single_item.find('.ur-field select').length != 0 ) {
 			var default_value = $single_item.find('.ur-field select').find(':selected').attr('value');
         } else if( $single_item.find('.ur-field textarea').length != 0 ){

--- a/includes/abstracts/abstract-ur-form-field.php
+++ b/includes/abstracts/abstract-ur-form-field.php
@@ -92,6 +92,8 @@ abstract class UR_Form_Field {
 
 			'hide_label' => isset( $data['general_setting']->hide_label ) ? $data['general_setting']->hide_label : '',
 
+			'default' => isset( $data['general_setting']->default ) ? $data['general_setting']->default : '',
+
 			'type' => $field_type,
 		);
 

--- a/includes/abstracts/abstract-ur-form-field.php
+++ b/includes/abstracts/abstract-ur-form-field.php
@@ -56,6 +56,20 @@ abstract class UR_Form_Field {
 		return '';
 	}
 
+	public function get_advance_setting_data( $key ) {
+
+		if ( isset( $this->admin_data->advance_setting->$key ) ) {
+
+			return $this->admin_data->advance_setting->$key;
+		}
+
+		if ( isset( $this->field_defaults[ 'default_' . $key ] ) ) {
+
+			return $this->field_defaults[ 'default_' . $key ];
+		}
+
+		return '';
+	}
 
 	public function get_admin_template( $admin_data = array() ) {
 
@@ -91,8 +105,6 @@ abstract class UR_Form_Field {
 			'description' => isset( $data['general_setting']->description ) ? $data['general_setting']->description : '',
 
 			'hide_label' => isset( $data['general_setting']->hide_label ) ? $data['general_setting']->hide_label : '',
-
-			'default' => isset( $data['general_setting']->default ) ? $data['general_setting']->default : '',
 
 			'type' => $field_type,
 		);

--- a/includes/form/settings/class-ur-setting-checkbox.php
+++ b/includes/form/settings/class-ur-setting-checkbox.php
@@ -4,11 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Abstract UR Setting Select Class
+ * UR Setting Select Class
  *
  * @version  1.0.0
  * @package  UserRegistration/Form/Settings
- * @category Abstract Class
  * @author   WPEverest
  */
 class UR_Setting_Checkbox extends UR_Field_Settings {
@@ -22,7 +21,6 @@ class UR_Setting_Checkbox extends UR_Field_Settings {
 
 	public function output( $field_data = array() ) {
 
-		// TODO: Implement output() method.
 		$this->field_data = $field_data;
 
 		$this->register_fields();
@@ -33,7 +31,7 @@ class UR_Setting_Checkbox extends UR_Field_Settings {
 	}
 
 	public function register_fields() {
-		// TODO: Implement register_fields() method.
+
 		$fields = array(
 
 			'custom_class' => array(

--- a/includes/form/settings/class-ur-setting-country.php
+++ b/includes/form/settings/class-ur-setting-country.php
@@ -4,11 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Abstract UR Setting Select Class
+ * UR Setting Country Class
  *
  * @version  1.0.0
  * @package  UserRegistration/Form/Settings
- * @category Abstract Class
  * @author   WPEverest
  */
 class UR_Setting_Country extends UR_Field_Settings {
@@ -22,7 +21,6 @@ class UR_Setting_Country extends UR_Field_Settings {
 
 	public function output( $field_data = array() ) {
 
-		// TODO: Implement output() method.
 		$this->field_data = $field_data;
 
 		$this->register_fields();
@@ -33,7 +31,7 @@ class UR_Setting_Country extends UR_Field_Settings {
 	}
 
 	public function register_fields() {
-		// TODO: Implement register_fields() method.
+
 		$fields = array(
 
 			'custom_class' => array(

--- a/includes/form/settings/class-ur-setting-email.php
+++ b/includes/form/settings/class-ur-setting-email.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Abstract UR Setting Email Class
+ * UR Setting Email Class
  *
  * @version  1.0.0
  * @package  UserRegistration/Form/Settings
@@ -22,7 +22,6 @@ class UR_Setting_Email extends UR_Field_Settings {
 
 	public function output( $field_data = array() ) {
 
-		// TODO: Implement output() method.
 		$this->field_data = $field_data;
 
 		$this->register_fields();
@@ -33,7 +32,7 @@ class UR_Setting_Email extends UR_Field_Settings {
 	}
 
 	public function register_fields() {
-		// TODO: Implement register_fields() method.
+
 		$fields = array(
 
 			'custom_class' => array(

--- a/includes/form/settings/class-ur-setting-password.php
+++ b/includes/form/settings/class-ur-setting-password.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Abstract UR Setting Password Class
+ * UR Setting Password Class
  *
  * @version  1.0.0
  * @package  UserRegistration/Form/Settings
@@ -22,7 +22,6 @@ class UR_Setting_Password extends UR_Field_Settings {
 
 	public function output( $field_data = array() ) {
 
-		// TODO: Implement output() method.
 		$this->field_data = $field_data;
 
 		$this->register_fields();
@@ -33,7 +32,7 @@ class UR_Setting_Password extends UR_Field_Settings {
 	}
 
 	public function register_fields() {
-		// TODO: Implement register_fields() method.
+
 		$fields = array(
 
 			'size' => array(

--- a/includes/form/settings/class-ur-setting-radio.php
+++ b/includes/form/settings/class-ur-setting-radio.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Abstract UR Setting Radio Class
+ * UR Setting Radio Class
  *
  * @version  1.0.0
  * @package  UserRegistration/Form/Settings
@@ -22,7 +22,6 @@ class UR_Setting_Radio extends UR_Field_Settings {
 
 	public function output( $field_data = array() ) {
 
-		// TODO: Implement output() method.
 		$this->field_data = $field_data;
 
 		$this->register_fields();
@@ -33,7 +32,7 @@ class UR_Setting_Radio extends UR_Field_Settings {
 	}
 
 	public function register_fields() {
-		// TODO: Implement register_fields() method.
+
 		$fields = array(
 
 			'custom_class' => array(

--- a/includes/form/settings/class-ur-setting-select.php
+++ b/includes/form/settings/class-ur-setting-select.php
@@ -4,11 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Abstract UR Setting Select Class
+ * UR Setting Select Class
  *
  * @version  1.0.0
  * @package  UserRegistration/Form/Settings
- * @category Abstract Class
  * @author   WPEverest
  */
 class UR_Setting_Select extends UR_Field_Settings {
@@ -22,7 +21,6 @@ class UR_Setting_Select extends UR_Field_Settings {
 
 	public function output( $field_data = array() ) {
 
-		// TODO: Implement output() method.
 		$this->field_data = $field_data;
 
 		$this->register_fields();
@@ -33,7 +31,7 @@ class UR_Setting_Select extends UR_Field_Settings {
 	}
 
 	public function register_fields() {
-		// TODO: Implement register_fields() method.
+		
 		$fields = array(
 
 			'custom_class' => array(

--- a/includes/form/settings/class-ur-setting-text.php
+++ b/includes/form/settings/class-ur-setting-text.php
@@ -4,11 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Abstract UR Setting Text Class
+ * UR Setting Text Class
  *
  * @version  1.0.0
  * @package  UserRegistration/Form/Settings
- * @category Abstract Class
  * @author   WPEverest
  */
 class UR_Setting_Text extends UR_Field_Settings {
@@ -22,7 +21,6 @@ class UR_Setting_Text extends UR_Field_Settings {
 
 	public function output( $field_data = array() ) {
 
-		// TODO: Implement output() method.
 		$this->field_data = $field_data;
 
 		$this->register_fields();
@@ -33,7 +31,6 @@ class UR_Setting_Text extends UR_Field_Settings {
 	}
 
 	public function register_fields() {
-		// TODO: Implement register_fields() method.
 		$fields = array(
 
 			'size'          => array(
@@ -53,25 +50,6 @@ class UR_Setting_Text extends UR_Field_Settings {
 				'default' => '20',
 
 				'placeholder' => __( 'Size','user-registration' ),
-
-			),
-			'default_value' => array(
-
-				'label' => __( 'Default Value','user-registration' ),
-
-				'data-id' => $this->field_id . '_default_value',
-
-				'name' => $this->field_id . '[default_value]',
-
-				'class' => $this->default_class . ' ur-settings-default-value',
-
-				'type' => 'text',
-
-				'required' => false,
-
-				'default' => '',
-
-				'placeholder' => __( 'Default Value','user-registration' ),
 
 			),
 			'custom_class'  => array(

--- a/includes/form/settings/class-ur-setting-textarea.php
+++ b/includes/form/settings/class-ur-setting-textarea.php
@@ -4,11 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Abstract UR Setting Textarea Class
+ * UR Setting Textarea Class
  *
  * @version  1.0.0
  * @package  UserRegistration/Form/Settings
- * @category Abstract Class
  * @author   WPEverest
  */
 class UR_Setting_Textarea extends UR_Field_Settings {
@@ -22,7 +21,6 @@ class UR_Setting_Textarea extends UR_Field_Settings {
 
 	public function output( $field_data = array() ) {
 
-		// TODO: Implement output() method.
 		$this->field_data = $field_data;
 
 		$this->register_fields();
@@ -33,28 +31,7 @@ class UR_Setting_Textarea extends UR_Field_Settings {
 	}
 
 	public function register_fields() {
-		// TODO: Implement register_fields() method.
 		$fields = array(
-
-			'default_value' => array(
-
-				'label' => __( 'Default Value','user-registration' ),
-
-				'data-id' => $this->field_id . '_default_value',
-
-				'name' => $this->field_id . '[default_value]',
-
-				'class' => $this->default_class . ' ur-settings-default-value',
-
-				'type' => 'text',
-
-				'required' => false,
-
-				'default' => '',
-
-				'placeholder' => __( 'Default Value', 'user-registration' ),
-
-			),
 			'custom_class'  => array(
 
 				'label' => __( 'Custom Class', 'user-registration' ),

--- a/includes/form/views/admin/admin-checkbox.php
+++ b/includes/form/views/admin/admin-checkbox.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Form View: Input Type Checkbox
-*/
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -16,13 +16,17 @@ $choices = isset( $this->admin_data->advance_setting->choices ) ? explode( ',', 
 	</div>
 
 	<div class="ur-field" data-field-key="checkbox">
+		<?php $selected = $this->get_advance_setting_data( 'default_value' ); ?>
 		<?php
-			if( count( $choices ) < 1 ) {
-				echo "<input type = 'checkbox'  value='1'/>";
+			if( count( $choices ) === 1 ) {
+				echo "<input type = 'checkbox'  value='1' " . checked( $selected, 1, false ) . ">";
 			}
-			foreach ( $choices as $choice ) {
-				echo "<input type = 'checkbox'  value='" . esc_attr( $choice ) . "'/>" . esc_html( trim( $choice ) ) . '<br>';
+			else {
+				foreach ( $choices as $choice ) {
+					echo "<input type = 'checkbox'  value=" . esc_attr( $choice ) . ">" . esc_html( trim( $choice ) ) . "<br>";
+				}
 			}
+	
 		?>
 	</div>
 	

--- a/includes/form/views/admin/admin-checkbox.php
+++ b/includes/form/views/admin/admin-checkbox.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Form View: Input Type Checkbox
- */
+*/
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -11,28 +11,23 @@ $choices = isset( $this->admin_data->advance_setting->choices ) ? explode( ',', 
 ?>
 
 <div class="ur-input-type-checkbox ur-admin-template">
-
 	<div class="ur-label">
 		<label><?php echo esc_html( $this->get_general_setting_data( 'label' ) ); ?></label>
-
 	</div>
+
 	<div class="ur-field" data-field-key="checkbox">
-
 		<?php
-		if(count($choices)<1){
-			echo "<input type = 'checkbox'  value='1'/>";
-		}
-		foreach ( $choices as $choice ) {
-			echo "<input type = 'checkbox'  value='" . esc_attr( $choice ) . "'/>" . esc_html( trim( $choice ) ) . '<br>';
-
-		}
+			if( count( $choices ) < 1 ) {
+				echo "<input type = 'checkbox'  value='1'/>";
+			}
+			foreach ( $choices as $choice ) {
+				echo "<input type = 'checkbox'  value='" . esc_attr( $choice ) . "'/>" . esc_html( trim( $choice ) ) . '<br>';
+			}
 		?>
-
 	</div>
+	
 	<?php
-
-	UR_Checkbox::get_instance()->get_setting();
-
+		UR_Checkbox::get_instance()->get_setting();
 	?>
 </div>
 

--- a/includes/form/views/admin/admin-checkbox.php
+++ b/includes/form/views/admin/admin-checkbox.php
@@ -18,12 +18,13 @@ $choices = isset( $this->admin_data->advance_setting->choices ) ? explode( ',', 
 	<div class="ur-field" data-field-key="checkbox">
 		<?php $selected = $this->get_advance_setting_data( 'default_value' ); ?>
 		<?php
-			if( count( $choices ) === 1 ) {
+			if( count( $choices ) <= 1 ) {
 				echo "<input type = 'checkbox'  value='1' " . checked( $selected, 1, false ) . ">";
 			}
 			else {
 				foreach ( $choices as $choice ) {
-					echo "<input type = 'checkbox'  value=" . esc_attr( $choice ) . ">" . esc_html( trim( $choice ) ) . "<br>";
+					$checked = ( is_array( $selected ) && in_array( $choice, $selected ) ) ? 'checked="checked"' : '';
+					echo "<input type = 'checkbox'  value=" . esc_attr( $choice ) . " ". $checked . ">" . esc_html( trim( $choice ) ) . "<br>";
 				}
 			}
 	

--- a/includes/form/views/admin/admin-country.php
+++ b/includes/form/views/admin/admin-country.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Form View: Country
-*/
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -20,7 +20,7 @@ $instance = UR_Country::get_instance();
 		<select id="ur-input-type-country">
 			<?php
 				foreach ( $instance->get_country() as $country_key => $country_name ) {
-					echo "<option value='" . esc_attr( $country_key ) . "' '"  . selected( $selected, $country_key ) . "' >" . esc_html( trim( $country_name ) ) . '</option>';
+					echo "<option value=" . esc_attr( $country_key ) . " "  . selected( $selected, $country_key ) . " >" . esc_html( trim( $country_name ) ) . "</option>";
 				}
 			?>
 		</select>

--- a/includes/form/views/admin/admin-country.php
+++ b/includes/form/views/admin/admin-country.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Form View: Country
- */
+*/
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -9,35 +9,26 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $instance = UR_Country::get_instance();
 ?>
-<div class="ur-input-type-country ur-admin-template">
 
+<div class="ur-input-type-country ur-admin-template">
 	<div class="ur-label">
 		<label><?php echo esc_html($this->get_general_setting_data( 'label' )); ?></label>
-
 	</div>
+
 	<div class="ur-field" data-field-key="country">
-
-
 		<select id="ur-input-type-country">
 			<?php
-
-			foreach ( $instance->get_country() as $country_key => $country_name ) {
-				?>
-				<option value="<?php echo esc_attr($country_key) ?>"><?php echo esc_html($country_name); ?></option>
-				<?php
-
-			}
-
+				foreach ( $instance->get_country() as $country_key => $country_name ) {
+					?>
+						<option value="<?php echo esc_attr( $country_key ) ?>"><?php echo esc_html( $country_name ); ?></option>
+					<?php
+				}
 			?>
-
 		</select>
-
 	</div>
+
 	<?php
-
-
-	$instance->get_setting();
-
+		$instance->get_setting();
 	?>
 </div>
 

--- a/includes/form/views/admin/admin-country.php
+++ b/includes/form/views/admin/admin-country.php
@@ -16,12 +16,11 @@ $instance = UR_Country::get_instance();
 	</div>
 
 	<div class="ur-field" data-field-key="country">
+		<?php $selected = $this->get_advance_setting_data( 'default_value' ); ?>
 		<select id="ur-input-type-country">
 			<?php
 				foreach ( $instance->get_country() as $country_key => $country_name ) {
-					?>
-						<option value="<?php echo esc_attr( $country_key ) ?>"><?php echo esc_html( $country_name ); ?></option>
-					<?php
+					echo "<option value='" . esc_attr( $country_key ) . "' '"  . selected( $selected, $country_key ) . "' >" . esc_html( trim( $country_name ) ) . '</option>';
 				}
 			?>
 		</select>

--- a/includes/form/views/admin/admin-date.php
+++ b/includes/form/views/admin/admin-date.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	
 	<div class="ur-field" data-field-key="date">
-		<input type="date" id="ur-input-type-date" value="<?php echo esc_attr($this->get_general_setting_data( 'default' )); ?>" placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
+		<input type="date" id="ur-input-type-date" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>" placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
 	</div>
 
 	<?php

--- a/includes/form/views/admin/admin-date.php
+++ b/includes/form/views/admin/admin-date.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Form View: Input Type Date
- */
+*/
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -9,21 +9,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 ?>
 <div class="ur-input-type-date ur-admin-template">
-
 	<div class="ur-label">
 		<label><?php echo esc_html($this->get_general_setting_data( 'label' )); ?></label>
-
 	</div>
+	
 	<div class="ur-field" data-field-key="date">
-
-		<input type="date" id="ur-input-type-date"
-		       placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
-
+		<input type="date" id="ur-input-type-date" value="<?php echo esc_attr($this->get_general_setting_data( 'default' )); ?>" placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
 	</div>
+
 	<?php
-
-	UR_Date::get_instance()->get_setting();
-
+		UR_Date::get_instance()->get_setting();
 	?>
 </div>
 

--- a/includes/form/views/admin/admin-date.php
+++ b/includes/form/views/admin/admin-date.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Form View: Input Type Date
-*/
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	
 	<div class="ur-field" data-field-key="date">
-		<input type="date" id="ur-input-type-date" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>" placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
+		<input type="date" id="ur-input-type-date" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>">
 	</div>
 
 	<?php

--- a/includes/form/views/admin/admin-description.php
+++ b/includes/form/views/admin/admin-description.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Form View: User Description
-*/
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/includes/form/views/admin/admin-description.php
+++ b/includes/form/views/admin/admin-description.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<label><?php echo esc_html($this->get_general_setting_data( 'label' )); ?></label>
 	</div>
 	<div class="ur-field" data-field-key="description">
-		<textarea id="ur-input-type-description"><?php echo esc_attr($this->get_general_setting_data( 'default' )); ?></textarea>
+		<textarea id="ur-input-type-description"><?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?></textarea>
 	</div>
 
 	<?php

--- a/includes/form/views/admin/admin-description.php
+++ b/includes/form/views/admin/admin-description.php
@@ -1,28 +1,23 @@
 <?php
 /**
  * Form View: User Description
- */
+*/
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 ?>
+
 <div class="ur-input-type-description ur-admin-template">
-
 	<div class="ur-label">
-
 		<label><?php echo esc_html($this->get_general_setting_data( 'label' )); ?></label>
-
 	</div>
 	<div class="ur-field" data-field-key="description">
-
-		<textarea id="ur-input-type-description"></textarea>
-
+		<textarea id="ur-input-type-description"><?php echo esc_attr($this->get_general_setting_data( 'default' )); ?></textarea>
 	</div>
+
 	<?php
-
-	UR_Description::get_instance()->get_setting();
-
+		UR_Description::get_instance()->get_setting();
 	?>
 </div>
 

--- a/includes/form/views/admin/admin-display-name.php
+++ b/includes/form/views/admin/admin-display-name.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Form View: Input Display Name
- */
+*/
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -9,21 +9,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 ?>
 <div class="ur-input-type-display-name ur-admin-template">
-
 	<div class="ur-label">
 		<label><?php echo esc_html($this->get_general_setting_data( 'label' )); ?></label>
-
 	</div>
+
 	<div class="ur-field" data-field-key="display_name">
-
-		<input type="text" value="<?php echo esc_attr($this->get_general_setting_data( 'default' )); ?>" id="ur-input-type-display-name"
-			   placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
-
+		<input type="text" value="<?php echo esc_attr($this->get_general_setting_data( 'default' )); ?>" id="ur-input-type-display-name"  placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
 	</div>
+
 	<?php
-
-	UR_Display_Name::get_instance()->get_setting();
-
+		UR_Display_Name::get_instance()->get_setting();
 	?>
 </div>
 

--- a/includes/form/views/admin/admin-display-name.php
+++ b/includes/form/views/admin/admin-display-name.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 
 	<div class="ur-field" data-field-key="display_name">
-		<input type="text" value="<?php echo esc_attr($this->get_general_setting_data( 'default' )); ?>" id="ur-input-type-display-name"  placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
+		<input type="text" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>" id="ur-input-type-display-name"  placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
 	</div>
 
 	<?php

--- a/includes/form/views/admin/admin-display-name.php
+++ b/includes/form/views/admin/admin-display-name.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Form View: Input Display Name
-*/
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/includes/form/views/admin/admin-display-name.php
+++ b/includes/form/views/admin/admin-display-name.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="ur-field" data-field-key="display_name">
 
-		<input type="text" id="ur-input-type-display-name"
+		<input type="text" value="<?php echo esc_attr($this->get_general_setting_data( 'default' )); ?>" id="ur-input-type-display-name"
 			   placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
 
 	</div>

--- a/includes/form/views/admin/admin-email.php
+++ b/includes/form/views/admin/admin-email.php
@@ -8,19 +8,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 <div class="ur-input-type-email ur-admin-template">
-
 	<div class="ur-label">
 		<label><?php echo esc_html($this->get_general_setting_data( 'label' )); ?></label>
 	</div>
+
 	<div class="ur-field" data-field-key="email">
-
 		<input type="email" placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>" id="ur-input-type-email"/>
-
 	</div>
 	<?php
-
-	  UR_Email::get_instance()->get_setting();
-
-		?>
+	  	UR_Email::get_instance()->get_setting();
+	?>
 </div>
 

--- a/includes/form/views/admin/admin-email.php
+++ b/includes/form/views/admin/admin-email.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="ur-field" data-field-key="email">
 
-		<input type="email" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>" id="ur-input-type-email"/>
+		<input type="email" placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>" id="ur-input-type-email"/>
 
 	</div>
 	<?php

--- a/includes/form/views/admin/admin-email.php
+++ b/includes/form/views/admin/admin-email.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="ur-field" data-field-key="email">
 
-		<input type="email" id="ur-input-type-email"/>
+		<input type="email" value="<?php echo esc_attr($this->get_general_setting_data( 'default' )); ?>" id="ur-input-type-email"/>
 
 	</div>
 	<?php

--- a/includes/form/views/admin/admin-email.php
+++ b/includes/form/views/admin/admin-email.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="ur-field" data-field-key="email">
 
-		<input type="email" value="<?php echo esc_attr($this->get_general_setting_data( 'default' )); ?>" id="ur-input-type-email"/>
+		<input type="email" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>" id="ur-input-type-email"/>
 
 	</div>
 	<?php

--- a/includes/form/views/admin/admin-first-name.php
+++ b/includes/form/views/admin/admin-first-name.php
@@ -16,8 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="ur-field" data-field-key="first_name">
 
-		<input type="text" id="ur-input-type-first-name" value="<?php echo esc_attr($this->get_general_setting_data( 'default' )); ?>"
-			   placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
+		<input type="text" id="ur-input-type-first-name" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>" placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
 
 	</div>
 	<?php

--- a/includes/form/views/admin/admin-first-name.php
+++ b/includes/form/views/admin/admin-first-name.php
@@ -9,20 +9,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 ?>
 <div class="ur-input-type-first-name ur-admin-template">
-
 	<div class="ur-label">
 		<label><?php echo esc_html($this->get_general_setting_data( 'label' )); ?></label>
-
 	</div>
+	
 	<div class="ur-field" data-field-key="first_name">
-
 		<input type="text" id="ur-input-type-first-name" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>" placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
-
 	</div>
 	<?php
-
-	UR_First_Name::get_instance()->get_setting();
-
+		UR_First_Name::get_instance()->get_setting();
 	?>
 </div>
 

--- a/includes/form/views/admin/admin-first-name.php
+++ b/includes/form/views/admin/admin-first-name.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="ur-field" data-field-key="first_name">
 
-		<input type="text" id="ur-input-type-first-name"
+		<input type="text" id="ur-input-type-first-name" value="<?php echo esc_attr($this->get_general_setting_data( 'default' )); ?>"
 			   placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
 
 	</div>

--- a/includes/form/views/admin/admin-last-name.php
+++ b/includes/form/views/admin/admin-last-name.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="ur-field" data-field-key="last_name">
 
-		<input type="text" id="ur-input-type-last-name"
+		<input type="text" id="ur-input-type-last-name" value="<?php echo esc_attr($this->get_general_setting_data( 'default' )); ?>"
 			   placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
 
 	</div>

--- a/includes/form/views/admin/admin-last-name.php
+++ b/includes/form/views/admin/admin-last-name.php
@@ -9,20 +9,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 ?>
 <div class="ur-input-type-last-name ur-admin-template">
-
 	<div class="ur-label">
 		<label><?php echo esc_html($this->get_general_setting_data( 'label' )); ?></label>
-
 	</div>
+
 	<div class="ur-field" data-field-key="last_name">
-
 		<input type="text" id="ur-input-type-last-name" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>" placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
-
 	</div>
 	<?php
-
-	UR_Last_Name::get_instance()->get_setting();
-
+		UR_Last_Name::get_instance()->get_setting();
 	?>
 </div>
 

--- a/includes/form/views/admin/admin-last-name.php
+++ b/includes/form/views/admin/admin-last-name.php
@@ -16,8 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="ur-field" data-field-key="last_name">
 
-		<input type="text" id="ur-input-type-last-name" value="<?php echo esc_attr($this->get_general_setting_data( 'default' )); ?>"
-			   placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
+		<input type="text" id="ur-input-type-last-name" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>" placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
 
 	</div>
 	<?php

--- a/includes/form/views/admin/admin-nickname.php
+++ b/includes/form/views/admin/admin-nickname.php
@@ -16,8 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="ur-field" data-field-key="nickname">
 
-		<input type="text" id="ur-input-type-nickname" value="<?php echo esc_attr($this->get_general_setting_data( 'default' )); ?>"
-			   placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
+		<input type="text" id="ur-input-type-nickname" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>" placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
 
 	</div>
 	<?php

--- a/includes/form/views/admin/admin-nickname.php
+++ b/includes/form/views/admin/admin-nickname.php
@@ -9,20 +9,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 ?>
 <div class="ur-input-type-nickname ur-admin-template">
-
 	<div class="ur-label">
 		<label><?php echo esc_html($this->get_general_setting_data( 'label' )); ?></label>
-
 	</div>
+
 	<div class="ur-field" data-field-key="nickname">
-
 		<input type="text" id="ur-input-type-nickname" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>" placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
-
 	</div>
+
 	<?php
-
-	UR_Nickname::get_instance()->get_setting();
-
+		UR_Nickname::get_instance()->get_setting();
 	?>
 </div>
 

--- a/includes/form/views/admin/admin-nickname.php
+++ b/includes/form/views/admin/admin-nickname.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="ur-field" data-field-key="nickname">
 
-		<input type="text" id="ur-input-type-nickname"
+		<input type="text" id="ur-input-type-nickname" value="<?php echo esc_attr($this->get_general_setting_data( 'default' )); ?>"
 			   placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
 
 	</div>

--- a/includes/form/views/admin/admin-number.php
+++ b/includes/form/views/admin/admin-number.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="ur-field" data-field-key="number">
 
-		<input type="number" id="ur-input-type-number"
+		<input type="number" value="<?php echo esc_attr($this->get_general_setting_data( 'default' )); ?>" id="ur-input-type-number"
 			   placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
 
 	</div>

--- a/includes/form/views/admin/admin-number.php
+++ b/includes/form/views/admin/admin-number.php
@@ -9,21 +9,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 ?>
 <div class="ur-input-type-number ur-admin-template">
-
 	<div class="ur-label">
 		<label><?php echo esc_html($this->get_general_setting_data( 'label' )); ?></label>
-
 	</div>
+
 	<div class="ur-field" data-field-key="number">
-
-		<input type="number" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>" id="ur-input-type-number"
-			   placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
-
+		<input type="number" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>" id="ur-input-type-number" placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
 	</div>
+
 	<?php
-
-	  UR_Number::get_instance()->get_setting();
-
+		UR_Number::get_instance()->get_setting();
 	?>
 </div>
 

--- a/includes/form/views/admin/admin-number.php
+++ b/includes/form/views/admin/admin-number.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="ur-field" data-field-key="number">
 
-		<input type="number" value="<?php echo esc_attr($this->get_general_setting_data( 'default' )); ?>" id="ur-input-type-number"
+		<input type="number" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>" id="ur-input-type-number"
 			   placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
 
 	</div>

--- a/includes/form/views/admin/admin-password.php
+++ b/includes/form/views/admin/admin-password.php
@@ -13,14 +13,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<div class="ur-label">
 		<label><?php echo esc_html($this->get_general_setting_data( 'label' )); ?></label>
 	</div>
+
 	<div class="ur-field" data-field-key="password">
 		<input type="password" id="ur-input-type-password"/>
 	</div>
 
 	<?php
-
-	UR_Password::get_instance()->get_setting();
-
+		UR_Password::get_instance()->get_setting();
 	?>
 </div>
 

--- a/includes/form/views/admin/admin-privacy-policy.php
+++ b/includes/form/views/admin/admin-privacy-policy.php
@@ -15,15 +15,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	</div>
 	<div class="ur-field" data-field-key="privacy_policy">
-
-		<input type="checkbox" id="ur-input-type-privacy-policy" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>"
-		       placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
-
+		<?php $selected = $this->get_advance_setting_data( 'default_value' ); ?>
+		<input type="checkbox" id="ur-input-type-privacy-policy" value="1" <?php echo checked( $selected, 1, false );?> >
 	</div>
 	<?php
-
-	UR_Privacy_Policy::get_instance()->get_setting();
-
+		UR_Privacy_Policy::get_instance()->get_setting();
 	?>
 </div>
 

--- a/includes/form/views/admin/admin-privacy-policy.php
+++ b/includes/form/views/admin/admin-privacy-policy.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="ur-field" data-field-key="privacy_policy">
 
-		<input type="checkbox" id="ur-input-type-privacy-policy"
+		<input type="checkbox" id="ur-input-type-privacy-policy" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>"
 		       placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
 
 	</div>

--- a/includes/form/views/admin/admin-radio.php
+++ b/includes/form/views/admin/admin-radio.php
@@ -14,23 +14,21 @@ $options = isset( $this->admin_data->advance_setting->options ) ? explode( ',', 
 
 	<div class="ur-label">
 		<label><?php echo esc_html($this->get_general_setting_data( 'label' )); ?></label>
-
 	</div>
-	<div class="ur-field" data-field-key="radio">
 
+	<div class="ur-field" data-field-key="radio">
+			<?php $selected = $this->get_advance_setting_data( 'default_value' ); ?>
 			<?php
-			if(count($options)<1){
-				echo "<input type = 'radio'  value='1'/>";
+			if( count( $options ) < 1 ) {
+				echo "<input type = 'radio'  value='1' '"  . checked( $selected, 1, false ) . "'>";
 			}
 			foreach ( $options as $option ) {
-				echo "<input type = 'radio'  value='" . esc_attr( $option ) . "'/>" . esc_html( trim( $option ) ) . '<br>';
+				echo "<input name = " . esc_html( $this->get_general_setting_data(  'field_name' ) ) . " type = 'radio'  value=" . esc_attr( $option ) . " "  . checked( $selected, $option, false ) . " >" . esc_html( trim( $option ) ) . '<br>';
 			}
 			?>
 	</div>
 	<?php
-
 	  UR_Radio::get_instance()->get_setting();
-
 	?>
 </div>
 

--- a/includes/form/views/admin/admin-select.php
+++ b/includes/form/views/admin/admin-select.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Form View: Select
- */
+*/
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -11,28 +11,23 @@ $options = isset( $this->admin_data->advance_setting->options ) ? explode( ',', 
 
 ?>
 <div class="ur-input-type-select ur-admin-template">
-
 	<div class="ur-label">
 		<label><?php echo esc_html($this->get_general_setting_data( 'label' )); ?></label>
-
 	</div>
+
 	<div class="ur-field" data-field-key="select">
-
+		<?php $selected = $this->get_advance_setting_data( 'default_value' ); ?>
 		<select id="ur-input-type-select">
-
 			<?php
-			foreach ( $options as $option ) {
-
-				echo "<option value='" . esc_attr($option) . "'>" . esc_html( trim( $option ) ) . '</option>';
-			}
+				foreach ( $options as $option ) {
+					echo "<option value='" . esc_attr($option) . "' '"  . selected( $selected, $option ) . "' >" . esc_html( trim( $option ) ) . '</option>';
+				}
 			?>
 		</select>
-
 	</div>
+
 	<?php
-
 	  UR_Select::get_instance()->get_setting();
-
 	?>
 </div>
 

--- a/includes/form/views/admin/admin-select.php
+++ b/includes/form/views/admin/admin-select.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Form View: Select
-*/
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -20,7 +20,7 @@ $options = isset( $this->admin_data->advance_setting->options ) ? explode( ',', 
 		<select id="ur-input-type-select">
 			<?php
 				foreach ( $options as $option ) {
-					echo "<option value='" . esc_attr($option) . "' '"  . selected( $selected, $option ) . "' >" . esc_html( trim( $option ) ) . '</option>';
+					echo "<option value=" . esc_attr($option) . " " . selected( $selected, $option ) . ">" . esc_html( trim( $option ) ) . '</option>';
 				}
 			?>
 		</select>

--- a/includes/form/views/admin/admin-text.php
+++ b/includes/form/views/admin/admin-text.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="ur-field" data-field-key="text">
 
-		<input type="text" id="ur-input-type-text"
+		<input type="text" id="ur-input-type-text" value="<?php echo esc_attr($this->get_general_setting_data( 'default' )); ?>"
 			   placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
 
 	</div>

--- a/includes/form/views/admin/admin-text.php
+++ b/includes/form/views/admin/admin-text.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="ur-field" data-field-key="text">
 
-		<input type="text" id="ur-input-type-text" value="<?php echo esc_attr($this->get_general_setting_data( 'default' )); ?>"
+		<input type="text" id="ur-input-type-text" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>"
 			   placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
 
 	</div>

--- a/includes/form/views/admin/admin-text.php
+++ b/includes/form/views/admin/admin-text.php
@@ -9,21 +9,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 ?>
 <div class="ur-input-type-text ur-admin-template">
-
 	<div class="ur-label">
 		<label><?php echo esc_html($this->get_general_setting_data( 'label' )); ?></label>
-
 	</div>
+
 	<div class="ur-field" data-field-key="text">
-
-		<input type="text" id="ur-input-type-text" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>"
-			   placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
-
+		<input type="text" id="ur-input-type-text" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>" placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
 	</div>
+
 	<?php
-
-	  UR_Text::get_instance()->get_setting();
-
+		UR_Text::get_instance()->get_setting();
 	?>
 </div>
 

--- a/includes/form/views/admin/admin-textarea.php
+++ b/includes/form/views/admin/admin-textarea.php
@@ -15,7 +15,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	</div>
 	<div class="ur-field" data-field-key="textarea">
-
 		<textarea id="ur-input-type-textarea"><?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?></textarea>
 
 	</div>

--- a/includes/form/views/admin/admin-textarea.php
+++ b/includes/form/views/admin/admin-textarea.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="ur-field" data-field-key="textarea">
 
-		<textarea id="ur-input-type-textarea"></textarea>
+		<textarea id="ur-input-type-textarea"><?php echo esc_attr($this->get_general_setting_data( 'default' )); ?></textarea>
 
 	</div>
 	<?php

--- a/includes/form/views/admin/admin-textarea.php
+++ b/includes/form/views/admin/admin-textarea.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="ur-field" data-field-key="textarea">
 
-		<textarea id="ur-input-type-textarea"><?php echo esc_attr($this->get_general_setting_data( 'default' )); ?></textarea>
+		<textarea id="ur-input-type-textarea"><?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?></textarea>
 
 	</div>
 	<?php

--- a/includes/form/views/admin/admin-user-confirm-password.php
+++ b/includes/form/views/admin/admin-user-confirm-password.php
@@ -16,8 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="ur-field" data-field-key="user_confirm_password">
 
-		<input type="password" id="ur-input-type-user-confirm-password"
-			   placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
+		<input type="password" id="ur-input-type-user-confirm-password" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>" placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
 
 	</div>
 	<?php

--- a/includes/form/views/admin/admin-user-email.php
+++ b/includes/form/views/admin/admin-user-email.php
@@ -16,8 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="ur-field" data-field-key="user_email">
 
-		<input type="email" id="ur-input-type-user-email" value="<?php echo esc_attr($this->get_general_setting_data( 'default' )); ?>"
-			   placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
+		<input type="email" id="ur-input-type-user-email" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>" placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
 
 	</div>
 	<?php

--- a/includes/form/views/admin/admin-user-email.php
+++ b/includes/form/views/admin/admin-user-email.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="ur-field" data-field-key="user_email">
 
-		<input type="email" id="ur-input-type-user-email"
+		<input type="email" id="ur-input-type-user-email" value="<?php echo esc_attr($this->get_general_setting_data( 'default' )); ?>"
 			   placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
 
 	</div>

--- a/includes/form/views/admin/admin-user-login.php
+++ b/includes/form/views/admin/admin-user-login.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="ur-field" data-field-key="user_login">
 
-		<input type="text" id="ur-input-type-user-login"
+		<input type="text" id="ur-input-type-user-login" value="<?php echo esc_attr($this->get_general_setting_data( 'default' )); ?>"
 			   placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
 
 	</div>

--- a/includes/form/views/admin/admin-user-login.php
+++ b/includes/form/views/admin/admin-user-login.php
@@ -16,8 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="ur-field" data-field-key="user_login">
 
-		<input type="text" id="ur-input-type-user-login" value="<?php echo esc_attr($this->get_general_setting_data( 'default' )); ?>"
-			   placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
+		<input type="text" id="ur-input-type-user-login" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>" placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
 
 	</div>
 	<?php

--- a/includes/form/views/admin/admin-user-pass.php
+++ b/includes/form/views/admin/admin-user-pass.php
@@ -16,8 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="ur-field" data-field-key="user_pass">
 
-		<input type="password" id="ur-input-type-user-pass"
-			   placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
+		<input type="password" id="ur-input-type-user-pass" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>" placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
 
 	</div>
 	<?php

--- a/includes/form/views/admin/admin-user-url.php
+++ b/includes/form/views/admin/admin-user-url.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="ur-field" data-field-key="user_url">
 
-		<input type="text" id="ur-input-type-user-url" value="<?php echo esc_attr($this->get_general_setting_data( 'default' )); ?>"
+		<input type="text" id="ur-input-type-user-url" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>"
 			   placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
 
 	</div>

--- a/includes/form/views/admin/admin-user-url.php
+++ b/includes/form/views/admin/admin-user-url.php
@@ -16,8 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="ur-field" data-field-key="user_url">
 
-		<input type="text" id="ur-input-type-user-url" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>"
-			   placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
+		<input type="text" id="ur-input-type-user-url" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>" placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
 
 	</div>
 	<?php

--- a/includes/form/views/admin/admin-user-url.php
+++ b/includes/form/views/admin/admin-user-url.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="ur-field" data-field-key="user_url">
 
-		<input type="text" id="ur-input-type-user-url"
+		<input type="text" id="ur-input-type-user-url" value="<?php echo esc_attr($this->get_general_setting_data( 'default' )); ?>"
 			   placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
 
 	</div>

--- a/includes/form/views/admin/admin-user-url.php
+++ b/includes/form/views/admin/admin-user-url.php
@@ -9,20 +9,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 ?>
 <div class="ur-input-type-user-url ur-admin-template">
-
 	<div class="ur-label">
 		<label><?php echo esc_html($this->get_general_setting_data( 'label' )); ?></label>
-
 	</div>
+
 	<div class="ur-field" data-field-key="user_url">
-
 		<input type="text" id="ur-input-type-user-url" value="<?php echo esc_attr( $this->get_advance_setting_data( 'default_value' )); ?>" placeholder="<?php echo esc_attr($this->get_general_setting_data( 'placeholder' )); ?>"/>
-
 	</div>
+
 	<?php
-
-	UR_User_Url::get_instance()->get_setting();
-
+		UR_User_Url::get_instance()->get_setting();
 	?>
 </div>
 

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -188,12 +188,8 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 
 			if( isset($args['choices']) && count($args['choices']) >1 ){
 
-				//TODO
-				//$default = !empty($args['default']) ? unserialize( $args['default'] ) : array();		
-				$default = array();
-
+				$default = !empty($args['default']) ? $args['default'] : array();		
 				$choices = isset( $args['choices'] ) ? $args['choices'] : array();
-
 				$field   = '<label class="checkbox ' . implode( ' ', $custom_attributes ) . '">';
 				$field   .= $args['label'] . $required . '</label>';
 				$checkbox_start =0;

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -98,7 +98,6 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 	 * @return string
 	 */
 	function user_registration_form_field( $key, $args, $value = null ) {
-
 		$defaults = array(
 			'type'              => 'text',
 			'label'             => '',

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -189,7 +189,9 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 
 			if( isset($args['choices']) && count($args['choices']) >1 ){
 
-				$default = !empty($args['default']) ? unserialize( $args['default'] ) : array();		
+				//TODO
+				//$default = !empty($args['default']) ? unserialize( $args['default'] ) : array();		
+				$default = array();
 
 				$choices = isset( $args['choices'] ) ? $args['choices'] : array();
 

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -98,6 +98,7 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 	 * @return string
 	 */
 	function user_registration_form_field( $key, $args, $value = null ) {
+
 		$defaults = array(
 			'type'              => 'text',
 			'label'             => '',


### PR DESCRIPTION
Includes the feature to add default values, previously, there is an default value in field's advance setting. However, for the WordPress default fields, the section doesnot seem to appear. Also, since there is an option to enter text directly, default value in advance setting should be removed.