### PR TITLE
Fix - Date Field value disappears on user update by admin and woocommerce compatibility

### DIFF
--- a/assets/js/frontend/user-registration.js
+++ b/assets/js/frontend/user-registration.js
@@ -777,7 +777,12 @@
 			// Load a flatpicker for the field, if hasn't been loaded.
 			if ( ! date_flatpickr ) {
 				var formated_date = $( this ).closest( '.ur-field-item' ).find( '#formated_date' ).val();
-				var date_selector = $( '.ur-frontend-form #' + field_id ).attr( 'type', 'text' ).val( formated_date );
+
+				if( 0 < $( '.ur-frontend-form').length ) {
+					var date_selector = $( '.ur-frontend-form #' + field_id ).attr( 'type', 'text' ).val( formated_date );
+				}else{
+					var date_selector = $( '.woocommerce-MyAccount-content #' + field_id ).attr( 'type', 'text' ).val( formated_date );
+				}
 
 				$( this ).attr( 'data-date-format', date_selector.data( 'date-format') );
 				$( this ).attr( 'data-mode', date_selector.data( 'mode') );

--- a/includes/admin/class-ur-admin-profile.php
+++ b/includes/admin/class-ur-admin-profile.php
@@ -244,8 +244,8 @@ if ( ! class_exists( 'UR_Admin_Profile', false ) ) :
 										   class="regular-text"
 										   data-id = '<?php echo esc_attr( $key ); ?>'
 										   readonly />
-									<input type="hidden" id="formated_date" value="<?php echo esc_attr( $value ); ?>"/>
-									<input type="date" name="<?php echo esc_attr( $key ); ?>"
+										   <input type="hidden" id="formated_date" value="<?php echo esc_attr( $value ); ?>"/>
+										   <input type="text" name="<?php echo esc_attr( $key ); ?>"
 										   id="<?php echo esc_attr( $key ); ?>"
 										   value="<?php echo esc_attr( $value ); ?>"
 										   class="<?php echo( ! empty( $field['class'] ) ? esc_attr( $field['class'] ) : 'regular-text' ); ?>"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR resolve two issues are as bellow
1. Date Field value disappear on user update by admin
2. Date Field Format not compatible with woocommerce my-account

### How to test the changes in this Pull Request:

1. Create a form with Date Field and then register a user by filling date field.
2. After login test date-field with a different format in woo-commerce myaccount profile page.
3. In Backend Edit User and don't  change the date field and update user. And check whether date field value disappears  or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Date Field value disappears on user update by admin and woocommerce compatibility.
