### PR TITLE
Dev - Replaced Deprecated function with new one

### DIFF
--- a/assets/js/frontend/password-strength-meter.js
+++ b/assets/js/frontend/password-strength-meter.js
@@ -68,7 +68,12 @@ jQuery(function ( $ ) {
 			var submit_button = wrapper.find( 'input[type="submit"].user-registration-Button' );
 			var minimum_password_strength = wrapper.attr( 'data-minimum-password-strength' );
 
-			var disallowedListArray = wp.passwordStrength.userInputDisallowedList();
+			var disallowedListArray = [];
+			if ( 'function' === typeof wp.passwordStrength.userInputDisallowedList ) {
+				disallowedListArray = wp.passwordStrength.userInputDisallowedList();
+			} else {
+				disallowedListArray = wp.passwordStrength.userInputBlacklist();
+			}
 			disallowedListArray.push( wrapper.find('input[data-id="user_email"]').val() ); // Add email address in disallowedList.
 			disallowedListArray.push( wrapper.find('input[data-id="user_login"]').val() ); // Add username in disallowedList.
 

--- a/assets/js/frontend/password-strength-meter.js
+++ b/assets/js/frontend/password-strength-meter.js
@@ -68,11 +68,11 @@ jQuery(function ( $ ) {
 			var submit_button = wrapper.find( 'input[type="submit"].user-registration-Button' );
 			var minimum_password_strength = wrapper.attr( 'data-minimum-password-strength' );
 
-			var blacklistArray = wp.passwordStrength.userInputBlacklist();
-			blacklistArray.push( wrapper.find('input[data-id="user_email"]').val() ); // Add email address in blacklist.
-			blacklistArray.push( wrapper.find('input[data-id="user_login"]').val() ); // Add username in blacklist.
+			var disallowedListArray = wp.passwordStrength.userInputDisallowedList();
+			disallowedListArray.push( wrapper.find('input[data-id="user_email"]').val() ); // Add email address in disallowedList.
+			disallowedListArray.push( wrapper.find('input[data-id="user_login"]').val() ); // Add username in disallowedList.
 
-			var strength = wp.passwordStrength.meter(field.val(), blacklistArray);
+			var strength = wp.passwordStrength.meter(field.val(), disallowedListArray);
 
 			var error = '';
 			// Reset

--- a/assets/js/frontend/user-registration.js
+++ b/assets/js/frontend/user-registration.js
@@ -810,7 +810,12 @@
 				if ( 'yes' === enable_strength_password || '1' === enable_strength_password ) {
 					var wrapper                   = $this.closest('form');
 					var minimum_password_strength = wrapper.attr( 'data-minimum-password-strength' );
-					var disallowedListArray            = wp.passwordStrength.userInputDisallowedList();
+					var disallowedListArray = [];
+					if ( 'function' === typeof wp.passwordStrength.userInputDisallowedList ) {
+						disallowedListArray = wp.passwordStrength.userInputDisallowedList();
+					} else {
+						disallowedListArray = wp.passwordStrength.userInputBlacklist();
+					}
 
 					disallowedListArray.push( wrapper.find( 'input[data-id="user_email"]' ).val() ); // Add email address in disallowedList.
 					disallowedListArray.push( wrapper.find( 'input[data-id="user_login"]' ).val() ); // Add username in disallowedList.

--- a/assets/js/frontend/user-registration.js
+++ b/assets/js/frontend/user-registration.js
@@ -810,12 +810,12 @@
 				if ( 'yes' === enable_strength_password || '1' === enable_strength_password ) {
 					var wrapper                   = $this.closest('form');
 					var minimum_password_strength = wrapper.attr( 'data-minimum-password-strength' );
-					var blacklistArray            = wp.passwordStrength.userInputBlacklist();
+					var disallowedListArray            = wp.passwordStrength.userInputDisallowedList();
 
-					blacklistArray.push( wrapper.find( 'input[data-id="user_email"]' ).val() ); // Add email address in blacklist.
-					blacklistArray.push( wrapper.find( 'input[data-id="user_login"]' ).val() ); // Add username in blacklist.
+					disallowedListArray.push( wrapper.find( 'input[data-id="user_email"]' ).val() ); // Add email address in disallowedList.
+					disallowedListArray.push( wrapper.find( 'input[data-id="user_login"]' ).val() ); // Add username in disallowedList.
 
-					var strength = wp.passwordStrength.meter( $this.val(), blacklistArray );
+					var strength = wp.passwordStrength.meter( $this.val(), disallowedListArray );
 					if( strength < minimum_password_strength ) {
 						if( $this.val() !== "" ){
 							wrapper.find( '#' + this_data_id + '_error' ).remove();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR replaces the older function for password strength to match the new WordPress(5.5) standard. It removes this warning(see screenshot) from the console. 
![prsnip](https://user-images.githubusercontent.com/37950847/91892812-01b28800-ecb3-11ea-9761-bbfdb7af197d.PNG)
 

### Steps to replicate the issue:

1. Switch to the Develop branch and try to reset the password. 
2. When you are typing the new password, check the browser console. 
3. You will see the message there.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Updated the deprecated password strength function.
