### PR TITLE
Redirect users to the redirect url set in settings on registration page

### DIFF
--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -87,6 +87,7 @@ function ur_registration_template_redirect() {
 
 		if ( has_shortcode( $post_content, 'user_registration_form' ) ) {
 			$redirect_url = get_option( 'user_registration_general_setting_redirect_options' );
+			$redirect_url = apply_filters( 'user_registration_redirect_from_registration_page', $redirect, $current_user );
 
 			if( ! empty( $redirect_url ) ) {
 				wp_safe_redirect( $redirect_url );

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -16,6 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 add_action( 'template_redirect', 'ur_template_redirect' );
 add_action( 'template_redirect', 'ur_login_template_redirect' );
+add_action( 'template_redirect', 'ur_registration_template_redirect' );
 
 /**
  * Redirect after logout.
@@ -56,6 +57,29 @@ function ur_login_template_redirect() {
 		if ( ! empty( $redirect_url ) ) {
 			wp_redirect( $redirect_url );
 		}
+	}
+}
+
+/**
+ * Redirects the logged in user to the option set in settings if registration page is selected.
+ * Donot redirect for admins.
+ * @return void
+ * @since  1.5.2
+ */
+function ur_registration_template_redirect() {
+
+	// Return if the user is not logged in.
+	if( is_user_logged_in() === false ) {
+		return;
+	}
+
+	$current_user = wp_get_current_user();
+
+	// Donot redirect for admins.
+	if( in_array( 'administrator', wp_get_current_user()->roles) ) {
+		return;
+	} else {
+
 	}
 }
 

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -80,6 +80,18 @@ function ur_registration_template_redirect() {
 		return;
 	} else {
 
+		global $post;
+
+		$post_content = isset( $post->post_content ) ? $post->post_content : '';
+
+		if ( has_shortcode( $post_content, 'user_registration_form' ) ) {
+			$redirect_url = get_option( 'user_registration_general_setting_redirect_options' );
+
+			if( ! empty( $redirect_url ) ) {
+				wp_safe_redirect( $redirect_url );
+				exit();
+			}
+		}
 	}
 }
 

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -56,6 +56,7 @@ function ur_login_template_redirect() {
 
 		if ( ! empty( $redirect_url ) ) {
 			wp_redirect( $redirect_url );
+			exit();
 		}
 	}
 }

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -86,8 +86,9 @@ function ur_registration_template_redirect() {
 		$post_content = isset( $post->post_content ) ? $post->post_content : '';
 
 		if ( has_shortcode( $post_content, 'user_registration_form' ) ) {
+
 			$redirect_url = get_option( 'user_registration_general_setting_redirect_options' );
-			$redirect_url = apply_filters( 'user_registration_redirect_from_registration_page', $redirect, $current_user );
+			$redirect_url = apply_filters( 'user_registration_redirect_from_registration_page', $redirect_url, $current_user );
 
 			if( ! empty( $redirect_url ) ) {
 				wp_safe_redirect( $redirect_url );


### PR DESCRIPTION
Previously, if the user is already logged in and upon registration page this message was shown:

> You are currently logged in as {username}. Logout? 

It would be appropriate to redirect users to the redirect url set after registration in the settings.