### PR TITLE
Fix - Reset password error for other plugins registered users

### DIFF
--- a/includes/admin/class-ur-admin-user-manager.php
+++ b/includes/admin/class-ur-admin-user-manager.php
@@ -190,7 +190,7 @@ class UR_Admin_User_Manager {
 
 		if ( is_array( $user_status ) ) {
 
-			if ( 'admin_approval' === $user_status['login_option'] ) {
+			if ( 'admin_approval' === $user_status['login_option'] || 'default' === $user_status['login_option'] ) {
 				return ( $user_status['user_status'] == self::APPROVED );
 			}
 		}
@@ -198,7 +198,7 @@ class UR_Admin_User_Manager {
 	}
 
 	/**
-	 * Check if the user is pending
+	 * Check if the user is pending.
 	 *
 	 * @return bool
 	 */
@@ -206,7 +206,7 @@ class UR_Admin_User_Manager {
 		$user_status = $this->get_user_status();
 
 		if ( is_array( $user_status ) ) {
-			if ( 'admin_approval' === $user_status['login_option'] ) {
+			if ( 'admin_approval' === $user_status['login_option'] || 'default' === $user_status['login_option'] ) {
 				return ( $user_status['user_status'] == self::PENDING );
 			}
 		}
@@ -223,7 +223,7 @@ class UR_Admin_User_Manager {
 
 		if ( is_array( $user_status ) ) {
 
-			if ( 'admin_approval' === $user_status['login_option'] ) {
+			if ( 'admin_approval' === $user_status['login_option'] || 'default' === $user_status['login_option'] ) {
 				return ( $user_status['user_status'] == self::DENIED );
 			}
 		}

--- a/includes/class-ur-user-approval.php
+++ b/includes/class-ur-user-approval.php
@@ -300,7 +300,8 @@ class UR_User_Approval {
 
 		$form_id = ur_get_form_id_by_userid( $user_id );
 
-		if ( 'admin_approval' === ur_get_single_post_meta( $form_id, 'user_registration_form_setting_login_options', get_option( 'user_registration_general_setting_login_options', 'default' ) ) ) {
+		// Check if the form is our form and the login option is admin approval.
+		if ( 0 !== $form_id && 'admin_approval' === ur_get_single_post_meta( $form_id, 'user_registration_form_setting_login_options', get_option( 'user_registration_general_setting_login_options', 'default' ) ) ) {
 			$user_manager = new UR_Admin_User_Manager( $user_id );
 
 			if ( ! $user_manager->is_approved() ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously when a user registered and approved into the site with other user registration plugins, tries to reset password through our login form, an admin approval still pending message was thrown. This PR purposes a solution to this issue.

### How to test the changes in this Pull Request:

1. Register a user into the system with other user registration plugins.
2. Try to reset that user's password through our login form.
3. An admin approval still pending message thrown previously will not be seen and the reset password email is sent.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Reset password error for other plugins registered users.
