### PR TITLE
Added Group Descriptions to Exporters and updated Privacy Policy guide to drop use of deprecated classes

### DIFF
--- a/includes/admin/functions-ur-admin.php
+++ b/includes/admin/functions-ur-admin.php
@@ -206,10 +206,11 @@ function user_registration_data_exporter( $email_address, $page = 1 ) {
 		}
 
 		$export_items[] = array(
-			'group_id'    => 'user-registration',
-			'group_label' => __( 'User Extra Information', 'user-registration' ),
-			'item_id'     => "user-registration-{$meta->umeta_id}",
-			'data'        => $data,
+			'group_id'          => 'user-registration',
+			'group_label'       => __( 'User Extra Information', 'user-registration' ),
+			'group_description' => __( 'User registration data.', 'user-registration' ),
+			'item_id'           => "user-registration-{$meta->umeta_id}",
+			'data'              => $data,
 		);
 	}
 

--- a/includes/class-ur-privacy.php
+++ b/includes/class-ur-privacy.php
@@ -40,56 +40,50 @@ class UR_Privacy {
 	 */
 	public function get_privacy_message() {
 		$content = '
-			<div contenteditable="false">' .
-				'<p class="wp-policy-help">' .
+			<div class="wp-suggested-text">' .
+				'<p class="privacy-policy-tutorial">' .
 					__( 'This sample policy includes the basics around what personal data you may be collecting, storing and sharing, as well as who may have access to that data. Depending on what settings are enabled and which additional plugins are used, the specific information shared by your form will vary. We recommend consulting with a lawyer when deciding what information to disclose on your privacy policy.', 'user-registration' ) .
 				'</p>' .
-			'</div>' .
-			'<p>' . __( 'We collect information about the user during the user registration form submission process on our site.', 'user-registration' ) . '</p>' .
-			'<h2>' . __( 'What we collect and store', 'user-registration' ) . '</h2>' .
-			'<p>' . __( 'While you visit our site, we’ll track:', 'user-registration' ) . '</p>' .
-			'<ul>' .
-				'<li>' . __( 'Form Fields Data: Forms Fields data includes the available field types when creating a form. We’ll use this to, for example, collect informations like Name, Email and other available fields.', 'user-registration' ) . '</li>' .
-				'<li>' . __( 'Location, IP address and browser type: we’ll use this for purposes like geolocating users and reducing fraudulent activities.', 'user-registration' ) . '</li>' .
-				'<li>' . __( 'Transaction Details: we’ll ask you to enter this so we can, for instance, provide subscription packs, and keep track of your payment details for subscription packs!', 'user-registration' ) . '</li>' .
-			'</ul>' .
-			'<p>' . __( 'When you fill up a form, we’ll ask you to provide information including your name, address, email, phone number, payment details and optional account information like username and password and any other form fields available in the registration form. We’ll use this information for purposes, such as, to:', 'user-registration' ) . '</p>' .
-			'<ul>' .
-				'<li>' . __( 'Send you information about your account and order', 'user-registration' ) . '</li>' .
-				'<li>' . __( 'Respond to your requests, including transaction details and complaints', 'user-registration' ) . '</li>' .
-				'<li>' . __( 'Process payments and prevent fraud', 'user-registration' ) . '</li>' .
-				'<li>' . __( 'Set up your account for our site', 'user-registration' ) . '</li>' .
-				'<li>' . __( 'Comply with any legal obligations we have, such as calculating taxes', 'user-registration' ) . '</li>' .
-				'<li>' . __( 'Improve our form offerings', 'user-registration' ) . '</li>' .
-				'<li>' . __( 'Send you marketing messages, if you choose to receive them', 'user-registration' ) . '</li>' .
-				'<li>' . __( 'Or any other service the built form was created to comply with and it’s necessary information', 'user-registration' ) . '</li>' .
-			'</ul>' .
-			'<p>' . __( 'If you create an account, we will store your name, address, email and phone number, which will be used to populate the form fields for future submissions.', 'user-registration' ) . '</p>' .
-			'<p>' . __( 'We generally store information about you for as long as we need the information for the purposes for which we collect and use it, and we are not legally required to continue to keep it. For example, we will store form submission information for XXX years for geolocating and marketting purposes. This includes your name, address, email, phone number.', 'user-registration' ) . '</p>' .
-			'<h2>' . __( 'Who on our team has access', 'user-registration' ) . '</h2>' .
-			'<p>' . __( 'Members of our team have access to the information you provide us. For example, both Administrators and Editors can access:', 'user-registration' ) . '</p>' .
-			'<ul>' .
-				'<li>' . __( 'Form submission information and other details related to it', 'user-registration' ) . '</li>' .
-				'<li>' . __( 'Customer information like your name, email and address information.', 'user-registration' ) . '</li>' .
-			'</ul>' .
-			'<p>' . __( 'Our team members have access to this information to help fulfill entries and support you.', 'user-registration' ) . '</p>' .
-			'<h2>' . __( 'What we share with others', 'user-registration' ) . '</h2>' .
-			'<div contenteditable="false">' .
-				'<p class="wp-policy-help">' . __( 'In this section you should list who you’re sharing data with, and for what purpose. This could include, but may not be limited to, analytics, marketing, payment gateways, shipping providers, and third party embeds.', 'user-registration' ) . '</p>' .
-			'</div>' .
-			'<p>' . __( 'We share information with third parties who help us provide our orders and store services to you; for example --', 'user-registration' ) . '</p>' .
-			'<h3>' . __( 'Payments', 'user-registration' ) . '</h3>' .
-			'<div contenteditable="false">' .
-				'<p class="wp-policy-help">' . __( 'In this subsection you should list which third party payment processors you’re using to take payments on your site since these may handle customer data. We’ve included PayPal as an example, but you should remove this if you’re not using PayPal.', 'user-registration' ) . '</p>' .
-			'</div>' .
-			'<p>' . __( 'We accept payments through PayPal. When processing payments, some of your data will be passed to PayPal, including information required to process or support the payment, such as the purchase total and billing information.', 'user-registration' ) . '</p>' .
-			'<p>' . __( 'Please see the <a href="https://www.paypal.com/us/webapps/mpp/ua/privacy-full">PayPal Privacy Policy</a> for more details.', 'user-registration' ) . '</p>' .
-			'<h3>' . __( 'Available Modules', 'user-registration' ) . '</h3>' .
-			'<div contenteditable="false">' .
-				'<p class="wp-policy-help">' . __( 'In this subsection you should list which third party modules you’re using to increase functionality on your site since these may handle customer data. We’ve included MailChimp as an example, but you should remove this if you’re not using MailChimp.', 'user-registration' ) . '</p>' .
-			'</div>' .
-			'<p>' . __( 'We send beautiful email through MailChimp. When processing emails, some of your data will be passed to MailChimp, including information required to process or support the email marketing services, such as the name, email address and any other information that you intend to pass or collect including all collected information through subscription.', 'user-registration' ) . '</p>' .
-			'<p>' . __( 'Please see the <a href="https://mailchimp.com/legal/privacy/">MailChimp Privacy Policy</a> for more details.', 'user-registration' ) . '</p>';
+				'<p>' . __( 'We collect information about the user during the user registration form submission process on our site.', 'user-registration' ) . '</p>' .
+				'<h2>' . __( 'What we collect and store', 'user-registration' ) . '</h2>' .
+				'<p>' . __( 'While you visit our site, we’ll track:', 'user-registration' ) . '</p>' .
+				'<ul>' .
+					'<li>' . __( 'Form Fields Data: Forms Fields data includes the available field types when creating a form. We’ll use this to, for example, collect informations like Name, Email and other available fields.', 'user-registration' ) . '</li>' .
+					'<li>' . __( 'Location, IP address and browser type: we’ll use this for purposes like geolocating users and reducing fraudulent activities.', 'user-registration' ) . '</li>' .
+					'<li>' . __( 'Transaction Details: we’ll ask you to enter this so we can, for instance, provide subscription packs, and keep track of your payment details for subscription packs!', 'user-registration' ) . '</li>' .
+				'</ul>' .
+				'<p>' . __( 'When you fill up a form, we’ll ask you to provide information including your name, address, email, phone number, payment details and optional account information like username and password and any other form fields available in the registration form. We’ll use this information for purposes, such as, to:', 'user-registration' ) . '</p>' .
+				'<ul>' .
+					'<li>' . __( 'Send you information about your account and order', 'user-registration' ) . '</li>' .
+					'<li>' . __( 'Respond to your requests, including transaction details and complaints', 'user-registration' ) . '</li>' .
+					'<li>' . __( 'Process payments and prevent fraud', 'user-registration' ) . '</li>' .
+					'<li>' . __( 'Set up your account for our site', 'user-registration' ) . '</li>' .
+					'<li>' . __( 'Comply with any legal obligations we have, such as calculating taxes', 'user-registration' ) . '</li>' .
+					'<li>' . __( 'Improve our form offerings', 'user-registration' ) . '</li>' .
+					'<li>' . __( 'Send you marketing messages, if you choose to receive them', 'user-registration' ) . '</li>' .
+					'<li>' . __( 'Or any other service the built form was created to comply with and it’s necessary information', 'user-registration' ) . '</li>' .
+				'</ul>' .
+				'<p>' . __( 'If you create an account, we will store your name, address, email and phone number, which will be used to populate the form fields for future submissions.', 'user-registration' ) . '</p>' .
+				'<p>' . __( 'We generally store information about you for as long as we need the information for the purposes for which we collect and use it, and we are not legally required to continue to keep it. For example, we will store form submission information for XXX years for geolocating and marketting purposes. This includes your name, address, email, phone number.', 'user-registration' ) . '</p>' .
+				'<h2>' . __( 'Who on our team has access', 'user-registration' ) . '</h2>' .
+				'<p>' . __( 'Members of our team have access to the information you provide us. For example, both Administrators and Editors can access:', 'user-registration' ) . '</p>' .
+				'<ul>' .
+					'<li>' . __( 'Form submission information and other details related to it', 'user-registration' ) . '</li>' .
+					'<li>' . __( 'Customer information like your name, email and address information.', 'user-registration' ) . '</li>' .
+				'</ul>' .
+				'<p>' . __( 'Our team members have access to this information to help fulfill entries and support you.', 'user-registration' ) . '</p>' .
+				'<h2>' . __( 'What we share with others', 'user-registration' ) . '</h2>' .
+				'<p class="privacy-policy-tutorial">' . __( 'In this section you should list who you’re sharing data with, and for what purpose. This could include, but may not be limited to, analytics, marketing, payment gateways, shipping providers, and third party embeds.', 'user-registration' ) . '</p>' .
+				'<p>' . __( 'We share information with third parties who help us provide our orders and store services to you; for example --', 'user-registration' ) . '</p>' .
+				'<h3>' . __( 'Payments', 'user-registration' ) . '</h3>' .
+				'<p class="privacy-policy-tutorial">' . __( 'In this subsection you should list which third party payment processors you’re using to take payments on your site since these may handle customer data. We’ve included PayPal as an example, but you should remove this if you’re not using PayPal.', 'user-registration' ) . '</p>' .
+				'<p>' . __( 'We accept payments through PayPal. When processing payments, some of your data will be passed to PayPal, including information required to process or support the payment, such as the purchase total and billing information.', 'user-registration' ) . '</p>' .
+				'<p>' . __( 'Please see the <a href="https://www.paypal.com/us/webapps/mpp/ua/privacy-full">PayPal Privacy Policy</a> for more details.', 'user-registration' ) . '</p>' .
+				'<h3>' . __( 'Available Modules', 'user-registration' ) . '</h3>' .
+				'<p class="privacy-policy-tutorial">' . __( 'In this subsection you should list which third party modules you’re using to increase functionality on your site since these may handle customer data. We’ve included MailChimp as an example, but you should remove this if you’re not using MailChimp.', 'user-registration' ) . '</p>' .
+				'<p>' . __( 'We send beautiful email through MailChimp. When processing emails, some of your data will be passed to MailChimp, including information required to process or support the email marketing services, such as the name, email address and any other information that you intend to pass or collect including all collected information through subscription.', 'user-registration' ) . '</p>' .
+				'<p>' . __( 'Please see the <a href="https://mailchimp.com/legal/privacy/">MailChimp Privacy Policy</a> for more details.', 'user-registration' ) . '</p>' .
+			'</div>';
 
 		return apply_filters( 'user_registration_privacy_policy_content', $content );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds support for group_description for privacy exporters which was added in WP5.3 through [WPCoreChangeset#45825](https://core.trac.wordpress.org/changeset/45825) and [WPCoreTracTicket#45491](https://core.trac.wordpress.org/ticket/45491)

Update Suggested Privacy Policy text to utilize privacy-policy-tutorial css class instead of wp-policy-help as it was deprecated. Also wrap the contents in the wp-suggested-text div to style the section to match WordPress. This follows from [WPCoreTrac#49282](https://core.trac.wordpress.org/ticket/49282) and although back-compat is being introduced in WP5.4 as of [WPChangeset#47112](https://core.trac.wordpress.org/changeset/47112) this change will better support users of WP5.1-5.4

This also removes the wrapping <div contenteditable="false"> as it's now unnecessary. As long as the content uses the proper privacy-policy-tutorial class then the WP Privacy Policy Guide section copy action will avoid copying that content. The contenteditable divs were there originally when the contents was fully copied due to not using the appropriate class, and when originally the entire guide would be dumped into the WYSIWYG editor with wp-policy-help sections being highlighted.

### How to test the changes in this Pull Request:

1. Install plugin and go to Privacy Policy Guide to view and test copy the contents.
2. Create a user with data and export to check the group description is added.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

- Added description to the privacy exporter group.
- Updated Privacy Policy Guide suggested content to use the correct css classes.
