### PR TITLE
Fix - Required option and Hide Label option conflict

### DIFF
--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -1765,7 +1765,6 @@ jQuery(function ($) {
 
 	function trigger_general_setting_hide_label($label) {
 		var wrapper = $('.ur-selected-item.ur-item-active');
-		wrapper.find('.ur-label').find('label').find('span').remove();
 		wrapper.find('.ur-general-setting-block').find('select[data-field="' + $label.attr('data-field') + '"]').find('option[value="' + $label.val() + '"]').attr('selected', 'selected');
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### How to reproduce the issue:
1. Create a form
2. Add some fields and make them required
3. Now try to toggle the `Hide Label` option of those fields

You should see that the red asterisk gets removed and doesn't get restored when you change the `Hide Label` option to **No**.
![image](https://user-images.githubusercontent.com/58679177/89163118-d560fa00-d594-11ea-9b7f-f9c9d26a8c68.png)


### Changes proposed in this Pull Request:
This PR fixes the above issue.

### How to test the changes in this Pull Request:

1. Switch to this branch and see if the issue still exist or not

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Required option and Hide Label option conflict
