### PR TITLE
Fix - Log delete on reload

### DIFF
--- a/includes/admin/class-ur-admin-status.php
+++ b/includes/admin/class-ur-admin-status.php
@@ -173,5 +173,8 @@ class UR_Admin_Status {
 			$log_handler = new UR_Log_Handler_File();
 			$log_handler->remove( $_REQUEST['handle'] );
 		}
+
+		wp_safe_redirect( esc_url_raw( admin_url( 'admin.php?page=user-registration-status&tab=logs' ) ) );
+		exit();
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Redirected back to log status page after deleting selected log.

### How to test the changes in this Pull Request:

1. Delete log status.
2. And reload the same page.
3. Previously it used to delete the log again and again on reload.

### Types of changes:

* [X] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> This PR fixes the issue of the log being deleted again on reload after deleting one log.
