### PR TITLE
Fix - Invalid invite code not validate and required sign not showing.

### DIFF
--- a/assets/js/frontend/user-registration.js
+++ b/assets/js/frontend/user-registration.js
@@ -211,7 +211,7 @@
 							var single_data = this_instance.get_fieldwise_data($(this));
 							const invite_code = document.querySelector('.field-invite_code')
 							if( 'invite_code' === single_data.field_name ) {
-								if( 'block' === invite_code.style.display ) {
+								if( 'none' !== invite_code.style.display ) {
 									form_data.push(single_data);
 								}
 							} else {
@@ -556,7 +556,7 @@
 		$('form.register').ur_form_submission();
 
 		var date_flatpickrs = {};
-		
+
 		$( document.body ).on( 'click', '#load_flatpickr', function() {
 			var field_id = $( this ).data( 'id' );
 			var date_flatpickr = date_flatpickrs[ field_id ];

--- a/includes/abstracts/abstract-ur-form-field.php
+++ b/includes/abstracts/abstract-ur-form-field.php
@@ -421,7 +421,13 @@ abstract class UR_Form_Field {
 					if ( isset( $setting_value['options'] )
 						&& gettype( $setting_value['options'] ) == 'array' ) {
 
-						$general_setting_wrapper .= '<select data-field="' . $setting_key . '" class="ur-general-setting-field ur-type-' . $setting_value['type'] . '"  name="' . $setting_value['name'] . '">';
+						$disabled = '';
+							// To make invite code required field non editable.
+						if ( 'required' === $setting_key && 'invite_code' === $strip_prefix ) {
+							$disabled = 'disabled';
+						}
+
+						$general_setting_wrapper .= '<select data-field="' . $setting_key . '" class="ur-general-setting-field ur-type-' . $setting_value['type'] . '"  name="' . $setting_value['name'] . '" ' . $disabled . '>';
 
 						foreach ( $setting_value['options'] as $option_key => $option_value ) {
 							$selected                 = $this->get_general_setting_data( $setting_key ) == $option_key ? "selected='selected'" : '';

--- a/includes/frontend/class-ur-frontend-form-handler.php
+++ b/includes/frontend/class-ur-frontend-form-handler.php
@@ -172,7 +172,7 @@ class UR_Frontend_Form_Handler {
 			foreach ( $missing_item as $key => $value ) {
 
 				// Ignoring confirm password and confirm email field, since they are handled separately.
-				if ( 'user_confirm_password' !== $value && 'user_confirm_email' !== $value ) {
+				if ( 'user_confirm_password' !== $value && 'user_confirm_email' !== $value && 'invite_code' !== $value ) {
 					self::ur_missing_field_validation( $form_field_data, $key, $value );
 				}
 			}
@@ -410,6 +410,9 @@ class UR_Frontend_Form_Handler {
 	 */
 	private static function ur_missing_field_validation( $form_field_data, $key, $value ) {
 
+		error_log( print_r( $form_field_data, true ) );
+		error_log( print_r( $key, true ) );
+		error_log( print_r( $value, true ) );
 		if ( $value == $form_field_data[ $key ]->general_setting->field_name ) {
 
 			if ( 'yes' === $form_field_data[ $key ]->general_setting->required ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

 Invalid Invite code without throwing an error user can register and Even Invite code is required '*" sign in red color is not showing this needs to be fixed by this PR.

### How to test the changes in this Pull Request:

Dependency: https://github.com/wpeverest/user-registration-invite-codes/pull/5

1. Invalid Invite code without throwing an error user can register.
2. Even Invite code is required '*" sign in red color is not showing.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Invalid invite code not validate and required sign not showing.
