### PR TITLE
Fix/switch focusout code from jquery validate to user registration

### DIFF
--- a/assets/js/frontend/jquery.validate.js
+++ b/assets/js/frontend/jquery.validate.js
@@ -298,31 +298,6 @@ $.extend( $.validator, {
 		onfocusout: function( element ) {
 			if ( !this.checkable( element ) && ( element.name in this.submitted || !this.optional( element ) ) ) {
 				this.element( element );
-
-				if( element.name=="user_pass" ){
-
-					var $this = $( element );
-
-					var enable_strength_password  = $this.closest( 'form' ).attr( 'data-enable-strength-password' );
-
-					if ( 'yes' === enable_strength_password ) {
-						var wrapper                   = $this.closest('form');
-						var minimum_password_strength = wrapper.attr( 'data-minimum-password-strength' );
-						var blacklistArray            = wp.passwordStrength.userInputBlacklist();
-
-						blacklistArray.push( wrapper.find( 'input[data-id="user_email"]' ).val() ); // Add email address in blacklist.
-						blacklistArray.push( wrapper.find( 'input[data-id="user_login"]' ).val() ); // Add username in blacklist.
-
-						var strength = wp.passwordStrength.meter( element.value, blacklistArray );
-						if( strength < minimum_password_strength ) {
-							if( wrapper.find('input[data-id="user_pass"]').val() !== "" ){
-								wrapper.find( '#user_pass-error' ).remove();
-								var error_msg_dom = '<label id="user_pass-error" class="user-registration-error" for="user_pass">Password strength is not strong enough.</label>';
-								$this.closest( '.form-row' ).append( error_msg_dom );
-							}
-						}
-					}
-				}
 			}
 		},
 		onkeyup: function( element, event ) {

--- a/assets/js/frontend/user-registration.js
+++ b/assets/js/frontend/user-registration.js
@@ -485,6 +485,29 @@
 				disableMobile: true
 			});
 		}
+
+		$("form.register").on("focusout", "#user_pass", function() {
+			$this = $('#user_pass');
+			var enable_strength_password  = $this.closest( 'form' ).attr( 'data-enable-strength-password' );
+
+			if ( 'yes' === enable_strength_password ) {
+				var wrapper                   = $this.closest('form');
+				var minimum_password_strength = wrapper.attr( 'data-minimum-password-strength' );
+				var blacklistArray            = wp.passwordStrength.userInputBlacklist();
+
+				blacklistArray.push( wrapper.find( 'input[data-id="user_email"]' ).val() ); // Add email address in blacklist.
+				blacklistArray.push( wrapper.find( 'input[data-id="user_login"]' ).val() ); // Add username in blacklist.
+
+				var strength = wp.passwordStrength.meter( $this.val(), blacklistArray );
+				if( strength < minimum_password_strength ) {
+					if( wrapper.find('input[data-id="user_pass"]').val() !== "" ){
+						wrapper.find( '#user_pass-error' ).remove();
+						var error_msg_dom = '<label id="user_pass-error" class="user-registration-error" for="user_pass">Password strength is not strong enough.</label>';
+						$this.closest( '.form-row' ).append( error_msg_dom );
+					}
+				}
+			}
+		});
 	});
 
 	$(function () {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Password Strength error message on focus out code was written in core jquery.validate.js file that code is removed and added in the user-registration.js file.


### How to test the changes in this Pull Request:

1. Enable Password Strength to YES and set your password strength to stronger or else.
2. In Registration Form enter the weak password and click outside( focus out).
3. A password strength error message must be displayed.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Password Strength Error message on focus out code shifted to user-registration.js file. ( Code Cleaning )
