### PR TITLE
Hide signup link on login form if user registration is not open

### DIFF
--- a/templates/myaccount/form-login.php
+++ b/templates/myaccount/form-login.php
@@ -107,6 +107,9 @@ if ( 'bordered' === $form_template ) {
 					?>
 
 					<?php
+					$users_can_register = get_option( 'users_can_register', 'yes' );
+				
+				if ( $users_can_register ) {
 						$url_options = get_option( 'user_registration_general_setting_registration_url_options' );
 
 					if ( ! empty( $url_options ) ) {
@@ -127,6 +130,7 @@ if ( 'bordered' === $form_template ) {
 						}
 						echo '</p>';
 					}
+				}
 					?>
 					</p>
 					<?php do_action( 'user_registration_login_form_end' ); ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

If user registration is disabled in Wordpress Settings / General, the sign up link should be hidden on the User Registration login form. This commit adds a check using get_option for users_can_register and only displays the sign up link if registration is open.

### How to test the changes in this Pull Request:

1. Under WordPress Settings / General, uncheck "Anyone can register" and the sign up link will disappear from the User Registration login form.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

Hide signup link on login form if user registration is disabled in WordPress settings.