### PR TITLE
Fix - Number field min/max options

### DIFF
--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -4,6 +4,17 @@
  */
 jQuery(function ($) {
 
+	// Sync Number field's options with hidden corresponding elements.
+	$( document.body ).on( 'input', '.ur_advance_setting.ur-settings-min', function() {
+		$( '.ur-selected-item.ur-item-active .ur_advance_setting.ur-settings-min' ).val( $(this).val() );
+	});
+	$( document.body ).on( 'input', '.ur_advance_setting.ur-settings-max', function() {
+		$( '.ur-selected-item.ur-item-active .ur_advance_setting.ur-settings-max' ).val( $(this).val() );
+	});
+	$( document.body ).on( 'input', '.ur_advance_setting.ur-settings-step', function() {
+		$( '.ur-selected-item.ur-item-active .ur_advance_setting.ur-settings-step' ).val( $(this).val() );
+	});
+
 	// Bind UI Action handlers for searching fields.
 	$( document.body ).on( 'input', '#ur-search-fields', function() {
 		var search_string = $( this ).val().toLowerCase();

--- a/includes/abstracts/abstract-ur-form-field.php
+++ b/includes/abstracts/abstract-ur-form-field.php
@@ -154,6 +154,10 @@ abstract class UR_Form_Field {
 			$form_data['max'] = $data['advance_setting']->max;
 		}
 
+		if ( isset( $data['advance_setting']->step ) ) {
+			$form_data['step'] = $data['advance_setting']->step;
+		}
+
 		if ( isset( $data['advance_setting']->default_value ) ) {
 			$form_data['default'] = $data['advance_setting']->default_value;
 		}

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -209,12 +209,16 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 			$args['custom_attributes']['maxlength'] = absint( $args['size'] );
 		}
 
-		if ( $args['min'] ) {
-			$args['custom_attributes']['min'] = absint( $args['min'] );
+		if ( ! empty( $args['min'] ) ) {
+			$args['custom_attributes']['min'] = $args['min'];
 		}
 
-		if ( $args['max'] ) {
-			$args['custom_attributes']['max'] = absint( $args['max'] );
+		if ( ! empty( $args['max'] ) ) {
+			$args['custom_attributes']['max'] = $args['max'];
+		}
+
+		if ( ! empty( $args['step'] ) ) {
+			$args['custom_attributes']['step'] = $args['step'];
 		}
 
 		if ( ! empty( $args['autocomplete'] ) ) {

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -209,15 +209,15 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 			$args['custom_attributes']['maxlength'] = absint( $args['size'] );
 		}
 
-		if ( ! empty( $args['min'] ) ) {
+		if ( isset( $args['min'] ) ) {
 			$args['custom_attributes']['min'] = $args['min'];
 		}
 
-		if ( ! empty( $args['max'] ) ) {
+		if ( isset( $args['max'] ) ) {
 			$args['custom_attributes']['max'] = $args['max'];
 		}
 
-		if ( ! empty( $args['step'] ) ) {
+		if ( isset( $args['step'] ) ) {
 			$args['custom_attributes']['step'] = $args['step'];
 		}
 

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -209,15 +209,15 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 			$args['custom_attributes']['maxlength'] = absint( $args['size'] );
 		}
 
-		if ( isset( $args['min'] ) ) {
+		if ( ! empty( $args['min'] ) || '0' === $args['min'] ) {
 			$args['custom_attributes']['min'] = $args['min'];
 		}
 
-		if ( isset( $args['max'] ) ) {
+		if ( ! empty( $args['max'] ) || '0' === $args['max'] ) {
 			$args['custom_attributes']['max'] = $args['max'];
 		}
 
-		if ( isset( $args['step'] ) ) {
+		if ( ! empty( $args['step'] ) ) {
 			$args['custom_attributes']['step'] = $args['step'];
 		}
 

--- a/templates/myaccount/form-edit-profile.php
+++ b/templates/myaccount/form-edit-profile.php
@@ -157,6 +157,12 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 													}
 												}
 
+												if ( 'number' === $single_item->field_key ) {
+													$field['min']  = isset( $advance_data['advance_setting']->min ) ? $advance_data['advance_setting']->min : '';
+													$field['max']  = isset( $advance_data['advance_setting']->max ) ? $advance_data['advance_setting']->max : '';
+													$field['step'] = isset( $advance_data['advance_setting']->step ) ? $advance_data['advance_setting']->step : '';
+												}
+
 												if ( 'phone' === $single_item->field_key ) {
 													$field['phone_format'] = $single_item->general_setting->phone_format;
 													if ( 'smart' === $field['phone_format'] ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR fixes the issue: min/max options of the `Number` field not working.

### How to test the changes in this Pull Request:

1. Create a form and add a `Number` field
2. Set values for the min/max options
3. Reload the page and see if the values are still there and test it in the frontend

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Number field min/max options
