### PR TITLE
Enhance - now allows clicking out of form name edit inputbox

### DIFF
--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -96,7 +96,27 @@ jQuery(function ($) {
 			$input.focus();
 		}
 		$input.toggleClass( 'ur-editing' );
+		$input.attr('data-editing', $input.attr('data-editing') == 'true' ? 'false' : 'true');
 	} );
+
+	// In case the user goes out of focus from title edit state.
+	$( document.body ).not( $( '.ur-form-name-wrapper' ) ).click( function( e ) {
+		var field = $( '#ur-form-name' );
+
+		// Both of these controls should in no way allow stopping event propagation.
+		if( 'ur-form-name' === e.target.id || 'ur-form-name-edit-button' === e.target.id ) {
+			return;
+		}
+
+		if ( ! field.attr('hidden') && field.hasClass('ur-editing') ) {
+			e.stopPropagation();
+
+			// Only allow flipping state if currently editing.
+			if ( 'true' !== field.data( 'data-editing' ) && field.val() && '' !== field.val().trim() ) {
+				field.toggleClass( 'ur-editing' ).trigger( 'blur' ).attr('data-editing', field.attr('data-editing') == 'true' ? 'false' : 'true');
+			}
+		}
+	});
 
 	$( document ).on( 'init_perfect_scrollbar update_perfect_scrollbar', function() {
 

--- a/includes/admin/class-ur-admin-menus.php
+++ b/includes/admin/class-ur-admin-menus.php
@@ -851,8 +851,8 @@ if ( ! class_exists( 'UR_Admin_Menus', false ) ) :
 					<?php
 					$form_title = isset( $form_data->post_title ) ? trim( $form_data->post_title ) : __( 'Untitled', 'user-registration' );
 					?>
-					<input name="ur-form-name" id="ur-form-name" type="text" class="ur-form-name regular-text menu-item-textbox" value="<?php echo esc_html( $form_title ); ?>">
-					<span class="ur-edit-form-name dashicons dashicons-edit"></span>
+					<input name="ur-form-name" id="ur-form-name" type="text" class="ur-form-name regular-text menu-item-textbox" value="<?php echo esc_html( $form_title ); ?>" data-editing="false">
+					<span id="ur-form-name-edit-button" class="ur-edit-form-name dashicons dashicons-edit"></span>
 				</div>
 				<div class="ur-builder-header-right">
 					<?php do_action( 'user_registration_builder_header_extra', $form_data->ID, $form_data_array ); ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR intends to add a quality of life feature for users to be able to click out to lose focus, and have the edit-state revert back.

### How to test the changes in this Pull Request:

1. Navigate to the form builder.
2. Click on the edit button.
3. Make changes, and click to lose focus. The state should now revert back to the one that was present.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhance - now allows clicking out of form name edit inputbox.
