### PR TITLE
Fix- Enqueue password strength

### DIFF
--- a/assets/js/frontend/password-strength-meter.js
+++ b/assets/js/frontend/password-strength-meter.js
@@ -83,6 +83,8 @@ jQuery(function ( $ ) {
 
 			if( strength >= minimum_password_strength ) {
 				submit_button.removeAttr('disabled');
+			} else {
+				submit_button.attr('disabled', 'disabled');
 			}
 
 			switch ( strength ) {

--- a/assets/js/frontend/password-strength-meter.js
+++ b/assets/js/frontend/password-strength-meter.js
@@ -50,7 +50,7 @@ jQuery(function ( $ ) {
 			} else if ( 0 === meter.length ) {
 				var html = '<div class="user-registration-password-strength" aria-live="polite" data-min-strength="' + minimum_password_strength + '"></div>';
 				password_field.closest( '.field-user_pass' ).after( html );
-				$( '#password_1' ).after( html );
+				$( '#password_1' ).closest('.password-input-group').after( html );
 				$(document.body).trigger('ur-password-strength-added');
 			}
 		},

--- a/assets/js/frontend/user-registration.js
+++ b/assets/js/frontend/user-registration.js
@@ -53,8 +53,8 @@
 						equalTo: '#user_email',
 					};
 					messages.user_confirm_email = user_registration_params.message_confirm_email_fields;
-        }
-        
+				}
+
 				if ( $this.hasClass('edit-password') ) {
 					/**
 					 * Password matching for `Change Password` form
@@ -80,7 +80,7 @@
 					messages: messages,
 					errorPlacement: function (error, element) {
 						if ( element.is( '#password_2' ) ) {
-							element.parent().append(error);
+							element.parent().after(error);
 						} else if ( 'radio' === element.attr('type') || 'checkbox' === element.attr('type') || 'password' === element.attr('type') ) {
 							element.parent().parent().parent().append(error);
 						} else if ( element.is('select') && element.attr('class').match(/date-month|date-day|date-year/) ) {
@@ -119,7 +119,7 @@
 						$parent.removeClass('user-registration-has-error');
 					},
 					submitHandler: function (form) {
-						
+
 						// Return `true` for `Change Password` form to allow submission
 						if ( $(form).hasClass('edit-password') ) {
 							return true;
@@ -633,17 +633,23 @@
 		var current_task = ( $(this).hasClass( 'dashicons-hidden' ) ) ? 'show' : 'hide';
 		var $password_field = $(this).closest( '.user-registration-form-row' ).find( 'input[name="password"]' );
 
+		// Hide/show password for user registration form
 		if( $password_field.length === 0 ) {
 			$password_field = $(this).closest( '.field-user_pass' ).find( 'input[name="user_pass"]' );
 		}
 		if( $password_field.length === 0 ) {
 			$password_field = $(this).closest( '.field-user_confirm_password' ).find( 'input[name="user_confirm_password"]' );
 		}
+
+		// Hide/show password for edit password form
 		if( $password_field.length === 0 ) {
-			$password_field = $(this).closest( '.field-user_pass' ).find( 'input[name="user_registration_user_pass"]' );
+			$password_field = $(this).closest( '.user-registration-form-row' ).find( 'input[name="password_current"]' );
 		}
 		if( $password_field.length === 0 ) {
-			$password_field = $(this).closest( '.field-user_confirm_password' ).find( 'input[name="user_registration_user_confirm_password"]' );
+			$password_field = $(this).closest( '.user-registration-form-row' ).find( 'input[name="password_1"]' );
+		}
+		if( $password_field.length === 0 ) {
+			$password_field = $(this).closest( '.user-registration-form-row' ).find( 'input[name="password_2"]' );
 		}
 
 		if( $password_field.length > 0 ) {

--- a/includes/shortcodes/class-ur-shortcode-my-account.php
+++ b/includes/shortcodes/class-ur-shortcode-my-account.php
@@ -108,7 +108,7 @@ class UR_Shortcode_My_Account {
 				}
 			}
 
-			// Start output buffer since the html may need discarding for BW compatibility
+			// Start output buffer since the html may need discarding for BW compatibility.
 			ob_start();
 
 			if ( isset( $wp->query_vars['user-logout'] ) ) {
@@ -117,14 +117,14 @@ class UR_Shortcode_My_Account {
 
 			do_action( 'before-user-registration-my-account-shortcode' );
 
-			// Collect notices before output
+			// Collect notices before output.
 			include_once UR_ABSPATH . 'includes/functions-ur-notice.php';
 			$notices = ur_get_notices();
 
-			// Output the new account page
+			// Output the new account page.
 			self::my_account( $atts );
 
-			// Send output buffer
+			// Send output buffer.
 			ob_end_flush();
 		}
 	}
@@ -166,7 +166,7 @@ class UR_Shortcode_My_Account {
 				return;
 			}
 
-			// Prepare values
+			// Prepare values.
 			foreach ( $profile as $key => $field ) {
 				$value                    = get_user_meta( get_current_user_id(), $key, true );
 				$profile[ $key ]['value'] = apply_filters( 'user_registration_my_account_edit_profile_field_value', $value, $key );
@@ -178,7 +178,7 @@ class UR_Shortcode_My_Account {
 				} elseif ( isset( $user_data->$new_key ) && in_array( $new_key, ur_get_user_table_fields() ) ) {
 					$profile[ $key ]['value'] = apply_filters( 'user_registration_my_account_edit_profile_field_value', $user_data->$new_key, $key );
 
-				} elseif ( isset( $user_data->display_name ) && $key === 'user_registration_display_name' ) {
+				} elseif ( isset( $user_data->display_name ) && 'user_registration_display_name' === $key ) {
 					$profile[ $key ]['value'] = apply_filters( 'user_registration_my_account_edit_profile_field_value', $user_data->display_name, $key );
 				}
 			}
@@ -204,7 +204,7 @@ class UR_Shortcode_My_Account {
 		$enable_strong_password    = ur_get_single_post_meta( $form_id, 'user_registration_form_setting_enable_strong_password' );
 		$minimum_password_strength = ur_get_single_post_meta( $form_id, 'user_registration_form_setting_minimum_password_strength' );
 
-		if ( '1' === $enable_strong_password ) {
+		if ( 'yes' === $enable_strong_password || '1' === $enable_strong_password ) {
 			wp_enqueue_script( 'ur-password-strength-meter' );
 		}
 
@@ -246,7 +246,7 @@ class UR_Shortcode_My_Account {
 					wp_localize_script( 'ur-password-strength-meter', 'enable_strong_password', $enable_strong_password );
 				}
 
-				// reset key / login is correct, display reset password form with hidden key / login values
+				// reset key / login is correct, display reset password form with hidden key / login values.
 				if ( is_object( $user ) ) {
 					return ur_get_template(
 						'myaccount/form-reset-password.php',
@@ -263,7 +263,7 @@ class UR_Shortcode_My_Account {
 			}
 		}
 
-		// Show lost password form by default
+		// Show lost password form by default.
 		ur_get_template(
 			'myaccount/form-lost-password.php',
 			array(
@@ -333,7 +333,7 @@ class UR_Shortcode_My_Account {
 		// Get password reset key (function introduced in WordPress 4.4).
 		$key = get_password_reset_key( $user_data );
 
-		// Send email notification
+		// Send email notification.
 		if ( UR_Emailer::lost_password_email( $user_login, $user_data, $key ) == false ) {
 			ur_add_notice( __( 'The email could not be sent. Contact your site administrator. ', 'user-registration' ), 'error' );
 			return false;
@@ -347,9 +347,9 @@ class UR_Shortcode_My_Account {
 	 *
 	 * @uses $wpdb WordPress Database object
 	 *
-	 * @param string $key Hash to validate sending user's password
-	 * @param string $login The user login
-	 * @return WP_User|bool User's database row on success, false for invalid keys
+	 * @param string $key Hash to validate sending user's password.
+	 * @param string $login The user login.
+	 * @return WP_User|bool User's database row on success, false for invalid keys.
 	 */
 	public static function check_password_reset_key( $key, $login ) {
 		// Check for the password reset key.
@@ -367,8 +367,8 @@ class UR_Shortcode_My_Account {
 	/**
 	 * Handles resetting the user's password.
 	 *
-	 * @param object $user The user
-	 * @param string $new_pass New password for the user in plaintext
+	 * @param object $user The user.
+	 * @param string $new_pass New password for the user in plaintext.
 	 */
 	public static function reset_password( $user, $new_pass ) {
 		do_action( 'password_reset', $user, $new_pass );

--- a/includes/shortcodes/class-ur-shortcode-my-account.php
+++ b/includes/shortcodes/class-ur-shortcode-my-account.php
@@ -151,7 +151,7 @@ class UR_Shortcode_My_Account {
 		wp_enqueue_script( 'ur-my-account' );
 
 		$user_id = get_current_user_id();
-		$form_id       = ur_get_form_id_by_userid( $user_id );
+		$form_id = ur_get_form_id_by_userid( $user_id );
 
 		$profile = user_registration_form_data( $user_id, $form_id );
 
@@ -200,11 +200,11 @@ class UR_Shortcode_My_Account {
 	 */
 	public static function edit_account() {
 		$user_id                   = get_current_user_id();
-		$form_id       = ur_get_form_id_by_userid( $user_id );
+		$form_id                   = ur_get_form_id_by_userid( $user_id );
 		$enable_strong_password    = ur_get_single_post_meta( $form_id, 'user_registration_form_setting_enable_strong_password' );
-		$minimum_password_strength = ur_get_single_post_meta( $form_id, 'user_registration_form_setting_minimum_password_strength');
+		$minimum_password_strength = ur_get_single_post_meta( $form_id, 'user_registration_form_setting_minimum_password_strength' );
 
-		if ( 'yes' === $enable_strong_password ) {
+		if ( '1' === $enable_strong_password ) {
 			wp_enqueue_script( 'ur-password-strength-meter' );
 		}
 

--- a/templates/myaccount/form-edit-password.php
+++ b/templates/myaccount/form-edit-password.php
@@ -35,18 +35,39 @@ do_action( 'user_registration_before_change_password_form' );
 					<legend><?php _e( 'Change Password', 'user-registration' ); ?></legend>
 
 					<?php if ( apply_filters( 'user_registration_change_password_current_password_display', true ) ) { ?>
-					<p class="user-registration-form-row user-registration-form-row--wide form-row form-row-wide">
+					<p class="user-registration-form-row user-registration-form-row--wide form-row form-row-wide hide_show_password">
 						<label for="password_current"><?php _e( 'Current password', 'user-registration' ); ?></label>
+						<span class="password-input-group">
 						<input type="password" class="user-registration-Input user-registration-Input--password input-text" name="password_current" id="password_current" />
+						<?php
+						if ( 'yes' === get_option( 'user_registration_login_option_hide_show_password', 'no' ) ) {
+							echo '<a href="javaScript:void(0)" class="password_preview dashicons dashicons-hidden" title=" Show password "></a>';
+						}
+						?>
+						</span>
 					</p>
 					<?php } ?>
-					<p class="user-registration-form-row user-registration-form-row--wide form-row form-row-wide">
+					<p class="user-registration-form-row user-registration-form-row--wide form-row form-row-wide hide_show_password">
 						<label for="password_1"><?php _e( 'New password', 'user-registration' ); ?></label>
+						<span class="password-input-group">
 						<input type="password" class="user-registration-Input user-registration-Input--password input-text" name="password_1" id="password_1" />
+						<?php
+						if ( 'yes' === get_option( 'user_registration_login_option_hide_show_password', 'no' ) ) {
+							echo '<a href="javaScript:void(0)" class="password_preview dashicons dashicons-hidden" title=" Show password "></a>';
+						}
+						?>
+						</span>
 					</p>
-					<p class="user-registration-form-row user-registration-form-row--wide form-row form-row-wide">
+					<p class="user-registration-form-row user-registration-form-row--wide form-row form-row-wide hide_show_password">
 						<label for="password_2"><?php _e( 'Confirm new password', 'user-registration' ); ?></label>
+						<span class="password-input-group">
 						<input type="password" class="user-registration-Input user-registration-Input--password input-text" name="password_2" id="password_2" />
+						<?php
+						if ( 'yes' === get_option( 'user_registration_login_option_hide_show_password', 'no' ) ) {
+							echo '<a href="javaScript:void(0)" class="password_preview dashicons dashicons-hidden" title=" Show password "></a>';
+						}
+						?>
+						</span>
 					</p>
 				</fieldset>
 				<div class="clear"></div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes password strength enqueue for frontend edit password option. Also includes frontend validation, and prevention of submit button.

### How to test the changes in this Pull Request:

1. Enable password strength from the form builder general settings.
2. Navigate to a user's dashboard, and click on "Edit password"
3. Observe the new functionality, as well as password strength appearing.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix- Enqueue password strength
