### PR TITLE
Fix - Cannot auto-scroll while dragging fields in the form builder

### DIFF
--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -122,16 +122,7 @@ jQuery(function ($) {
 
 		// Init perfect Scrollbar.
 		if ( 'undefined' !== typeof PerfectScrollbar ) {
-			var builder_wrapper = $( '.ur-builder-wrapper' ),
-				tab_content = $( '.ur-tab-contents' );
-
-			if( builder_wrapper.length >= 1 && 'undefined' === typeof window.ur_builder_scrollbar ) {
-				window.ur_builder_scrollbar = new PerfectScrollbar( builder_wrapper.selector, {
-					suppressScrollX: true
-				} );
-			} else if( 'undefined' !== typeof window.ur_builder_scrollbar ) {
-				window.ur_builder_scrollbar.update();
-			}
+			var tab_content = $( '.ur-tab-contents' );
 
 			if( tab_content.length >= 1 && 'undefined' === typeof window.ur_tab_scrollbar ) {
 				window.ur_tab_scrollbar = new PerfectScrollbar( tab_content.selector, {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR fixes an issue with form builder. You can't scroll while dragging fields in the form builder.

### How to test the changes in this Pull Request:

1. Go to the form builder
2. Add a lot of fields to make scrollbar appear
3. Now drag a new field and try to drag it down the form. The form should auto-scroll.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Cannot auto-scroll while dragging fields in the form builder
