### PR TITLE
Cache helper

### DIFF
--- a/includes/class-ur-cache-helper.php
+++ b/includes/class-ur-cache-helper.php
@@ -20,19 +20,22 @@ class UR_Cache_Helper {
 	 */
 	public static function init() {
 		add_action( 'admin_notices', array( __CLASS__, 'notices' ) );
-		// add_action( 'wp', array( __CLASS__, 'prevent_caching' ) );
+		add_action( 'wp', array( __CLASS__, 'prevent_caching' ) );
 		add_action( 'user_registration_before_registration_form', array( __CLASS__, 'flush_w3tc_cache' ) );
+		add_action( 'user_registration_before_registration_form', array( __CLASS__, 'flush_wpsuper_cache' ) );
+		add_action( 'user_registration_before_registration_form', array( __CLASS__, 'flush_wprocket_cache' ) );
 	}
 
 	/**
 	 * Prevent caching on certain pages
 	 */
-	public static function prevent_caching( $id ) {
+	public static function prevent_caching( $id = '' ) {
 
 		if ( ! is_blog_installed() ) {
 			return;
 		}
 
+		$id       = is_integer( $id ) ? $id : -1;
 		$page_ids = array_filter( array( ur_get_page_id( 'myaccount' ), $id ) );
 
 		if ( is_page( $page_ids ) ) {
@@ -42,12 +45,33 @@ class UR_Cache_Helper {
 	}
 
 	/**
-	 * Flush already set cache on registration page.
+	 * Flush already set cache by w3total cache plugin on registration page.
 	 */
 	public static function flush_w3tc_cache() {
 		if ( function_exists( 'w3tc_pgcache_flush' ) ) {
-			$page_id = get_the_ID();
-			w3tc_pgcache_flush_post( $page_id );
+			$post_id = get_the_ID();
+			w3tc_pgcache_flush_post( $post_id );
+		}
+	}
+
+	/**
+	 * Flush already set cache by wp super cache plugin on registration page.
+	 */
+	public function flush_wpsuper_cache() {
+		if ( function_exitts( 'wpsc_delete_post_cache' ) ) {
+			$post_id = get_the_ID();
+			wpsc_delete_post_cache( $post_id );
+		}
+	}
+
+
+	/**
+	 * Flush already set cache by wp rocket cache plugin on registration page.
+	 */
+	public function flush_wprocket_cache() {
+		if ( function_exitts( 'rocket_clean_post' ) ) {
+			$post_id = get_the_ID();
+			rocket_clean_post( $post_id );
 		}
 	}
 

--- a/includes/class-ur-cache-helper.php
+++ b/includes/class-ur-cache-helper.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Cache Helper Class
+ *
+ * @class   UR_Cache_Helper
+ * @since   1.5.7
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * UR_Cache_Helper Class.
+ */
+class UR_Cache_Helper {
+
+	/**
+	 * Hook in methods.
+	 */
+	public static function init() {
+		add_action( 'admin_notices', array( __CLASS__, 'notices' ) );
+		add_action( 'wp', array( __CLASS__, 'prevent_caching' ) );
+		add_action( 'user_registration_before_registration_form', array( __CLASS__, 'flush_w3tc_cache ' ) );
+	}
+
+	/**
+	 * Prevent caching on certain pages
+	 */
+	public static function prevent_caching() {
+		if ( ! is_blog_installed() ) {
+			return;
+		}
+
+		$page_ids = array_filter( ur_get_page_id( 'myaccount' ) );
+
+		if ( is_page( $page_ids ) ) {
+			self::set_nocache_constants();
+			nocache_headers();
+		}
+	}
+
+	/**
+	 * Flush already set cache.
+	 */
+	public function flush_w3tc_cache() {
+		if ( function_exists( 'w3tc_pgcache_flush' ) ) {
+			w3tc_pgcache_flush();
+		}
+	}
+
+	/**
+	 * Set constants to prevent caching by some plugins.
+	 *
+	 * @param  mixed $return Value to return. Previously hooked into a filter.
+	 * @return mixed
+	 */
+	public static function set_nocache_constants( $return = true ) {
+		ur_maybe_define_constant( 'DONOTCACHEPAGE', true );
+		ur_maybe_define_constant( 'DONOTCACHEOBJECT', true );
+		ur_maybe_define_constant( 'DONOTCACHEDB', true );
+		return $return;
+	}
+
+	/**
+	 * Notices function.
+	 */
+	public static function notices() {
+		if ( ! function_exists( 'w3tc_pgcache_flush' ) || ! function_exists( 'w3_instance' ) ) {
+			return;
+		}
+
+		$config   = w3_instance( 'W3_Config' );
+		$enabled  = $config->get_integer( 'dbcache.enabled' );
+		$settings = array_map( 'trim', $config->get_array( 'dbcache.reject.sql' ) );
+
+		if ( $enabled && ! in_array( '_ur_session_', $settings, true ) ) {
+			?>
+			<div class="error">
+				<p><?php echo wp_kses_post( sprintf( __( 'In order for <strong>database caching</strong> to work with User Registration you must add %1$s to the "Ignored Query Strings" option in <a href="%2$s">W3 Total Cache settings</a>.', 'user-registration' ), '<code>_ur_session_</code>', esc_url( admin_url( 'admin.php?page=w3tc_dbcache' ) ) ) ); ?></p>
+			</div>
+			<?php
+		}
+	}
+}
+
+UR_Cache_Helper::init();

--- a/includes/class-ur-cache-helper.php
+++ b/includes/class-ur-cache-helper.php
@@ -20,19 +20,20 @@ class UR_Cache_Helper {
 	 */
 	public static function init() {
 		add_action( 'admin_notices', array( __CLASS__, 'notices' ) );
-		add_action( 'wp', array( __CLASS__, 'prevent_caching' ) );
-		add_action( 'user_registration_before_registration_form', array( __CLASS__, 'flush_w3tc_cache ' ) );
+		// add_action( 'wp', array( __CLASS__, 'prevent_caching' ) );
+		add_action( 'user_registration_before_registration_form', array( __CLASS__, 'flush_w3tc_cache' ) );
 	}
 
 	/**
 	 * Prevent caching on certain pages
 	 */
-	public static function prevent_caching() {
+	public static function prevent_caching( $id ) {
+
 		if ( ! is_blog_installed() ) {
 			return;
 		}
 
-		$page_ids = array_filter( ur_get_page_id( 'myaccount' ) );
+		$page_ids = array_filter( array( ur_get_page_id( 'myaccount' ), $id ) );
 
 		if ( is_page( $page_ids ) ) {
 			self::set_nocache_constants();
@@ -41,11 +42,12 @@ class UR_Cache_Helper {
 	}
 
 	/**
-	 * Flush already set cache.
+	 * Flush already set cache on registration page.
 	 */
-	public function flush_w3tc_cache() {
+	public static function flush_w3tc_cache() {
 		if ( function_exists( 'w3tc_pgcache_flush' ) ) {
-			w3tc_pgcache_flush();
+			$page_id = get_the_ID();
+			w3tc_pgcache_flush_post( $page_id );
 		}
 	}
 

--- a/includes/class-ur-shortcodes.php
+++ b/includes/class-ur-shortcodes.php
@@ -157,6 +157,10 @@ class UR_Shortcodes {
 	 * @since 1.0.1 Recaptcha only
 	 */
 	private static function render_form( $form_id ) {
+
+		$page_id = get_the_ID();
+		UR_Cache_Helper::prevent_caching( $page_id );
+
 		$args = array(
 			'post_type'   => 'user_registration',
 			'post_status' => 'publish',

--- a/user-registration.php
+++ b/user-registration.php
@@ -191,6 +191,7 @@ if ( ! class_exists( 'UserRegistration' ) ) :
 			include_once UR_ABSPATH . 'includes/class-ur-email-confirmation.php';
 			include_once UR_ABSPATH . 'includes/class-ur-privacy.php';
 			include_once UR_ABSPATH . 'includes/class-ur-form-block.php';
+			include_once UR_ABSPATH . 'includes/class-ur-cache-helper.php';
 
 			/**
 			 * Config classes.


### PR DESCRIPTION
This PR introduces a cache helper class to flush cache created on registration pages by some popular cache plugins such as: W3total cache, WP super cache and WP Rocket. It is also intended to prevent cache on registration pages and myaccount pages. However, to prevent caching `nocache_headers();` should be called as early on `wp` hook. Not after that and the registration page could only be identified later on. So, I guess cache flush is only the option and preventing cache maynot work.