### PR TITLE
Fix - Menu Items invalid arguments

### DIFF
--- a/includes/functions-ur-page.php
+++ b/includes/functions-ur-page.php
@@ -124,7 +124,7 @@ function ur_nav_menu_items( $items ) {
 	if ( ! is_user_logged_in() ) {
 		$customer_logout = get_option( 'user_registration_logout_endpoint', 'user-logout' );
 
-		if ( ! empty( $customer_logout ) ) {
+		if ( ! empty( $customer_logout ) && is_array( $items ) ) {
 			foreach ( $items as $key => $item ) {
 				if ( empty( $item->url ) ) {
 					continue;


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### How to test the changes in this Pull Request:

1. First Login to see Logout menu.
2. After that Log out.
3. Check if Logout menu is removed.

### Types of changes:

* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> This issue was reported by users. It seems they have no menu setup, which creates the $items variable not to be an array. 
Fixed the issue by adding a condition to check if the $items variable is an array.
