### PR TITLE
Fix/html field replace double quote with single

### DIFF
--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -901,6 +901,8 @@ jQuery(function ($) {
 							general_setting_data['default_value'] = get_ur_data($(this) );
 					}
 
+				} else if ( 'html' === $(this).attr('data-field') ) {
+					general_setting_data[$(this).attr('data-field')] = get_ur_data($(this)).replace(/"/g, "'");
 				} else {
 					general_setting_data[$(this).attr('data-field')] = get_ur_data($(this)) ;
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Fix - If we use HTML Field which contains double quotes that Form while Duplicating and Importing Form not working fixed by replacing double quote with a single quote while saving the form. 

### How to test the changes in this Pull Request:

1. Add HTML field which contains data like "< div class="abc">Something< / div >". 
2. Try to Duplicate the form and Import the form.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - HTML field replace double quote with single.
