### PR TITLE
BuddyPress compatibiltiy on members area

### DIFF
--- a/includes/frontend/class-ur-frontend-form-handler.php
+++ b/includes/frontend/class-ur-frontend-form-handler.php
@@ -268,6 +268,7 @@ class UR_Frontend_Form_Handler {
 				update_user_meta( $user_id, $field_name, $data->value );
 			}
 		update_user_meta( $user_id, 'ur_form_id', $form_id );
+		update_user_meta( $user_id, 'last_activity', '' ); //BuddyPress members area compatibility.
 		}
 	}
 

--- a/includes/frontend/class-ur-frontend-form-handler.php
+++ b/includes/frontend/class-ur-frontend-form-handler.php
@@ -268,7 +268,9 @@ class UR_Frontend_Form_Handler {
 				update_user_meta( $user_id, $field_name, $data->value );
 			}
 		update_user_meta( $user_id, 'ur_form_id', $form_id );
-		update_user_meta( $user_id, 'last_activity', '' ); //BuddyPress members area compatibility.
+
+		//BuddyPress members area compatibility.
+		function_exists( 'bp_update_user_last_activity' ) ? bp_update_user_last_activity( $user_id ) : update_user_meta( $user_id, 'last_activity', '' );
 		}
 	}
 


### PR DESCRIPTION
The users registered with user registration will not directly feature on BuddyPress members list until the user logs in. This PR removes this requisition.