### PR TITLE
Removed notice from form builder

### DIFF
--- a/includes/admin/class-ur-admin-notices.php
+++ b/includes/admin/class-ur-admin-notices.php
@@ -49,7 +49,7 @@ class UR_Admin_Notices {
 
 		if ( current_user_can( 'manage_user_registration' ) ) {
 			add_action( 'admin_print_styles', array( __CLASS__, 'add_notices' ) );
-			add_action( 'admin_print_scripts', array( __CLASS__, 'hide_unrelated_notices' ) );
+			add_action( 'in_admin_header', array( __CLASS__, 'hide_unrelated_notices' ) );
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
The notice displayed in the user registration form builder was disabled by adding the hide_unrelated_notices function to the in_admin_header action.


### How to test the changes in this Pull Request:

1. Install a plugin that displays a license activation notice.
2. Go to the user registration form builder. No notice will be displayed.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Removed notice from form builder.
