### PR TITLE
Fix - Unselect All countries option in Country field

### DIFF
--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -1572,12 +1572,7 @@ jQuery(function ($) {
 
 				if ( $this_node.prop('multiple') ) {
 					var selected_options = $this_node.val();
-
-					if ( Array.isArray( selected_options ) ) {
-						selected_options.forEach( function( value ) {
-							hidden_node.find( 'option[value="' + value + '"]' ).attr( 'selected', 'selected' );
-						});
-					}
+					hidden_node.val( selected_options );
 				} else {
 					hidden_node.find('option[value="' + $this_node.val() + '"]').attr( 'selected', 'selected' );
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR fixes an issue with the Country field. When you Unselect All and select some countries then try to save the form, an error is shown saying Select at least 1 country.

### How to test the changes in this Pull Request:

1. Switch to this branch and go to the form builder
2. Add a Country field
3. Click on Unselect All button in the Selected Countries option
4. Then select some countries
5. Now try to save the form and see if any error is shown. Also verify in the frontend, whether the selected countries appears or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Unselect All countries option in Country field
