### PR TITLE
Fix: Json_decode error on user profile.

### DIFF
--- a/includes/shortcodes/class-ur-shortcode-my-account.php
+++ b/includes/shortcodes/class-ur-shortcode-my-account.php
@@ -190,7 +190,7 @@ class UR_Shortcode_My_Account {
 				)
 			);
 		} else {
-			echo esc_html__( 'No profile details found.', 'user-registration' );
+			echo '<h1>' . esc_html__( 'No profile details found.', 'user-registration' ) . '</h1>';
 		}
 	}
 

--- a/includes/shortcodes/class-ur-shortcode-my-account.php
+++ b/includes/shortcodes/class-ur-shortcode-my-account.php
@@ -154,41 +154,44 @@ class UR_Shortcode_My_Account {
 
 		if ( isset( $form_data[0] ) ) {
 			$form_data = $form_data[0]->post_content;
-		}
-		$form_data_array = json_decode( $form_data );
 
-		if ( gettype( $form_data_array ) != 'array' ) {
-			$form_data_array = array();
-		}
+			$form_data_array = json_decode( $form_data );
 
-		if ( count( $profile ) < 1 ) {
-			return;
-		}
-
-		// Prepare values
-		foreach ( $profile as $key => $field ) {
-			$value                    = get_user_meta( get_current_user_id(), $key, true );
-			$profile[ $key ]['value'] = apply_filters( 'user_registration_my_account_edit_profile_field_value', $value, $key );
-			$new_key                  = str_replace( 'user_registration_', '', $key );
-
-			if ( in_array( $new_key, ur_get_registered_user_meta_fields() ) ) {
-				$value                    = get_user_meta( get_current_user_id(), ( str_replace( 'user_', '', $new_key ) ), true );
-				$profile[ $key ]['value'] = apply_filters( 'user_registration_my_account_edit_profile_field_value', $value, $key );
-			} elseif ( isset( $user_data->$new_key ) && in_array( $new_key, ur_get_user_table_fields() ) ) {
-				$profile[ $key ]['value'] = apply_filters( 'user_registration_my_account_edit_profile_field_value', $user_data->$new_key, $key );
-
-			} elseif ( isset( $user_data->display_name ) && $key === 'user_registration_display_name' ) {
-				$profile[ $key ]['value'] = apply_filters( 'user_registration_my_account_edit_profile_field_value', $user_data->display_name, $key );
+			if ( gettype( $form_data_array ) != 'array' ) {
+				$form_data_array = array();
 			}
-		}
 
-		ur_get_template(
-			'myaccount/form-edit-profile.php',
-			array(
-				'profile'         => apply_filters( 'user_registration_profile_to_edit', $profile ),
-				'form_data_array' => $form_data_array,
-			)
-		);
+			if ( count( $profile ) < 1 ) {
+				return;
+			}
+
+			// Prepare values
+			foreach ( $profile as $key => $field ) {
+				$value                    = get_user_meta( get_current_user_id(), $key, true );
+				$profile[ $key ]['value'] = apply_filters( 'user_registration_my_account_edit_profile_field_value', $value, $key );
+				$new_key                  = str_replace( 'user_registration_', '', $key );
+
+				if ( in_array( $new_key, ur_get_registered_user_meta_fields() ) ) {
+					$value                    = get_user_meta( get_current_user_id(), ( str_replace( 'user_', '', $new_key ) ), true );
+					$profile[ $key ]['value'] = apply_filters( 'user_registration_my_account_edit_profile_field_value', $value, $key );
+				} elseif ( isset( $user_data->$new_key ) && in_array( $new_key, ur_get_user_table_fields() ) ) {
+					$profile[ $key ]['value'] = apply_filters( 'user_registration_my_account_edit_profile_field_value', $user_data->$new_key, $key );
+
+				} elseif ( isset( $user_data->display_name ) && $key === 'user_registration_display_name' ) {
+					$profile[ $key ]['value'] = apply_filters( 'user_registration_my_account_edit_profile_field_value', $user_data->display_name, $key );
+				}
+			}
+
+			ur_get_template(
+				'myaccount/form-edit-profile.php',
+				array(
+					'profile'         => apply_filters( 'user_registration_profile_to_edit', $profile ),
+					'form_data_array' => $form_data_array,
+				)
+			);
+		} else {
+			echo esc_html__( 'No profile detail found', 'user-registration' );
+		}
 	}
 
 	/**

--- a/includes/shortcodes/class-ur-shortcode-my-account.php
+++ b/includes/shortcodes/class-ur-shortcode-my-account.php
@@ -190,7 +190,7 @@ class UR_Shortcode_My_Account {
 				)
 			);
 		} else {
-			echo esc_html__( 'No profile detail found', 'user-registration' );
+			echo esc_html__( 'No profile details found.', 'user-registration' );
 		}
 	}
 


### PR DESCRIPTION
Problem tackled:
When a user, especially admin who is not registered through a form tries to access his/her profile then it throws a json_decode error. This occurs because the user profile uses the same registration form which user used while registering. But in this case, when admin is not registered through the form, it will not find it and thus send no data in JSON. 

Solution:
Extended the condition to check if the form data is empty to cover the rest of the block. This way, if form data is empty then no other code will run and I added an else statement where it will display "No profile found".

