### PR TITLE
Fix/undefined error registration ajax

### DIFF
--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -62,6 +62,14 @@ class UR_AJAX {
 	 */
 	public static function user_form_submit() {
 
+		if ( is_user_logged_in() ) {
+			wp_send_json_error(
+				array(
+					'message' => __( 'You are already logged in.', 'user-registration' ),
+				)
+			);
+		}
+
 		if ( check_ajax_referer( 'user_registration_form_data_save_nonce', 'security', false ) ) {
 			wp_send_json_error(
 				array(

--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -62,7 +62,13 @@ class UR_AJAX {
 	 */
 	public static function user_form_submit() {
 
-		check_ajax_referer( 'user_registration_form_data_save_nonce', 'security' );
+		if ( check_ajax_referer( 'user_registration_form_data_save_nonce', 'security', false ) ) {
+			wp_send_json_error(
+				array(
+					'message' => __( 'Nonce error, please reload.', 'user-registration' ),
+				)
+			);
+		}
 
 		$form_id           = isset( $_POST['form_id'] ) ? absint( $_POST['form_id'] ) : 0;
 		$nonce             = isset( $_POST['ur_frontend_form_nonce'] ) ? $_POST['ur_frontend_form_nonce'] : '';


### PR DESCRIPTION
_It solves "Cannot read property ‘message’ of undefined" error in ajax registration form submission._

The undefined error was occurred due to **'security'** nonce. Or if the user is already logged-in in another tab. To fix this, I have added validation to check if the user is already _logged-in_ and also returned an error message for nonce error for security nonce also.