### PR TITLE
Tweak - Choice field option value change and update

### DIFF
--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -1634,10 +1634,12 @@ jQuery(function ($) {
 			}
 		}
 
-		if( this_node.is( ':checked' ) ) {
-			wrapper.find('.ur-general-setting-options li:nth(' + checked_index + ') input[data-field="default_value"]').prop("checked", true);
-		} else {
-			wrapper.find('.ur-general-setting-options li:nth(' + checked_index + ') input[data-field="default_value"]').removeAttr( 'checked' );
+		if ( 'checkbox' === this_node.attr( 'type' ) ) {
+			if( this_node.is( ':checked' ) ) {
+				wrapper.find('.ur-general-setting-options li:nth(' + checked_index + ') input[data-field="default_value"]').prop("checked", true);
+			} else {
+				wrapper.find('.ur-general-setting-options li:nth(' + checked_index + ') input[data-field="default_value"]').removeAttr( 'checked' );
+			}
 		}
 	}
 

--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -1345,8 +1345,6 @@ jQuery(function ($) {
 				}
 			}
 		});
-
-
 		return general_setting_data;
 	}
 
@@ -1372,7 +1370,7 @@ jQuery(function ($) {
 						break;
 
 					default:
-						value = $this_node.val();
+						value = $this_node.attr('value');
 						break;
 				}
 				break;
@@ -1901,7 +1899,7 @@ jQuery(function ($) {
 			this_index = $this.parent('li').index(),
 			cloning_element = $this.parent('li').clone(true, true);
 
-		cloning_element.find('input[data-field="options"]').val('');
+		cloning_element.find('input[data-field="options"]').attr('value', '');
 		cloning_element.find('input[data-field="default_value"]').removeAttr('checked');
 
 		$this.parent('li').after( cloning_element );

--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -1323,8 +1323,12 @@ jQuery(function ($) {
 			var is_checkbox = $(this).closest('.ur-general-setting').hasClass('ur-setting-checkbox');
 
 			if( 'options' === $(this).attr('data-field') ) {
-				general_setting_data['options'] = option_values.push( get_ur_data($(this) ) );
-				general_setting_data['options'] = option_values;
+				var choice_value = $.trim( get_ur_data($(this)) );
+				if( option_values.every( function(each_value) { return  each_value !== choice_value })){
+					general_setting_data['options'] = option_values.push( choice_value );
+					general_setting_data['options'] = option_values;
+				}
+
 			} else {
 
 				if( 'default_value' === $(this).attr('data-field') ) {
@@ -1363,10 +1367,13 @@ jQuery(function ($) {
 
 		switch (node_type) {
 			case 'input':
+
 				// Check input type.
 				switch ( $this_node.attr( 'type' ) ) {
 					case 'checkbox':
-						value = $this_node.is( ':checked' );
+						if( $this_node.is( ':checked' ) ){
+							value = $this_node.val();
+						}
 						break;
 
 					default:
@@ -1607,12 +1614,15 @@ jQuery(function ($) {
 		var array_value = [];
 		var li_elements = this_node.closest('ul').find('li');
 		var checked_index = this_node.closest('li').index();
-
 		li_elements.each( function( index, element) {
 			var value 	 = $( element ).find('input.ur-type-checkbox-label').val();
 				value 	 = $.trim(value);
 				checkbox = $( element ).find('input.ur-type-checkbox-value').is( ':checked' );
-				array_value.push( {value:value, checkbox:checkbox });
+
+				if( array_value.every( function(each_value) { return  each_value.value !== value })){
+					array_value.push({value:value, checkbox:checkbox });
+				}
+
 		});
 
 		var wrapper = $('.ur-selected-item.ur-item-active');
@@ -1620,7 +1630,7 @@ jQuery(function ($) {
 		checkbox.html('');
 
 		for (var i = 0; i < array_value.length; i++) {
-			if (array_value[i] !== '') {
+			if ( array_value[i] !== '' ) {
 				checkbox.append('<label><input value="' + array_value[i].value.trim() + '" type="checkbox" ' + ( (array_value[i].checkbox) ? 'checked' : '' ) + ' disabled>' + array_value[i].value.trim() + '</label>');
 			}
 		}
@@ -1645,7 +1655,10 @@ jQuery(function ($) {
 			if( radio === true) {
 				checked_index = index;
 			}
-			array_value.push({value:value, radio:radio });
+
+			if( array_value.every( function(each_value) { return  each_value.value !== value })){
+				array_value.push({value:value, radio:radio });
+			}
 		});
 
 		var wrapper = $('.ur-selected-item.ur-item-active');

--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -1332,7 +1332,9 @@ jQuery(function ($) {
 			} else {
 
 				if( 'default_value' === $(this).attr('data-field') ) {
+
 					if( is_checkbox === true ) {
+
 						if( $(this).is(":checked") ) {
 							general_setting_data['default_value'] = default_values.push( get_ur_data( $(this)));
 							general_setting_data['default_value'] = default_values;
@@ -1633,7 +1635,7 @@ jQuery(function ($) {
 		}
 
 		if( this_node.is( ':checked' ) ) {
-			wrapper.find('.ur-general-setting-options li:nth(' + checked_index + ') input[data-field="default_value"]').attr( 'checked', 'checked' );
+			wrapper.find('.ur-general-setting-options li:nth(' + checked_index + ') input[data-field="default_value"]').prop("checked", true);
 		} else {
 			wrapper.find('.ur-general-setting-options li:nth(' + checked_index + ') input[data-field="default_value"]').removeAttr( 'checked' );
 		}
@@ -1672,7 +1674,7 @@ jQuery(function ($) {
 		wrapper.find( '.ur-general-setting-options > ul.ur-options-list > li' ).each( function( index, element ) {
 			var radio_input = $(element).find( '[data-field="default_value"]' );
 			if( index === checked_index ){
-				radio_input.attr( 'checked', 'checked' );
+				radio_input.prop("checked", true);
 			}else{
 				radio_input.removeAttr( 'checked' );
 			}
@@ -1692,7 +1694,7 @@ jQuery(function ($) {
 		wrapper.find( '.ur-general-setting-options > ul.ur-options-list > li' ).each( function( index, element ) {
 			var radio_input = $(element).find( '[data-field="default_value"]' );
 			if( index === checked_index ){
-				radio_input.attr( 'checked', 'checked' );
+				radio_input.prop("checked", true);
 			}else{
 				radio_input.removeAttr( 'checked' );
 			}

--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -1370,7 +1370,7 @@ jQuery(function ($) {
 						break;
 
 					default:
-						value = $this_node.attr('value');
+						value = $this_node.val();
 						break;
 				}
 				break;
@@ -1698,7 +1698,7 @@ jQuery(function ($) {
 
 		var wrapper = $('.ur-selected-item.ur-item-active');
 		var index = $label.closest('li').index();
-		wrapper.find( '.ur-general-setting-block li:nth(' + index + ') input[data-field="' + $label.attr('data-field') + '"]' ).attr( 'value', $label.val() );
+		wrapper.find( '.ur-general-setting-block li:nth(' + index + ') input[data-field="' + $label.attr('data-field') + '"]' ).val( $label.val() );
 		wrapper.find( '.ur-general-setting-block li:nth(' + index + ') input[data-field="default_value"]' ).val( $label.val() );
 		$label.closest('li').find('[data-field="default_value"]').val( $label.val() );
 	}
@@ -1899,7 +1899,7 @@ jQuery(function ($) {
 			this_index = $this.parent('li').index(),
 			cloning_element = $this.parent('li').clone(true, true);
 
-		cloning_element.find('input[data-field="options"]').attr('value', '');
+		cloning_element.find('input[data-field="options"]').val('');
 		cloning_element.find('input[data-field="default_value"]').removeAttr('checked');
 
 		$this.parent('li').after( cloning_element );

--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -1332,14 +1332,13 @@ jQuery(function ($) {
 			} else {
 
 				if( 'default_value' === $(this).attr('data-field') ) {
-
 					if( is_checkbox === true ) {
 						if( $(this).is(":checked") ) {
 							general_setting_data['default_value'] = default_values.push( get_ur_data( $(this)));
 							general_setting_data['default_value'] = default_values;
 						}
 					} else if( $(this).is(":checked") ) {
-							general_setting_data['default_value'] = get_ur_data($(this) );
+						general_setting_data['default_value'] = get_ur_data($(this) );
 					}
 
 				} else if ( 'html' === $(this).attr('data-field') ) {
@@ -1364,10 +1363,8 @@ jQuery(function ($) {
 	function get_ur_data($this_node) {
 		var node_type = $this_node.get(0).tagName.toLowerCase();
 		var value = '';
-
 		switch (node_type) {
 			case 'input':
-
 				// Check input type.
 				switch ( $this_node.attr( 'type' ) ) {
 					case 'checkbox':
@@ -1683,7 +1680,7 @@ jQuery(function ($) {
 	}
 
 	function render_select_box(this_node) {
-		value = $.trim( this_node.val() );
+		var value = $.trim( this_node.val() );
 		var wrapper = $('.ur-selected-item.ur-item-active');
 		var checked_index = this_node.closest('li').index();
 		var select = wrapper.find('.ur-field').find('select');
@@ -1691,8 +1688,15 @@ jQuery(function ($) {
 		select.html('');
 		select.append('<option value=\'' + value + '\'>' + value + '</option>');
 
-		wrapper.find('.ur-general-setting-options li input[data-field="default_value"]').removeAttr( 'checked' );
-		wrapper.find('.ur-general-setting-options li:nth(' + checked_index + ') input[data-field="default_value"]').attr( 'checked', 'checked' );
+		// Loop through options in active fields general setting hidden div.
+		wrapper.find( '.ur-general-setting-options > ul.ur-options-list > li' ).each( function( index, element ) {
+			var radio_input = $(element).find( '[data-field="default_value"]' );
+			if( index === checked_index ){
+				radio_input.attr( 'checked', 'checked' );
+			}else{
+				radio_input.removeAttr( 'checked' );
+			}
+		} );
 	}
 
 	function trigger_general_setting_field_name($label) {

--- a/includes/form/views/admin/admin-radio.php
+++ b/includes/form/views/admin/admin-radio.php
@@ -25,11 +25,13 @@ $options         = array_map( 'trim', $options );
 				echo "<label><input type = 'radio'  value='1' disabled/></label>";
 			}
 
-			$checked = '';
-			if ( ! empty( $option ) ) {
-				$checked = checked( $option, $default_value, false );
-			}
 			foreach ( $options as $option ) {
+				$checked = '';
+
+				if ( ! empty( $option ) ) {
+					$checked = checked( $option, $default_value, false );
+				}
+
 				echo "<label><input type = 'radio'  value='" . esc_attr( trim( $option ) ) . "' '" . $checked . "' disabled/>" . esc_html( trim( $option ) ) . '</label>';
 			}
 			?>

--- a/includes/form/views/admin/admin-radio.php
+++ b/includes/form/views/admin/admin-radio.php
@@ -8,11 +8,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Compatibility for older version. Get string value from options in advanced settings. Modified since @1.5.7
-$default_options 	 = isset( $this->field_defaults['default_options'] ) ? $this->field_defaults['default_options'] : array();
-$old_options         = isset( $this->admin_data->advance_setting->options ) ? explode( ',', trim( $this->admin_data->advance_setting->options, ',' ) ) : $default_options;
-$options  			 = isset( $this->admin_data->general_setting->options ) ? $this->admin_data->general_setting->options : $old_options;
-$default_value 		 = isset( $this->admin_data->general_setting->default_value ) ? $this->admin_data->general_setting->default_value : '';
-$options 			 = array_map( 'trim', $options );
+$default_options = isset( $this->field_defaults['default_options'] ) ? $this->field_defaults['default_options'] : array();
+$old_options     = isset( $this->admin_data->advance_setting->options ) ? explode( ',', trim( $this->admin_data->advance_setting->options, ',' ) ) : $default_options;
+$options         = isset( $this->admin_data->general_setting->options ) ? $this->admin_data->general_setting->options : $old_options;
+$default_value   = isset( $this->admin_data->general_setting->default_value ) ? $this->admin_data->general_setting->default_value : '';
+$options         = array_map( 'trim', $options );
 ?>
 
 <div class="ur-input-type-select ur-admin-template">
@@ -25,8 +25,12 @@ $options 			 = array_map( 'trim', $options );
 				echo "<label><input type = 'radio'  value='1' disabled/></label>";
 			}
 
+			$checked = '';
+			if ( ! empty( $option ) ) {
+				$checked = checked( $option, $default_value, false );
+			}
 			foreach ( $options as $option ) {
-				echo "<label><input type = 'radio'  value='" . esc_attr( trim( $option ) ) . "' '" . checked( $option, $default_value, false ) . "' disabled/>" . esc_html( trim( $option ) ) . '</label>';
+				echo "<label><input type = 'radio'  value='" . esc_attr( trim( $option ) ) . "' '" . $checked . "' disabled/>" . esc_html( trim( $option ) ) . '</label>';
 			}
 			?>
 	</div>

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -242,7 +242,6 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 		$label_id        = $args['id'];
 		$sort            = $args['priority'] ? $args['priority'] : '';
 		$field_container = '<div class="form-row %1$s" id="%2$s" data-priority="' . esc_attr( $sort ) . '">%3$s</div>';
-
 		switch ( $args['type'] ) {
 
 			case 'title':
@@ -276,10 +275,12 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 					foreach ( $choices as $choice_index => $choice ) {
 
 						$value = '';
-						if ( is_array( $default ) && in_array( trim( $choice_index ), $default ) ) {
-							$value = 'checked="checked"';
-						} elseif ( $default === $choice_index ) {
-							$value = 'checked="checked"';
+						if ( '' !== $default ) {
+							if ( is_array( $default ) && in_array( trim( $choice_index ), $default ) ) {
+								$value = 'checked="checked"';
+							} elseif ( $default === $choice_index ) {
+								$value = 'checked="checked"';
+							}
 						}
 
 						$field .= '<li class="ur-checkbox-list">';
@@ -434,7 +435,13 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 					foreach ( $args['options'] as $option_index => $option_text ) {
 
 						$field .= '<li class="ur-radio-list">';
-						$field .= '<input data-rules="' . esc_attr( $rules ) . '" data-id="' . esc_attr( $key ) . '" type="radio" class="input-radio ' . esc_attr( implode( ' ', $args['input_class'] ) ) . '" value="' . esc_attr( trim( $option_index ) ) . '" name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '_' . esc_attr( $option_text ) . '" ' . implode( ' ', $custom_attributes ) . ' / ' . checked( $value, trim( $option_index ), false ) . ' /> ';
+
+						$checked = '';
+						if ( ! empty( $value ) ) {
+							$checked = checked( $value, trim( $option_index ), false );
+						}
+
+						$field .= '<input data-rules="' . esc_attr( $rules ) . '" data-id="' . esc_attr( $key ) . '" type="radio" class="input-radio ' . esc_attr( implode( ' ', $args['input_class'] ) ) . '" value="' . esc_attr( trim( $option_index ) ) . '" name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '_' . esc_attr( $option_text ) . '" ' . implode( ' ', $custom_attributes ) . ' / ' . $checked . ' /> ';
 						$field .= '<label for="' . esc_attr( $args['id'] ) . '_' . esc_attr( $option_text ) . '" class="radio">';
 
 						$field .= wp_kses(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When the WordPress version is updated from 5.4 to 5.5, then the newly added option values in choice fields like checkbox, radio, select, select2, and multi-select2 were not being updated and reflected in the form builder properly. This PR fixes this issue.

### How to test the changes in this Pull Request:

1. Update your system's WordPress version from 5.4 to 5.5.
2. Navigate to the form builder and tweak with the choice fields. Verify whether or not the options in choice field are properly updated and reflected in the form builder.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Choice field option value change and update
