### PR TITLE
Fix - Feature to Import/Export/Duplicate form not working

### DIFF
--- a/includes/abstracts/abstract-ur-form-field.php
+++ b/includes/abstracts/abstract-ur-form-field.php
@@ -101,7 +101,10 @@ abstract class UR_Form_Field {
 		ob_start();
 		$template_path       = str_replace( '_', '-', str_replace( 'user_registration_', 'admin-', $this->id ) );
 		$admin_template_path = apply_filters( $this->id . '_admin_template', UR_FORM_PATH . 'views' . UR_DS . 'admin' . UR_DS . $template_path . '.php' );
-		include $admin_template_path;
+
+		if ( file_exists( $admin_template_path ) ) {
+			include $admin_template_path;
+		}
 		$template = ob_get_clean();
 
 		$settings = $this->get_setting();

--- a/includes/admin/class-ur-admin-import-export-forms.php
+++ b/includes/admin/class-ur-admin-import-export-forms.php
@@ -62,6 +62,8 @@ class UR_Admin_Import_Export_Forms {
 		$meta_key_prefix = 'user_registration';
 		$form_post_meta  = $this->get_post_meta_by_prefix( $form_id, $meta_key_prefix );
 
+		$form_post->post_content = str_replace( '\\', '\\\\', $form_post->post_content );
+
 		$export_data = array(
 			'form_post'      => array(
 				'post_content' => $form_post->post_content,

--- a/includes/admin/class-ur-admin-menus.php
+++ b/includes/admin/class-ur-admin-menus.php
@@ -405,6 +405,8 @@ if ( ! class_exists( 'UR_Admin_Menus', false ) ) :
 					return false;
 				}
 
+				$post->post_content = str_replace( '\\', '\\\\', $post->post_content );
+
 				/*
 				 * new post data array
 				 */
@@ -824,7 +826,8 @@ if ( ! class_exists( 'UR_Admin_Menus', false ) ) :
 			}
 
 			try {
-				$form_data_array = json_decode( $form_data_content );
+				$form_data_content = str_replace( '"noopener noreferrer"', "'noopener noreferrer'", $form_data_content );
+				$form_data_array   = json_decode( $form_data_content );
 
 				if ( json_last_error() != JSON_ERROR_NONE ) {
 					throw new Exception( '' );

--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -576,6 +576,8 @@ class UR_Form_Handler {
 			$the_post = get_post( absint( $id ) );
 
 			if ( $the_post && 'user_registration' === $the_post->post_type ) {
+				$the_post->post_content = str_replace( '"noopener noreferrer"', "'noopener noreferrer'", $the_post->post_content );
+
 				if ( isset( $args['publish'] ) ) {
 					if ( ( $args['publish'] && 'publish' === $the_post->post_type ) || ( ! $args['publish'] && 'publish' !== $the_post->post_type ) ) {
 						return array();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR fixes issues with Import, Export and Duplicating forms.

Depends on this [branch](https://github.com/wpeverest/user-registration-conditional-logic/tree/fix/foreach-error)

### How to test the changes in this Pull Request:

1. Activate the Conditional Logic addon
2. Create a form. Add fields and add Html in field descriptions
3. Now try to duplicate, import and export the form. See if everything is working properly.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Feature to Import/Export/Duplicate form not working
