### PR TITLE
Fix: Display of new users count even after the all users page refresh

### DIFF
--- a/includes/admin/class-ur-admin.php
+++ b/includes/admin/class-ur-admin.php
@@ -30,7 +30,7 @@ class UR_Admin {
 		add_action( 'admin_notices', array( $this, 'review_notice' ) );
 		add_action( 'admin_footer', 'ur_print_js', 25 );
 		add_filter( 'heartbeat_received', array( $this, 'new_user_live_notice' ), 10, 2 );
-		
+
 	}
 
 	/**
@@ -186,8 +186,7 @@ class UR_Admin {
 	 * Mark the read time of the user list table.
 	 */
 	public function live_user_read() {
-
-		$now = date( 'Y-m-d h:i:s' );
+		$now = current_time( 'mysql' );
 		update_option( 'user_registration_users_listing_viewed', $now );
 	}
 	/**
@@ -204,7 +203,7 @@ class UR_Admin {
 
 		$read_time = get_option( 'user_registration_users_listing_viewed' );
 		if ( ! $read_time ) {
-			$now = date( 'Y-m-d h:i:s' );
+			$now = current_time( 'mysql' );
 			update_option( 'user_registration_users_listing_viewed', $now );
 			$read_time = $now;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
The bug was in how we were storing the `user_registration_users_listing_viewed` DateTime information. We were storing the `user_registration_users_listing_viewed` in 12-hour format whereas the WordPress stores the `user_registered` in 24-hour format.
![Screenshot-20200510193811-1522x190](https://user-images.githubusercontent.com/8264719/81501045-cf40e180-92f5-11ea-9bb1-00796acda4e2.png)
So, that's why we're getting new users' registration count even after the page refresh because we were comparing 12-hour DateTime format with 24-hour DateTime format. I have changed the `user_registration_users_listing_viewed` to 24-hour DateTime format.

Closes #227 .

### How to test the changes in this Pull Request:

1. Check out the `fix/227` branch.
2. Check whether the new user registration notifications are removed or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix: Display of new users count even after the all users page refresh.