### PR TITLE
Fix - ReCaptcha script loads in lost password page

### DIFF
--- a/includes/shortcodes/class-ur-shortcode-login.php
+++ b/includes/shortcodes/class-ur-shortcode-login.php
@@ -38,19 +38,20 @@ class UR_Shortcode_Login {
 	public static function output( $atts ) {
 		global $wp, $post;
 
-		$redirect_url      = isset( $atts['redirect_url'] ) ? trim( $atts['redirect_url'] ) : '';
-		$recaptcha_enabled = get_option( 'user_registration_login_options_enable_recaptcha', 'no' );
-
-		if ( 'yes' == $recaptcha_enabled || '1' == $recaptcha_enabled ) {
-			wp_enqueue_script( 'user-registration' );
-		}
+		$redirect_url = isset( $atts['redirect_url'] ) ? trim( $atts['redirect_url'] ) : '';
 
 		if ( ! is_user_logged_in() ) {
-			$recaptcha_node = ur_get_recaptcha_node( $recaptcha_enabled, 'login' );
 
 			if ( isset( $wp->query_vars['ur-lost-password'] ) ) {
 				UR_Shortcode_My_Account::lost_password();
 			} else {
+				$recaptcha_enabled = get_option( 'user_registration_login_options_enable_recaptcha', 'no' );
+
+				if ( 'yes' == $recaptcha_enabled || '1' == $recaptcha_enabled ) {
+					wp_enqueue_script( 'user-registration' );
+				}
+				$recaptcha_node = ur_get_recaptcha_node( $recaptcha_enabled, 'login' );
+
 				ur_get_template(
 					'myaccount/form-login.php',
 					array(

--- a/includes/shortcodes/class-ur-shortcode-my-account.php
+++ b/includes/shortcodes/class-ur-shortcode-my-account.php
@@ -64,12 +64,10 @@ class UR_Shortcode_My_Account {
 
 		if ( ! is_user_logged_in() ) {
 
-			$recaptcha_enabled = get_option( 'user_registration_login_options_enable_recaptcha', 'no' );
-			$recaptcha_node    = ur_get_recaptcha_node( $recaptcha_enabled, 'login' );
-			$redirect_url      = isset( $atts['redirect_url'] ) ? trim( $atts['redirect_url'] ) : '';
+			$redirect_url = isset( $atts['redirect_url'] ) ? trim( $atts['redirect_url'] ) : '';
 			$redirect_url      = ( isset( $_GET['redirect_to'] ) && empty( $redirect_url ) ) ? esc_url( wp_unslash( $_GET['redirect_to'] ) ) : ''; // @codingStandardsIgnoreLine
-			$form_id           = isset( $atts['form_id'] ) ? absint( $atts['form_id'] ) : 0;
-			$message           = apply_filters( 'user_registration_my_account_message', '' );
+			$form_id      = isset( $atts['form_id'] ) ? absint( $atts['form_id'] ) : 0;
+			$message      = apply_filters( 'user_registration_my_account_message', '' );
 
 			if ( ! empty( $message ) ) {
 				ur_add_notice( $message );
@@ -83,6 +81,8 @@ class UR_Shortcode_My_Account {
 			if ( isset( $wp->query_vars['ur-lost-password'] ) ) {
 				self::lost_password();
 			} else {
+				$recaptcha_enabled = get_option( 'user_registration_login_options_enable_recaptcha', 'no' );
+				$recaptcha_node    = ur_get_recaptcha_node( $recaptcha_enabled, 'login' );
 				ob_start();
 
 				ur_get_template(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Previously, Recaptcha script was loaded in lost password page even if the Recaptcha verification is not needed in the lost password page. This PR purpose a fix for this issue.

### How to test the changes in this Pull Request:

1. Enable ReCaptcha on the login page.
2. Visit the lost password page and view the source of the page.
3. Try searching for Recaptcha script there.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - ReCaptcha script loads in lost password page.
