### PR TITLE
Excluding fields in edit profile section fixed

### DIFF
--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -360,7 +360,7 @@ function ur_setcookie( $name, $value, $expire = 0, $secure = false ) {
  *
  * @since  1.1.0
  *
- * @param  array $headers
+ * @param  array $headers header.
  *
  * @return array $headers
  */
@@ -500,6 +500,7 @@ function ur_exclude_profile_details_fields() {
 			'user_pass',
 			'user_confirm_password',
 			'user_confirm_email',
+			'profile_picture',
 		)
 	);
 }

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -27,7 +27,7 @@ function ur_template_redirect() {
 
 	if ( isset( $wp->query_vars['user-logout'] ) && ! empty( $_REQUEST['_wpnonce'] ) && wp_verify_nonce( $_REQUEST['_wpnonce'], 'user-logout' ) ) {
 		// Logout
-		$redirect_url = str_replace('/user-logout','', $wp->request );
+		$redirect_url = str_replace( '/user-logout', '', $wp->request );
 		wp_safe_redirect( str_replace( '&amp;', '&', wp_logout_url( $redirect_url ) ) );
 		exit;
 	} elseif ( isset( $wp->query_vars['user-logout'] ) && 'true' === $wp->query_vars['user-logout'] ) {
@@ -56,7 +56,7 @@ function ur_login_template_redirect() {
 		$redirect_url = trim( $redirect_url, '"' );
 		$redirect_url = trim( $redirect_url, "'" );
 
-		if ( ! empty( $redirect_url )) {
+		if ( ! empty( $redirect_url ) ) {
 			wp_redirect( $redirect_url );
 			exit();
 		}
@@ -274,7 +274,7 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 						}
 
 						$field .= '<li class="ur-checkbox-list">';
-						$field .= '<input data-rules="' . esc_attr( $rules ) . '" data-id="' . esc_attr( $key ) . '" ' . implode( ' ', $custom_attributes ) . ' data-value="' . esc_attr($choice_index) . '" type="' . esc_attr( $args['type'] ) . '" class="input-checkbox ' . esc_attr( implode( ' ', $args['input_class'] ) ) . '" name="' . esc_attr( $key ) . '[]" id="' . esc_attr( $args['id'] ) . '_' . esc_attr( $choice_index ) . '" value="' . trim( $choice_index ) . '"' . esc_attr($value) . ' /> ';
+						$field .= '<input data-rules="' . esc_attr( $rules ) . '" data-id="' . esc_attr( $key ) . '" ' . implode( ' ', $custom_attributes ) . ' data-value="' . esc_attr( $choice_index ) . '" type="' . esc_attr( $args['type'] ) . '" class="input-checkbox ' . esc_attr( implode( ' ', $args['input_class'] ) ) . '" name="' . esc_attr( $key ) . '[]" id="' . esc_attr( $args['id'] ) . '_' . esc_attr( $choice_index ) . '" value="' . trim( $choice_index ) . '"' . esc_attr( $value ) . ' /> ';
 						$field .= '<label class="ur-checkbox-label" for="' . esc_attr( $args['id'] ) . '_' . esc_attr( $choice_index ) . '">' . trim( $choice ) . '</label> </li>';
 						$checkbox_start++;
 					}
@@ -292,8 +292,8 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 
 				if ( empty( $extra_params ) ) {
 					$field_container = '<div class="form-row %1$s hide_show_password" id="%2$s" data-priority="' . esc_attr( $sort ) . '">%3$s</div>';
-					$field .= '<span class="password-input-group">';
-					$field .= '<input data-rules="' . esc_attr( $rules ) . '" data-id="' . esc_attr( $key ) . '" type="' . esc_attr( $args['type'] ) . '" class="input-text input-' . esc_attr( $args['type'] ) . ' ' . esc_attr( implode( ' ', $args['input_class'] ) ) . '" name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '"  value="' . esc_attr( $value ) . '" ' . implode( ' ', $custom_attributes ) . ' />';
+					$field          .= '<span class="password-input-group">';
+					$field          .= '<input data-rules="' . esc_attr( $rules ) . '" data-id="' . esc_attr( $key ) . '" type="' . esc_attr( $args['type'] ) . '" class="input-text input-' . esc_attr( $args['type'] ) . ' ' . esc_attr( implode( ' ', $args['input_class'] ) ) . '" name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '"  value="' . esc_attr( $value ) . '" ' . implode( ' ', $custom_attributes ) . ' />';
 					if ( 'yes' === get_option( 'user_registration_login_option_hide_show_password', 'no' ) ) {
 						$field .= '<a href="javaScript:void(0)" class="password_preview dashicons dashicons-hidden" title=" Show password "></a>';
 					}
@@ -395,15 +395,15 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 						$field .= '<label for="' . esc_attr( $args['id'] ) . '_' . esc_attr( $option_text ) . '" class="radio">';
 
 						$field .= wp_kses(
-								trim( $option_text ),
-								array(
-									'a'    => array(
-										'href'  => array(),
-										'title' => array(),
-									),
-									'span' => array(),
-								)
-							) . '</label></li>';
+							trim( $option_text ),
+							array(
+								'a'    => array(
+									'href'  => array(),
+									'title' => array(),
+								),
+								'span' => array(),
+							)
+						) . '</label></li>';
 					}
 					$field .= '</ul>';
 				}
