### PR TITLE
Correcting misbehaving data attrib and value fields for checkbox

### DIFF
--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -272,7 +272,7 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 						}
 
 						$field .= '<li class="ur-checkbox-list">';
-						$field .= '<input data-rules="' . esc_attr( $rules ) . '" data-id="' . esc_attr( $key ) . '" ' . implode( ' ', $custom_attributes ) . ' data-value="' . $choice_index . '" type="' . esc_attr( $args['type'] ) . '" class="input-checkbox ' . esc_attr( implode( ' ', $args['input_class'] ) ) . '" name="' . esc_attr( $key ) . '[]" id="' . esc_attr( $args['id'] ) . '_' . esc_attr( $choice_index ) . '" value="' . trim( $choice_index ) . '"' . $value . ' /> ';
+						$field .= '<input data-rules="' . esc_attr( $rules ) . '" data-id="' . esc_attr( $key ) . '" ' . implode( ' ', $custom_attributes ) . ' data-value="' . esc_attr($choice_index) . '" type="' . esc_attr( $args['type'] ) . '" class="input-checkbox ' . esc_attr( implode( ' ', $args['input_class'] ) ) . '" name="' . esc_attr( $key ) . '[]" id="' . esc_attr( $args['id'] ) . '_' . esc_attr( $choice_index ) . '" value="' . trim( $choice_index ) . '"' . esc_attr($value) . ' /> ';
 						$field .= '<label class="ur-checkbox-label" for="' . esc_attr( $args['id'] ) . '_' . esc_attr( $choice_index ) . '">' . trim( $choice ) . '</label> </li>';
 						$checkbox_start++;
 					}


### PR DESCRIPTION
### Fixes #180 :

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Simply escapes the attributes which caused misbehaved rendering of the form in case of checkbox. Although denying escape characters would be desirable in the long run, for product health, this will have to do for the time being.
<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #180 

### How to test the changes in this Pull Request:

1. Uses ```esc_attr()``` on data-value and value attributes

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Explanation

Utilized an edge case ```""Hello">```, which would make the form break, along with the value attribute for the field.
&nbsp;
**Before**
![image](https://user-images.githubusercontent.com/30156167/70316083-fffe8580-1842-11ea-9028-cab3f8b59c5d.png)
&nbsp;
**After**
![image](https://user-images.githubusercontent.com/30156167/70316127-199fcd00-1843-11ea-8548-ad619978b0e7.png)
