### PR TITLE
Fix - Ignore missing field validation based on field visibility settings

### DIFF
--- a/includes/frontend/class-ur-frontend-form-handler.php
+++ b/includes/frontend/class-ur-frontend-form-handler.php
@@ -432,9 +432,15 @@ class UR_Frontend_Form_Handler {
 		if ( isset( $form_field_data[ $key ]->general_setting->field_name ) && $value == $form_field_data[ $key ]->general_setting->field_name ) {
 
 			if ( isset( $form_field_data[ $key ]->general_setting->required ) && 'yes' === $form_field_data[ $key ]->general_setting->required ) {
-				$field_label = $form_field_data[ $key ]->general_setting->label;
-				$response    = sprintf( __( '%s is a required field.', 'user-registration' ), $field_label );
-				array_push( self::$response_array, $response );
+
+				// Check for the field visibility settings.
+				if ( isset( $form_field_data[ $key ]->advance_setting->field_visibility ) && 'edit_form' === $form_field_data[ $key ]->advance_setting->field_visibility ) {
+					return;
+				} else {
+					$field_label = $form_field_data[ $key ]->general_setting->label;
+					$response    = sprintf( __( '%s is a required field.', 'user-registration' ), $field_label );
+					array_push( self::$response_array, $response );
+				}
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When a required field is hidden in registration form using field visibility addon, then the missing field validation treats the hidden field as missing field and throws field is required error on the frontend. This PR fixes this issue.

### How to test the changes in this Pull Request:

1. Hide a required field using field visibility addon.
2. Navigate to the registration form on the frontend and fill-up the form.
3. Check whether or not the field's required message is thrown.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Ignore missing field validation based on field visibility settings.