@@ -420,15 +420,15 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 			$field_html = '';
 			if ( $args['label'] && 'checkbox' != $args['type'] ) {
 				$field_html .= '<label for="' . esc_attr( $label_id ) . '" class="ur-label">' . wp_kses(
-						$args['label'],
-						array(
-							'a'    => array(
-								'href'  => array(),
-								'title' => array(),
-							),
-							'span' => array(),
-						)
-					) . $required . '</label>';
+					$args['label'],
+					array(
+						'a'    => array(
+							'href'  => array(),
+							'title' => array(),
+						),
+						'span' => array(),
+					)
+				) . $required . '</label>';
 			}
 
 			$field_html     .= $field;
@@ -529,16 +529,7 @@ if ( ! function_exists( 'user_registration_form_data' ) ) {
 
 						$extra_params['default'] = isset( $all_meta_value[ 'user_registration_' . $field_name ][0] ) ? $all_meta_value[ 'user_registration_' . $field_name ][0] : '';
 
-						if ( in_array( 'user_registration_' . $field_name, $all_meta_value_keys ) ) {
-							$fields[ 'user_registration_' . $field_name ] = array(
-								'label'       => $field_label,
-								'description' => $field_description,
-								'type'        => $field_type,
-								'placeholder' => $placeholder,
-								'field_key'   => $field_key,
-								'required'    => $required,
-							);
-						} elseif ( in_array( $field_key, ur_get_user_profile_field_only() ) ) {
+						if ( in_array( $field_key, ur_get_user_profile_field_only() ) ) {
 							$fields[ 'user_registration_' . $field_name ] = array(
 								'label'       => $field_label,
 								'description' => $field_description,
@@ -642,21 +633,21 @@ if ( ! function_exists( 'user_registration_account_edit_account' ) ) {
  * @return string
  */
 
-function ur_logout_url( $redirect = '' )
-{
-	$logout_endpoint = get_option('user_registration_logout_endpoint');
-	if (( ur_post_content_has_shortcode('user_registration_login') || ur_post_content_has_shortcode( 'user_registration_my_account')) && is_user_logged_in()) {
+function ur_logout_url( $redirect = '' ) {
+	$logout_endpoint = get_option( 'user_registration_logout_endpoint' );
+	if ( ( ur_post_content_has_shortcode( 'user_registration_login' ) || ur_post_content_has_shortcode( 'user_registration_my_account' ) ) && is_user_logged_in() ) {
 		global $post;
 		$post_content = isset( $post->post_content ) ? $post->post_content : '';
-		preg_match('/' . get_shortcode_regex() . '/s', $post_content, $matches);
+		preg_match( '/' . get_shortcode_regex() . '/s', $post_content, $matches );
 
 		$attributes = shortcode_parse_atts( $matches[3] );
 		/**
 		 * Introduced logout_redirect parameter in user_registration_my_account shortcode.
+		 *
 		 * @since  1.7.5
 		 */
-		if( isset( $attributes['logout_redirect'] ) ) {
-			$redirect = isset( $attributes['logout_redirect']) ? $attributes['logout_redirect'] : '';
+		if ( isset( $attributes['logout_redirect'] ) ) {
+			$redirect = isset( $attributes['logout_redirect'] ) ? $attributes['logout_redirect'] : '';
 			$redirect = trim( $redirect, ']' );
 			$redirect = trim( $redirect, '"' );
 			$redirect = trim( $redirect, "'" );

--- a/includes/shortcodes/class-ur-shortcode-my-account.php
+++ b/includes/shortcodes/class-ur-shortcode-my-account.php
@@ -153,7 +153,6 @@ class UR_Shortcode_My_Account {
 		$user_id = get_current_user_id();
 		$form_id = get_user_meta( $user_id, 'ur_form_id', true );
 
-		add_filter( 'user_registration_user_profile_field_only', 'ur_get_registered_form_fields' );
 		$profile = user_registration_form_data( $user_id, $form_id );
 
 		$user_data = get_userdata( $user_id );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
The field name of fields listed in the filter to exclude the fields in the edit profile was not excluded and the fields were visible in the edit profile section. This PR excludes the listed fields in the edit profile section.

### How to test the changes in this Pull Request:

1. Navigate to the edit profile section of My Account page.
2. The fields like user password, confirm password and confirm email are not displayed in the edit profile section.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Exclude fields in edit profile