### PR TITLE
Tweak - WPML compatibility for static strings

### DIFF
--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -68,7 +68,7 @@ class UR_AJAX {
 		if ( is_user_logged_in() && ! current_user_can( 'administrator' ) ) {
 			wp_send_json_error(
 				array(
-					'message' => __( 'You are already logged in.', 'user-registration' ),
+					'message' => ur_string_translation( null, 'ur_already_logged_in', __( 'You are already logged in.', 'user-registration' ) ),
 				)
 			);
 		}
@@ -76,7 +76,7 @@ class UR_AJAX {
 		if ( ! check_ajax_referer( 'user_registration_form_data_save_nonce', 'security', false ) ) {
 			wp_send_json_error(
 				array(
-					'message' => __( 'Nonce error, please reload.', 'user-registration' ),
+					'message' => ur_string_translation( null, 'ur_nonce_error', __( 'Nonce error, please reload.', 'user-registration' ) ),
 				)
 			);
 		}
@@ -98,7 +98,7 @@ class UR_AJAX {
 				if ( empty( $data->success ) || ( isset( $data->score ) && $data->score < apply_filters( 'user_registration_recaptcha_v3_threshold', 0.5 ) ) ) {
 					wp_send_json_error(
 						array(
-							'message' => __( 'Error on google reCaptcha. Contact your site administrator.', 'user-registration' ),
+							'message' => ur_string_translation( null, 'ur_recatcha_error', __( 'Error on google reCaptcha. Contact your site administrator.', 'user-registration' ) ),
 						)
 					);
 				}
@@ -114,7 +114,7 @@ class UR_AJAX {
 		if ( $flag != true || is_wp_error( $flag ) ) {
 			wp_send_json_error(
 				array(
-					'message' => __( 'Nonce error, please reload.', 'user-registration' ),
+					'message' => ur_string_translation( null, 'ur_nonce_error', __( 'Nonce error, please reload.', 'user-registration' ) ),
 				)
 			);
 		}
@@ -126,7 +126,7 @@ class UR_AJAX {
 			if ( ! $users_can_register ) {
 				wp_send_json_error(
 					array(
-						'message' => apply_filters( 'ur_register_pre_form_message', __( 'Only administrators can add new users.', 'user-registration' ) ),
+						'message' => ur_string_translation( null, 'ur_only_administrator_can_register', apply_filters( 'ur_register_pre_form_message', __( 'Only administrators can add new users.', 'user-registration' ) ) ),
 					)
 				);
 			}
@@ -144,7 +144,7 @@ class UR_AJAX {
 
 				wp_send_json_error(
 					array(
-						'message' => apply_filters( 'ur_register_pre_form_message', '<p class="alert" id="ur_register_pre_form_message">' . sprintf( __( 'You are currently logged in as %1$1s. %2$2s', 'user-registration' ), '<a href="#" title="' . $display_name . '">' . $display_name . '</a>', '<a href="' . wp_logout_url( $current_url ) . '" title="' . __( 'Log out of this account.', 'user-registration' ) . '">' . __( 'Logout', 'user-registration' ) . '  &raquo;</a>' ) . '</p>', $user_ID ),
+						'message' => apply_filters( 'ur_register_pre_form_message', '<p class="alert" id="ur_register_pre_form_message">' . sprintf( __( ur_string_translation( null, 'ur_currently_logged_in', 'You are currently logged in as %1$1s. %2$2s' ), 'user-registration' ), '<a href="#" title="' . $display_name . '">' . $display_name . '</a>', '<a href="' . wp_logout_url( $current_url ) . '" title="' . __( 'Log out of this account.', 'user-registration' ) . '">' . ur_string_translation( null, 'ur_logout_menu',__( 'Logout', 'user-registration' ) ) . '  &raquo;</a>' ) . '</p>', $user_ID ),
 					)
 				);
 			}
@@ -170,7 +170,7 @@ class UR_AJAX {
 		if ( ! check_ajax_referer( 'user_registration_profile_details_save_nonce', 'security', false ) ) {
 			wp_send_json_error(
 				array(
-					'message' => __( 'Nonce error, please reload.', 'user-registration' ),
+					'message' => ur_string_translation( null, 'ur_nonce_error', __( 'Nonce error, please reload.', 'user-registration' ) ),
 				)
 			);
 		}
@@ -236,7 +236,7 @@ class UR_AJAX {
 				if ( email_exists( $single_field[ $key ] ) === 1 ) {
 					wp_send_json_error(
 						array(
-							'message' => __( 'Email already exists.', 'user-registration' ),
+							'message' => ur_string_translation( null, 'ur_email_already_exist', __( 'Email already exists.', 'user-registration' ) ),
 						)
 					);
 				}
@@ -285,7 +285,7 @@ class UR_AJAX {
 				wp_update_user( $user_data );
 			}
 
-			$message = __( 'User profile updated successfully.', 'user-registration' );
+			$message = ur_string_translation( null, 'ur_profile_updated_successfully', __( 'User profile updated successfully.', 'user-registration' ) );
 			do_action( 'user_registration_save_profile_details', $user_id, $form_id );
 
 			wp_send_json_success(
@@ -314,7 +314,7 @@ class UR_AJAX {
 
 			wp_send_json_error(
 				array(
-					'message' => __( 'Nonce error, please reload.', 'user-registration' ),
+					'message' => ur_string_translation( null, 'ur_nonce_error', __( 'Nonce error, please reload.', 'user-registration' ) ),
 				)
 			);
 		}
@@ -365,14 +365,14 @@ class UR_AJAX {
 				case UPLOAD_ERR_INI_SIZE:
 					wp_send_json_error(
 						array(
-							'message' => __( 'File size exceed, please check your file size.', 'user-registration' ),
+							'message' => ur_string_translation( null, 'ur_file_size_exceed', __( 'File size exceed, please check your file size.', 'user-registration' ) ),
 						)
 					);
 					break;
 				default:
 					wp_send_json_error(
 						array(
-							'message' => __( 'Something went wrong while uploading, please contact your site administrator.', 'user-registration' ),
+							'message' => ur_string_translation( null, 'ur_uploading_error', __( 'Something went wrong while uploading, please contact your site administrator.', 'user-registration' ) ),
 						)
 					);
 					break;

--- a/includes/class-ur-email-confirmation.php
+++ b/includes/class-ur-email-confirmation.php
@@ -167,22 +167,22 @@ class UR_Email_Confirmation {
 
 	// Successful registration message.
 	public function custom_registration_message() {
-		return ur_print_notice( __( 'User successfully registered. Login to continue.', 'user-registration' ) );
+		return ur_print_notice( ur_string_translation( null, 'ur_registered_success_message', __( 'User successfully registered. Login to continue.', 'user-registration' ) ) );
 	}
 
 	// Token mismatch message.
 	public function custom_registration_error_message() {
-		return ur_print_notice( __( 'Token Mismatch!', 'user-registration' ), 'error' );
+		return ur_print_notice( ur_string_translation( null, 'ur_token_mismatch', __( 'Token Mismatch!', 'user-registration' ) ), 'error' );
 	}
 
 	// Resend verification email message.
 	public function custom_resend_email_token_message() {
-		return ur_print_notice( __( 'Verification Email Sent!', 'user-registration' ) );
+		return ur_print_notice( ur_string_translation( null, 'ur_verification_email_sent', __( 'Verification Email Sent!', 'user-registration' ) ) );
 	}
 
 	// Resend verification email error message.
 	public function custom_resend_email_token_error_message() {
-		return ur_print_notice( __( 'User does not exist!', 'user-registration' ), 'error' );
+		return ur_print_notice( ur_string_translation( null, 'ur_user_not_exist', __( 'User does not exist!', 'user-registration' ) ), 'error' );
 	}
 
 	/**
@@ -349,7 +349,7 @@ class UR_Email_Confirmation {
 			$url = wp_nonce_url( $url . '?ur_resend_id=' . $this->crypt_the_string( $user->ID, 'e' ) . '&ur_resend_token=true', 'ur_resend_token' );
 
 			if ( $email_status === '0' ) {
-				$message = '<strong>' . __( 'ERROR:', 'user-registration' ) . '</strong> ' . sprintf( __( 'Your account is still pending approval. Verify your email by clicking on the link sent to your email. %s', 'user-registration' ), '<a id="resend-email" href="' . esc_url( $url ) . '">' . __( 'Resend Verification Link', 'user-registration' ) . '</a>' );
+				$message = '<strong>' . ur_string_translation( null, 'ur_error', __( 'ERROR:', 'user-registration' ) ) . '</strong> ' . sprintf( __( ur_string_translation( null, 'ur_verify_email', 'Your account is still pending approval. Verify your email by clicking on the link sent to your email. %s' ), 'user-registration' ), '<a id="resend-email" href="' . esc_url( $url ) . '">' . ur_string_translation( null, 'ur_resend_verification', __( 'Resend Verification Link', 'user-registration' ) ) . '</a>' );
 				return new WP_Error( 'user_email_not_verified', $message );
 			}
 			return $user;
@@ -373,7 +373,7 @@ class UR_Email_Confirmation {
 			$email_status = get_user_meta( $user_id, 'ur_confirm_email', true );
 
 			if ( $email_status === '0' ) {
-				$error_message = __( 'Email not verified! Verify your email by clicking on the link sent to your email.', 'user-registration' );
+				$error_message = ur_string_translation( null, 'ur_email_not_verified', __( 'Email not verified! Verify your email by clicking on the link sent to your email.', 'user-registration' ) );
 				$result        = new WP_Error( 'user_email_not_verified', $error_message );
 			}
 		}

--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -98,10 +98,10 @@ class UR_Form_Handler {
 
 				switch ( $_FILES['profile-pic']['error'] ) {
 					case UPLOAD_ERR_INI_SIZE:
-						ur_add_notice( __( 'File size exceed, please check your file size.', 'user-registration' ), 'error' );
+						ur_add_notice( ur_string_translation( null, 'ur_file_size_exceed', __( 'File size exceed, please check your file size.', 'user-registration' ) ), 'error' );
 						break;
 					default:
-						ur_add_notice( __( 'Something went wrong while uploading, please contact your site administrator.', 'user-registration' ), 'error' );
+						ur_add_notice( ur_string_translation( null, 'ur_uploading_error', __( 'Something went wrong while uploading, please contact your site administrator.', 'user-registration' ) ), 'error' );
 						break;
 				}
 			} elseif ( empty( $_POST['profile-pic-url'] ) ) {
@@ -161,7 +161,7 @@ class UR_Form_Handler {
 
 			// Validation: Required fields.
 			if ( ! empty( $field['required'] ) && empty( $_POST[ $key ] ) && ! $disabled ) {
-				ur_add_notice( sprintf( __( '%s is a required field.', 'user-registration' ), $field['label'] ), 'error' );
+				ur_add_notice( sprintf( __( ur_string_translation( null, 'ur_field_is_required', '%s is a required field.', 'user-registration' ) ), $field['label'] ), 'error' );
 			}
 
 			if ( 'user_email' === $field['field_key'] ) {
@@ -169,7 +169,7 @@ class UR_Form_Handler {
 
 				// Check if email already exists before updating user details.
 				if ( email_exists( $_POST[ $key ] ) === 1 ) {
-					ur_add_notice( __( 'Email already exists', 'user-registration' ), 'error' );
+					ur_add_notice( ur_string_translation( null, 'ur_email_already_exits', __( 'Email already exists', 'user-registration' ) ), 'error' );
 				}
 			}
 
@@ -183,7 +183,7 @@ class UR_Form_Handler {
 								$_POST[ $key ] = strtolower( $_POST[ $key ] );
 
 								if ( ! is_email( $_POST[ $key ] ) ) {
-									ur_add_notice( sprintf( __( '%s is not a valid email address.', 'user-registration' ), '<strong>' . $field['label'] . '</strong>' ), 'error' );
+									ur_add_notice( sprintf( __( ur_string_translation( null, 'ur_invalid_email', '%s is not a valid email address.' ), 'user-registration' ), '<strong>' . $field['label'] . '</strong>' ), 'error' );
 								}
 
 								break;
@@ -227,7 +227,7 @@ class UR_Form_Handler {
 				wp_update_user( $user_data );
 			}
 
-			ur_add_notice( __( 'User profile updated successfully.', 'user-registration' ) );
+			ur_add_notice( ur_string_translation( null, 'ur_profile_updated_success', __( 'User profile updated successfully.', 'user-registration' ) ) );
 
 			do_action( 'user_registration_save_profile_details', $user_id, $form_id );
 
@@ -274,22 +274,22 @@ class UR_Form_Handler {
 		$bypass_current_password = apply_filters( 'user_registration_save_account_bypass_current_password', false );
 
 		if ( empty( $pass_cur ) && empty( $pass1 ) && empty( $pass2 ) ) {
-			ur_add_notice( __( 'Please fill out all password fields.', 'user-registration' ), 'error' );
+			ur_add_notice( ur_string_translation( null, 'ur_fill_password_field', __( 'Please fill out all password fields.', 'user-registration' ) ), 'error' );
 			$save_pass = false;
 		} elseif ( ! $bypass_current_password && empty( $pass_cur ) ) {
-			ur_add_notice( __( 'Please enter your current password.', 'user-registration' ), 'error' );
+			ur_add_notice( ur_string_translation( null, 'ur_enter_current_password', __( 'Please enter your current password.', 'user-registration' ) ), 'error' );
 			$save_pass = false;
 		} elseif ( empty( $pass1 ) ) {
-			ur_add_notice( __( 'Please enter your new password.', 'user-registration' ), 'error' );
+			ur_add_notice( ur_string_translation( null, 'ur_enter_new_password', __( 'Please enter your new password.', 'user-registration' ) ), 'error' );
 			$save_pass = false;
 		} elseif ( empty( $pass2 ) ) {
-			ur_add_notice( __( 'Please re-enter your password.', 'user-registration' ), 'error' );
+			ur_add_notice( ur_string_translation( null, 'ur_reenter_password', __( 'Please re-enter your password.', 'user-registration' ) ), 'error' );
 			$save_pass = false;
 		} elseif ( $pass1 !== $pass2 ) {
-			ur_add_notice( __( 'New passwords do not match.', 'user-registration' ), 'error' );
+			ur_add_notice( ur_string_translation( null, 'ur_new_password_not_matched', __( 'New passwords do not match.', 'user-registration' ) ), 'error' );
 			$save_pass = false;
 		} elseif ( ! $bypass_current_password && ! wp_check_password( $pass_cur, $current_user->user_pass, $current_user->ID ) ) {
-			ur_add_notice( __( 'Your current password is incorrect.', 'user-registration' ), 'error' );
+			ur_add_notice( ur_string_translation( null, 'ur_current_password_incorrect', __( 'Your current password is incorrect.', 'user-registration' ) ), 'error' );
 			$save_pass = false;
 		}
 
@@ -310,7 +310,7 @@ class UR_Form_Handler {
 
 			wp_update_user( $user );
 
-			ur_add_notice( __( 'Password changed successfully.', 'user-registration' ) );
+			ur_add_notice( ur_string_translation( null, 'ur_password_changed_success', __( 'Password changed successfully.', 'user-registration' ) ) );
 
 			do_action( 'user_registration_save_account_details', $user->ID );
 
@@ -361,19 +361,19 @@ class UR_Form_Handler {
 						$data = json_decode( wp_remote_retrieve_body( $data ) );
 
 						if ( empty( $data->success ) || ( isset( $data->score ) && $data->score < apply_filters( 'user_registration_recaptcha_v3_threshold', 0.5 ) ) ) {
-							throw new Exception( '<strong>' . __( 'ERROR:', 'user-registration' ) . '</strong>' . __( 'Error on google reCaptcha. Contact your site administrator.', 'user-registration' ) );
+							throw new Exception( '<strong>' . ur_string_translation( null, 'ur_error', __( 'ERROR:', 'user-registration' ) ) . '</strong>' . ur_string_translation( null, 'ur_google_recaptcha', __( 'Error on google reCaptcha. Contact your site administrator.', 'user-registration' ) ) );
 						}
 					} else {
-						throw new Exception( '<strong>' . __( 'ERROR:', 'user-registration' ) . '</strong>' . get_option( 'user_registration_form_submission_error_message_recaptcha', __( 'Captcha code error, please try again.', 'user-registration' ) ) );
+						throw new Exception( '<strong>' . ur_string_translation( null, 'ur_error', __( 'ERROR:', 'user-registration' ) ) . '</strong>' . get_option( 'user_registration_form_submission_error_message_recaptcha', __( 'Captcha code error, please try again.', 'user-registration' ) ) );
 					}
 				}
 
 				if ( $validation_error->get_error_code() ) {
-					throw new Exception( '<strong>' . __( 'ERROR:', 'user-registration' ) . '</strong>' . $validation_error->get_error_message() );
+					throw new Exception( '<strong>' . ur_string_translation( null, 'ur_error', __( 'ERROR:', 'user-registration' ) ) . '</strong>' . $validation_error->get_error_message() );
 				}
 
 				if ( empty( $username ) ) {
-					throw new Exception( '<strong>' . __( 'ERROR:', 'user-registration' ) . '</strong>' . $messages['username_is_required'] );
+					throw new Exception( '<strong>' . ur_string_translation( null, 'ur_error', __( 'ERROR:', 'user-registration' ) ) . '</strong>' . $messages['username_is_required'] );
 				}
 
 				if ( is_email( $username ) && apply_filters( 'user_registration_get_username_from_email', true ) ) {
@@ -382,7 +382,7 @@ class UR_Form_Handler {
 					if ( isset( $user->user_login ) ) {
 						$creds['user_login'] = $user->user_login;
 					} else {
-						throw new Exception( '<strong>' . __( 'ERROR:', 'user-registration' ) . '</strong>' . $messages['unknown_email'] );
+						throw new Exception( '<strong>' . ur_string_translation( null, 'ur_error', __( 'ERROR:', 'user-registration' ) ) . '</strong>' . $messages['unknown_email'] );
 					}
 				} else {
 					$creds['user_login'] = $username;
@@ -403,16 +403,16 @@ class UR_Form_Handler {
 				if ( is_wp_error( $user ) ) {
 					// Set custom error messages.
 					if ( ! empty( $user->errors['empty_password'] ) && ! empty( $messages['empty_password'] ) ) {
-						$user->errors['empty_password'][0] = sprintf( '<strong>%s:</strong> %s', __( 'ERROR', 'user-registration' ), $messages['empty_password'] );
+						$user->errors['empty_password'][0] = sprintf( '<strong>%s:</strong> %s', ur_string_translation( null, 'ur_error', __( 'ERROR', 'user-registration' ) ), $messages['empty_password'] );
 					}
 					if ( ! empty( $user->errors['invalid_username'] ) && ! empty( $messages['invalid_username'] ) ) {
 						$user->errors['invalid_username'][0] = $messages['invalid_username'];
 					}
 					if ( ! empty( $user->errors['pending_approval'] ) && ! empty( $messages['pending_approval'] ) ) {
-						$user->errors['pending_approval'][0] = sprintf( '<strong>%s:</strong> %s', __( 'ERROR', 'user-registration' ), $messages['pending_approval'] );
+						$user->errors['pending_approval'][0] = sprintf( '<strong>%s:</strong> %s', ur_string_translation( null, 'ur_error', __( 'ERROR', 'user-registration' ) ), $messages['pending_approval'] );
 					}
 					if ( ! empty( $user->errors['denied_access'] ) && ! empty( $messages['denied_access'] ) ) {
-						$user->errors['denied_access'][0] = sprintf( '<strong>%s:</strong> %s', __( 'ERROR', 'user-registration' ), $messages['denied_access'] );
+						$user->errors['denied_access'][0] = sprintf( '<strong>%s:</strong> %s', ur_string_translation( null, 'ur_error', __( 'ERROR', 'user-registration' ) ), $messages['denied_access'] );
 					}
 
 					$message = $user->get_error_message();
@@ -496,11 +496,11 @@ class UR_Form_Handler {
 
 		if ( $user instanceof WP_User ) {
 			if ( empty( $posted_fields['password_1'] ) ) {
-				ur_add_notice( __( 'Please enter your password.', 'user-registration' ), 'error' );
+				ur_add_notice( ur_string_translation( null, 'ur_enter_password', __( 'Please enter your password.', 'user-registration' ) ), 'error' );
 			}
 
 			if ( $posted_fields['password_1'] !== $posted_fields['password_2'] ) {
-				ur_add_notice( __( 'Passwords do not match.', 'user-registration' ), 'error' );
+				ur_add_notice( ur_string_translation( null, 'ur_password_mismatch',__( 'Passwords do not match.', 'user-registration' ) ), 'error' );
 			}
 
 			$errors = new WP_Error();

--- a/includes/class-ur-frontend-scripts.php
+++ b/includes/class-ur-frontend-scripts.php
@@ -349,7 +349,7 @@ class UR_Frontend_Scripts {
 					'user_registration_profile_picture_upload_nonce' => wp_create_nonce( 'user_registration_profile_picture_upload_nonce' ),
 					'form_required_fields'             => ur_get_required_fields(),
 					'login_option'                     => get_option( 'user_registration_general_setting_login_options' ),
-					'user_registration_profile_picture_uploading' => __( 'Uploading...', 'user-registration' ),
+					'user_registration_profile_picture_uploading' => ur_string_translation( null, 'ur_uploading', __( 'Uploading...', 'user-registration' ) ),
 					'ajax_submission_on_edit_profile'  => get_option( 'user_registration_ajax_form_submission_on_edit_profile', 'no' ),
 					'message_required_fields'          => get_option( 'user_registration_form_submission_error_message_required_fields', __( 'This field is required.', 'user-registration' ) ),
 					'message_email_fields'             => get_option( 'user_registration_form_submission_error_message_email', __( 'Please enter a valid email address.', 'user-registration' ) ),
@@ -363,9 +363,9 @@ class UR_Frontend_Scripts {
 						'user_under_approval'     => get_option( 'user_registration_successful_form_submission_message_admin_approval', __( 'User registered. Wait until admin approves your registration.', 'user-registration' ) ),
 						'user_email_pending'      => get_option( 'user_registration_successful_form_submission_message_email_confirmation', __( 'User registered. Verify your email by clicking on the link sent to your email.', 'user-registration' ) ),
 						'captcha_error'           => get_option( 'user_registration_form_submission_error_message_recaptcha', __( 'Captcha code error, please try again.', 'user-registration' ) ),
-						'hide_password_title'     => __( 'Hide Password', 'user-registration' ),
-						'show_password_title'     => __( 'Show Password', 'user-registration' ),
-						'password_strength_error' => __( 'Password strength is not strong enough', 'user-registration' ),
+						'hide_password_title'     => ur_string_translation( null, 'ur_hide_password', __( 'Hide Password', 'user-registration' ) ),
+						'show_password_title'     => ur_string_translation( null, 'ur_show_password',__( 'Show Password', 'user-registration' ) ),
+						'password_strength_error' => ur_string_translation( null, 'ur_password_strength_message', __( 'Password strength is not strong enough', 'user-registration' ) ),
 					),
 				);
 			break;
@@ -373,16 +373,16 @@ class UR_Frontend_Scripts {
 			case 'ur-password-strength-meter':
 				return array(
 					'home_url'            => home_url(),
-					'i18n_password_error' => esc_attr__( 'Please enter a stronger password.', 'user-registration' ),
+					'i18n_password_error' => ur_string_translation( null, 'ur_enter_strong_password', esc_attr__( 'Please enter a stronger password.', 'user-registration' ) ),
 					'pwsL10n'             => array(
-						'shortpw'  => __( 'Very Weak', 'user-registration' ),
-						'bad'      => __( 'Weak', 'user-registration' ),
-						'good'     => __( 'Medium', 'user-registration' ),
-						'strong'   => __( 'Strong', 'user-registration' ),
-						'mismatch' => __( 'Password with confirm password not matched.', 'user-registration' ),
+						'shortpw'  => ur_string_translation( null, 'ur_very_weak_password', __( 'Very Weak', 'user-registration' ) ),
+						'bad'      => ur_string_translation( null, 'ur_weak_password',__( 'Weak', 'user-registration' ) ),
+						'good'     => ur_string_translation( null, 'ur_medium_password',__( 'Medium', 'user-registration' ) ),
+						'strong'   => ur_string_translation( null, 'ur_strong_password',__( 'Strong', 'user-registration' ) ),
+						'mismatch' => ur_string_translation( null, 'ur_mismatch_password',__( 'Password with confirm password not matched.', 'user-registration' ) )
 
 					),
-					'i18n_password_hint'  => apply_filters( 'user_registration_strong_password_message', __( 'Hint: To make password stronger, use upper and lower case letters, numbers, and symbols like ! " ? $ % ^ & ).', 'user-registration' ) ),
+					'i18n_password_hint'  => ur_string_translation( null, 'ur_password_hint', apply_filters( 'user_registration_strong_password_message', __( 'Hint: To make password stronger, use upper and lower case letters, numbers, and symbols like ! " ? $ % ^ & ).', 'user-registration' ) ) ),
 				);
 				break;
 		}

--- a/includes/class-ur-query.php
+++ b/includes/class-ur-query.php
@@ -69,13 +69,13 @@ class UR_Query {
 	public function get_endpoint_title( $endpoint ) {
 		switch ( $endpoint ) {
 			case 'edit-password':
-				$title = __( 'Change Password', 'user-registration' );
+				$title = ur_string_translation( null, 'ur_change_password_menu', __( 'Change Password', 'user-registration' ) );
 				break;
 			case 'edit-profile':
-				$title = __( 'Profile Details', 'user-registration' );
+				$title = ur_string_translation( null, 'ur_profile_details_menu',__( 'Profile Details', 'user-registration' ) );
 				break;
 			case 'ur-lost-password':
-				$title = __( 'Lost password', 'user-registration' );
+				$title = ur_string_translation( null, 'ur_lost_password_menu',__( 'Lost password', 'user-registration' ) );
 				break;
 			default:
 				$title = '';

--- a/includes/class-ur-shortcodes.php
+++ b/includes/class-ur-shortcodes.php
@@ -27,7 +27,7 @@ class UR_Shortcodes {
 		$shortcodes = array(
 			'user_registration_form'       => __CLASS__ . '::form', // change it to user_registration_form ;)
 			'user_registration_my_account' => __CLASS__ . '::my_account',
-			'user_registration_login'      => __class__ . '::login',
+			'user_registration_login'      => __CLASS__ . '::login',
 		);
 		add_filter( 'pre_do_shortcode_tag', array( UR_Shortcode_My_Account::class, 'pre_do_shortcode_tag' ), 10, 4 );
 
@@ -122,7 +122,7 @@ class UR_Shortcodes {
 
 		if ( ! is_user_logged_in() ) {
 			if ( ! $users_can_register ) {
-				return apply_filters( 'ur_register_pre_form_message', '<p class="alert" id="ur_register_pre_form_message">' . __( 'Only administrators can add new users.', 'user-registration' ) . '</p>' );
+				return apply_filters( 'ur_register_pre_form_message', '<p class="alert" id="ur_register_pre_form_message">' . ur_string_translation( null, 'ur_only_administrator_can_register',__( 'Only administrators can add new users.', 'user-registration' ) ) . '</p>' );
 			}
 		} else {
 

--- a/includes/class-ur-user-approval.php
+++ b/includes/class-ur-user-approval.php
@@ -184,12 +184,12 @@ class UR_User_Approval {
 					return $user;
 					break;
 				case UR_Admin_User_Manager::PENDING:
-					$message = '<strong>' . __( 'ERROR:', 'user-registration' ) . '</strong> ' . __( 'Your account is still pending approval.', 'user-registration' );
+					$message = '<strong>' . ur_string_translation( null, 'ur_error', esc_html__( 'ERROR:', 'user-registration' ) ) . '</strong> ' . ur_string_translation( null, 'ur_pending_approval_message', esc_html__( 'Your account is still pending approval.', 'user-registration' ) );
 
 					return new WP_Error( 'pending_approval', $message );
 					break;
 				case UR_Admin_User_Manager::DENIED:
-					$message = '<strong>' . __( 'ERROR:', 'user-registration' ) . '</strong> ' . __( 'Your account has been denied.', 'user-registration' );
+					$message = '<strong>' . ur_string_translation( null, 'ur_error', esc_html__( 'ERROR:', 'user-registration' ) ) . '</strong> ' . ur_string_translation( null, 'ur_account_denied_message', esc_html__( 'Your account has been denied.', 'user-registration' ) );
 
 					return new WP_Error( 'denied_access', $message );
 					break;
@@ -204,7 +204,7 @@ class UR_User_Approval {
 			$url      = wp_nonce_url( $url . '?ur_resend_id=' . $instance->crypt_the_string( $user->ID, 'e' ) . '&ur_resend_token=true', 'ur_resend_token' );
 
 			if ( '0' === $status['user_status'] ) {
-				$message = '<strong>' . esc_html__( 'ERROR:', 'user-registration' ) . '</strong> ' . sprintf( __( 'Your account is still pending approval. Verify your email by clicking on the link sent to your email. %s', 'user-registration' ), '<a id="resend-email" href="' . esc_url( $url ) . '">' . __( 'Resend Verification Link', 'user-registration' ) . '</a>' );
+				$message = '<strong>' . ur_string_translation( null, 'ur_error', esc_html__( 'ERROR:', 'user-registration' ) ) . '</strong> ' . sprintf( __( ur_string_translation( null, 'ur_verify_email_message', 'Your account is still pending approval. Verify your email by clicking on the link sent to your email. %s' ), 'user-registration' ), '<a id="resend-email" href="' . esc_url( $url ) . '">' . ur_string_translation( null, 'ur_resend_verification_link', __( 'Resend Verification Link', 'user-registration' ) ) . '</a>' );
 				return new WP_Error( 'user_email_not_verified', $message );
 			}
 			return $user;
@@ -218,7 +218,7 @@ class UR_User_Approval {
 				$user_id      = $user->ID;
 				$instance     = new User_Registration_Payments_Process();
 				$redirect_url = $instance->generate_redirect_url( $user_id );
-				$message      = '<strong>' . __( 'ERROR:', 'user-registration' ) . '</strong> ' . sprintf( __( 'Your account is still pending payment. Process the payment by clicking on this: %s', 'user-registration' ), '<a id="payment-link" href="' . esc_url( $redirect_url ) . '">' . __( 'link', 'user-registration' ) . '</a>' );
+				$message      = '<strong>' . ur_string_translation( null, 'ur_error', __( 'ERROR:', 'user-registration' ) ) . '</strong> ' . sprintf( __( ur_string_translation( null, 'ur_payment_pending_message', 'Your account is still pending payment. Process the payment by clicking on this: %s' ), 'user-registration' ), '<a id="payment-link" href="' . esc_url( $redirect_url ) . '">' . __( 'link', 'user-registration' ) . '</a>' );
 
 				return new WP_Error( 'user_payment_pending', $message );
 			}
@@ -305,7 +305,7 @@ class UR_User_Approval {
 			$user_manager = new UR_Admin_User_Manager( $user_id );
 
 			if ( ! $user_manager->is_approved() ) {
-				$error_message = __( 'Your account is still awaiting admin approval. Reset Password is not allowed.', 'user-registration' );
+				$error_message = ur_string_translation( null, 'ur_awaiting_admin_approval_message', __( 'Your account is still awaiting admin approval. Reset Password is not allowed.', 'user-registration' ) );
 				$result        = new WP_Error( 'user_not_approved', $error_message );
 			}
 		}

--- a/includes/frontend/class-ur-frontend-form-handler.php
+++ b/includes/frontend/class-ur-frontend-form-handler.php
@@ -120,7 +120,7 @@ class UR_Frontend_Form_Handler {
 			}
 			wp_send_json_error(
 				array(
-					'message' => __( 'Something went wrong! please try again', 'user-registration' ),
+					'message' =>  ur_string_translation( null, 'ur_something_went_wrong', __( 'Something went wrong! please try again', 'user-registration' ) ),
 				)
 			);
 		} else {
@@ -165,13 +165,13 @@ class UR_Frontend_Form_Handler {
 		$form_key_list       = wp_list_pluck( wp_list_pluck( $form_field_data, 'general_setting' ), 'field_name' );
 		$duplicate_field_key = array_diff_key( $form_data_field, array_unique( $form_data_field ) );
 		if ( count( $duplicate_field_key ) > 0 ) {
-			array_push( self::$response_array, __( 'Duplicate field key in form, please contact site administrator.', 'user-registration' ) );
+			array_push( self::$response_array, ur_string_translation( null, 'ur_duplicate_field_key', __( 'Duplicate field key in form, please contact site administrator.', 'user-registration' ) ) );
 		}
 
 		$contains_search = count( array_intersect( ur_get_required_fields(), $form_data_field ) ) == count( ur_get_required_fields() );
 
 		if ( false === $contains_search ) {
-			array_push( self::$response_array, __( 'Required form field not found.', 'user-registration' ) );
+			array_push( self::$response_array,  ur_string_translation( null, 'ur_required_form_field_not_found', __( 'Required form field not found.', 'user-registration' ) ) );
 		}
 
 		// Check if a required field is missing.
@@ -367,7 +367,7 @@ class UR_Frontend_Form_Handler {
 
 		if ( $has_confirm_password ) {
 			if ( empty( $confirm_password ) ) {
-				array_push( self::$response_array, __( 'Empty confirm password', 'user-registration' ) );
+				array_push( self::$response_array,  ur_string_translation( null, 'ur_empty_confirm_password', __( 'Empty confirm password', 'user-registration' ) ) );
 			} elseif ( strcmp( $confirm_password, $password ) != 0 ) {
 				array_push( self::$response_array, get_option( 'user_registration_form_submission_error_message_confirm_password', __( 'Password and confirm password not matched', 'user-registration' ) ) );
 			}
@@ -412,7 +412,7 @@ class UR_Frontend_Form_Handler {
 
 		if ( $has_confirm_email ) {
 			if ( empty( $confirm_email_value ) ) {
-				array_push( self::$response_array, __( 'Empty confirm email', 'user-registration' ) );
+				array_push( self::$response_array, ur_string_translation( null, 'ur_empty_confirm_email', __( 'Empty confirm email', 'user-registration' ) ) );
 			} elseif ( strcasecmp( $confirm_email_value, $email ) != 0 ) {
 				array_push( self::$response_array, get_option( 'user_registration_form_submission_error_message_confirm_email', __( 'Email and confirm email not matched', 'user-registration' ) ) );
 			}
@@ -439,7 +439,7 @@ class UR_Frontend_Form_Handler {
 					return;
 				} else {
 					$field_label = $form_field_data[ $key ]->general_setting->label;
-					$response    = sprintf( __( '%s is a required field.', 'user-registration' ), $field_label );
+					$response    = sprintf( __( ur_string_translation( null, 'ur_field_is_required', '%s is a required field.' ), 'user-registration' ), $field_label );
 					array_push( self::$response_array, $response );
 				}
 			}
@@ -473,7 +473,7 @@ class UR_Frontend_Form_Handler {
 		}
 
 		if ( $password_value === $email_value || $password_value === $username_value ) {
-			array_push( self::$response_array, __( 'Password should not match with Username or Email address.', 'user-registration' ) );
+			array_push( self::$response_array, ur_string_translation( null, 'ur_password_username_matched_message', __( 'Password should not match with Username or Email address.', 'user-registration' ) ) );
 		}
 	}
 }

--- a/includes/functions-ur-account.php
+++ b/includes/functions-ur-account.php
@@ -50,10 +50,10 @@ function ur_login_error_message( $error ) {
 	// Its the correct username with incorrect password.
 	if ( is_int( $pos ) && isset( $_POST['username'] ) ) {
 
-		$error = sprintf( '<strong>' . __( 'ERROR:', 'user-registration' ) . '</strong>' . __( 'The password you entered for username %1$1s is incorrect. %2$2s', 'user-registration' ), $_POST['username'], "<a href='" . esc_url( wp_lostpassword_url() ) . "'>" . __( 'Lost Your Password?', 'user-registration' ) . '</a>' );
+		$error = sprintf( '<strong>' . ur_string_translation( null, 'ur_error', __( 'ERROR:', 'user-registration' ) ) . '</strong>' . ur_string_translation( null, 'ur_incorrect_password', __( 'The password you entered for username %1$1s is incorrect. %2$2s', 'user-registration' ) ), $_POST['username'], "<a href='" . esc_url( wp_lostpassword_url() ) . "'>" . ur_string_translation( null, 'ur_lost_your_password', __( 'Lost Your Password?', 'user-registration' ) ) . '</a>' );
 	} // It's invalid username.
 	elseif ( is_int( $pos2 ) && isset( $_POST['username'] ) ) {
-		$error = sprintf( '<strong>' . __( 'ERROR:', 'user-registration' ) . '</strong>' . __( 'Invalid username. %1s', 'user-registration' ), "<a href='" . esc_url( wp_lostpassword_url() ) . "'>" . __( 'Lost Your Password?', 'user-registration' ) . '</a>' );
+		$error = sprintf( '<strong>' . ur_string_translation( null, 'ur_error', __( 'ERROR:', 'user-registration' ) ) . '</strong>' . ur_string_translation( null, 'ur_invalid_username', __( 'Invalid username. %1s', 'user-registration' ) ), "<a href='" . esc_url( wp_lostpassword_url() ) . "'>" . ur_string_translation( null, 'ur_lost_your_password', __( 'Lost Your Password?', 'user-registration' ) ) . '</a>' );
 	}
 
 	return $error;
@@ -105,10 +105,10 @@ function ur_get_account_menu_items() {
 	);
 
 	$items = array(
-		'dashboard'     => __( 'Dashboard', 'user-registration' ),
-		'edit-profile'  => __( 'Profile Details', 'user-registration' ),
-		'edit-password' => __( 'Change Password', 'user-registration' ),
-		'user-logout'   => __( 'Logout', 'user-registration' ),
+		'dashboard'     => ur_string_translation( null, 'ur_dashboard_menu', __( 'Dashboard', 'user-registration' ) ),
+		'edit-profile'  => ur_string_translation( null, 'ur_profile_details_menu', __( 'Profile Details', 'user-registration' ) ),
+		'edit-password' => ur_string_translation( null, 'ur_change_password_menu', __( 'Change Password', 'user-registration' ) ),
+		'user-logout'   => ur_string_translation( null, 'ur_logout_menu', __( 'Logout', 'user-registration' ) ),
 	);
 
 	$user_id = get_current_user_id();

--- a/includes/shortcodes/class-ur-shortcode-login.php
+++ b/includes/shortcodes/class-ur-shortcode-login.php
@@ -61,7 +61,7 @@ class UR_Shortcode_Login {
 				);
 			}
 		} else {
-			echo apply_filters( 'user_registration_logged_in_message', sprintf( __( 'You are already logged in. <a href="%s">Log out?</a>', 'user-registration' ), ur_logout_url() ) );
+			echo apply_filters( 'user_registration_logged_in_message', sprintf( __( ur_string_translation( null, 'ur_already_loggedin_message', 'You are already logged in. <a href="%s">Log out?</a>' ), 'user-registration' ), ur_logout_url() ) );
 		}
 	}
 }

--- a/includes/shortcodes/class-ur-shortcode-my-account.php
+++ b/includes/shortcodes/class-ur-shortcode-my-account.php
@@ -75,7 +75,7 @@ class UR_Shortcode_My_Account {
 
 			// After password reset, add confirmation message.
 			if ( ! empty( $_GET['password-reset'] ) ) {
-				ur_add_notice( __( 'Your password has been reset successfully.', 'user-registration' ) );
+				ur_add_notice( ur_string_translation( null, 'ur_password_reset_success_notice', __( 'Your password has been reset successfully.', 'user-registration' ) ) );
 			}
 
 			if ( isset( $wp->query_vars['ur-lost-password'] ) ) {
@@ -134,7 +134,7 @@ class UR_Shortcode_My_Account {
 			ob_start();
 
 			if ( isset( $wp->query_vars['user-logout'] ) ) {
-				ur_add_notice( sprintf( __( 'Are you sure you want to log out?&nbsp;<a href="%s">Confirm and log out</a>', 'user-registration' ), ur_logout_url() ) );
+				ur_add_notice( sprintf( __( ur_string_translation( null, 'ur_are_you_sure_logout', 'Are you sure you want to log out?&nbsp;<a href="%s">Confirm and log out</a>' ), 'user-registration' ), ur_logout_url() ) );
 			}
 
 			do_action( 'before-user-registration-my-account-shortcode' );
@@ -213,7 +213,7 @@ class UR_Shortcode_My_Account {
 				)
 			);
 		} else {
-			echo '<h1>' . esc_html__( 'No profile details found.', 'user-registration' ) . '</h1>';
+			echo '<h1>' . ur_string_translation( null, 'ur_no_profile_details', esc_html__( 'No profile details found.', 'user-registration' ) ) . '</h1>';
 		}
 	}
 
@@ -312,7 +312,7 @@ class UR_Shortcode_My_Account {
 		$login = trim( $_POST['user_login'] );
 
 		if ( empty( $login ) ) {
-			ur_add_notice( __( 'Enter a username or email address.', 'user-registration' ), 'error' );
+			ur_add_notice( ur_string_translation( null, 'ur_enter_username_notice', __( 'Enter a username or email address.', 'user-registration' ) ), 'error' );
 			return false;
 		} else {
 			// Check on username first, as customers can use emails as usernames.
@@ -333,12 +333,12 @@ class UR_Shortcode_My_Account {
 		}
 
 		if ( ! $user_data ) {
-			ur_add_notice( __( 'Invalid username or email.', 'user-registration' ), 'error' );
+			ur_add_notice( ur_string_translation( null, 'ur_invalid_username_notice', __( 'Invalid username or email.', 'user-registration' ) ), 'error' );
 			return false;
 		}
 
 		if ( is_multisite() && ! is_user_member_of_blog( $user_data->ID, get_current_blog_id() ) ) {
-			ur_add_notice( __( 'Invalid username or email.', 'user-registration' ), 'error' );
+			ur_add_notice( ur_string_translation( null, 'ur_invalid_username_notice', __( 'Invalid username or email.', 'user-registration' ) ), 'error' );
 			return false;
 		}
 
@@ -348,7 +348,8 @@ class UR_Shortcode_My_Account {
 		$allow = apply_filters( 'allow_password_reset', true, $user_data->ID );
 
 		if ( ! $allow ) {
-			ur_add_notice( __( 'Password reset is not allowed for this user', 'user-registration' ), 'error' );
+			ur_add_notice( ur_string_translation( null, 'ur_reset_password_not_allowed_notice',
+			__( 'Password reset is not allowed for this user', 'user-registration' ) ), 'error' );
 			return false;
 
 		} elseif ( is_wp_error( $allow ) ) {
@@ -361,7 +362,7 @@ class UR_Shortcode_My_Account {
 
 		// Send email notification.
 		if ( UR_Emailer::lost_password_email( $user_login, $user_data, $key ) == false ) {
-			ur_add_notice( __( 'The email could not be sent. Contact your site administrator. ', 'user-registration' ), 'error' );
+			ur_add_notice( ur_string_translation( null, 'ur_email_not_sent_notice',__( 'The email could not be sent. Contact your site administrator. ', 'user-registration' ) ), 'error' );
 			return false;
 		}
 

--- a/templates/form-login-registration.php
+++ b/templates/form-login-registration.php
@@ -28,11 +28,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 <div class="ur-frontend-form login-registration">
 	<div class="ur-form-row">
 		<div class="ur-form-grid">
-			<h2 class="ur-form-title"><?php echo __( 'Login', 'user-registration' ); ?></h2>
+			<h2 class="ur-form-title"><?php echo ur_string_translation( null, 'ur_login', esc_html__( 'Login', 'user-registration' ) ); ?></h2>
 			<?php echo $login_form; ?>
 		</div>
 		<div class="ur-form-grid">
-			<h2 class="ur-form-title"><?php echo __( 'Registration', 'user-registration' ); ?></h2>
+			<h2 class="ur-form-title"><?php echo ur_string_translation( null, 'ur_registration', esc_html__( 'Registration', 'user-registration' ) ); ?></h2>
 			<?php echo $registration_form; ?>
 		</div>
 	</div>

--- a/templates/myaccount/dashboard.php
+++ b/templates/myaccount/dashboard.php
@@ -25,11 +25,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <h2>
 	<?php
-	echo ur_string_translation( null, 'ur_dashboard_welcome',
+	echo
 	sprintf(
-		__( 'Welcome, %1$s', 'user-registration' ),
+		__( ur_string_translation( null, 'ur_dashboard_welcome','Welcome, %1$s' ), 'user-registration' ),
 		esc_html( $current_user->display_name )
-	) );
+	);
 	?>
 </h2>
 
@@ -73,24 +73,24 @@ if ( ! defined( 'ABSPATH' ) ) {
 <p>
 <?php
 	/* translators: 1 profile details url, 2: change password url */
-	echo ur_string_translation( null, 'ur_dashboard_message',
+	echo
 	sprintf(
-		__( 'From your account dashboard you can edit your <a href="%1$s"> profile details</a> and <a href="%2$s">edit your password</a>.', 'user-registration' ),
+		__( ur_string_translation( null, 'ur_dashboard_message', 'From your account dashboard you can edit your <a href="%1$s"> profile details</a> and <a href="%2$s">edit your password</a>.' ), 'user-registration' ),
 		esc_url( ur_get_endpoint_url( 'edit-profile' ) ),
 		esc_url( ur_get_endpoint_url( 'edit-password' ) )
-	) );
+	);
 	?>
 </p>
 
 <p>
 	<?php
 		/* translators: 1: user display name 2: logout url */
-		echo ur_string_translation( null, 'ur_dashboard_signout_message',
+		echo
 		sprintf(
-			__( 'Not %1$s? <a href="%2$s">Sign out</a>', 'user-registration' ),
+			__( ur_string_translation( null, 'ur_dashboard_signout_message', 'Not %1$s? <a href="%2$s">Sign out</a>' ), 'user-registration' ),
 			'<strong>' . esc_html( $current_user->display_name ) . '</strong>',
 			esc_url( ur_logout_url( ur_get_page_permalink( 'myaccount' ) ) )
-		) );
+		);
 		?>
 </p>
 

--- a/templates/myaccount/dashboard.php
+++ b/templates/myaccount/dashboard.php
@@ -25,10 +25,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <h2>
 	<?php
-	printf(
+	echo ur_string_translation( null, 'ur_dashboard_welcome',
+	sprintf(
 		__( 'Welcome, %1$s', 'user-registration' ),
 		esc_html( $current_user->display_name )
-	);
+	) );
 	?>
 </h2>
 
@@ -72,22 +73,24 @@ if ( ! defined( 'ABSPATH' ) ) {
 <p>
 <?php
 	/* translators: 1 profile details url, 2: change password url */
-	printf(
+	echo ur_string_translation( null, 'ur_dashboard_message',
+	sprintf(
 		__( 'From your account dashboard you can edit your <a href="%1$s"> profile details</a> and <a href="%2$s">edit your password</a>.', 'user-registration' ),
 		esc_url( ur_get_endpoint_url( 'edit-profile' ) ),
 		esc_url( ur_get_endpoint_url( 'edit-password' ) )
-	);
+	) );
 	?>
 </p>
 
 <p>
 	<?php
 		/* translators: 1: user display name 2: logout url */
-		printf(
+		echo ur_string_translation( null, 'ur_dashboard_signout_message',
+		sprintf(
 			__( 'Not %1$s? <a href="%2$s">Sign out</a>', 'user-registration' ),
 			'<strong>' . esc_html( $current_user->display_name ) . '</strong>',
 			esc_url( ur_logout_url( ur_get_page_permalink( 'myaccount' ) ) )
-		);
+		) );
 		?>
 </p>
 

--- a/templates/myaccount/form-edit-password.php
+++ b/templates/myaccount/form-edit-password.php
@@ -34,13 +34,13 @@ do_action( 'user_registration_before_change_password_form' );
 				<fieldset>
 					<legend><?php
 					echo ur_string_translation( null, 'ur_change_password_title',
-					__( 'Change Password', 'user-registration' ) ); ?></legend>
+					esc_html__( 'Change Password', 'user-registration' ) ); ?></legend>
 
 					<?php if ( apply_filters( 'user_registration_change_password_current_password_display', true ) ) { ?>
 					<p class="user-registration-form-row user-registration-form-row--wide form-row form-row-wide hide_show_password">
 						<label for="password_current"><?php
 						echo ur_string_translation( null, 'ur_current_password_label',
-						__( 'Current password', 'user-registration' ) ); ?></label>
+						esc_html__( 'Current password', 'user-registration' ) ); ?></label>
 						<span class="password-input-group">
 						<input type="password" class="user-registration-Input user-registration-Input--password input-text" name="password_current" id="password_current" />
 						<?php
@@ -54,8 +54,8 @@ do_action( 'user_registration_before_change_password_form' );
 					</p>
 					<?php } ?>
 					<p class="user-registration-form-row user-registration-form-row--wide form-row form-row-wide hide_show_password">
-						<label for="password_1"><?php echo ur_string_translation( null, 'ur_current_password_label',
-						__( 'New password', 'user-registration' ) ); ?></label>
+						<label for="password_1"><?php echo ur_string_translation( null, 'ur_new_password_label',
+						esc_html__( 'New password', 'user-registration' ) ); ?></label>
 						<span class="password-input-group">
 						<input type="password" class="user-registration-Input user-registration-Input--password input-text" name="password_1" id="password_1" />
 						<?php
@@ -68,12 +68,13 @@ do_action( 'user_registration_before_change_password_form' );
 						</span>
 					</p>
 					<p class="user-registration-form-row user-registration-form-row--wide form-row form-row-wide hide_show_password">
-						<label for="password_2"><?php _e( 'Confirm new password', 'user-registration' ); ?></label>
+						<label for="password_2"><?php echo ur_string_translation( null, 'ur_confirm_new_password', esc_html__( 'Confirm new password', 'user-registration' ) ); ?></label>
 						<span class="password-input-group">
 						<input type="password" class="user-registration-Input user-registration-Input--password input-text" name="password_2" id="password_2" />
 						<?php
 						if ( 'yes' === get_option( 'user_registration_login_option_hide_show_password', 'no' ) ) {
-							echo '<a href="javaScript:void(0)" class="password_preview dashicons dashicons-hidden" title="' . esc_attr__( 'Show Password', 'user-registration' ) . '"></a>';
+							echo '<a href="javaScript:void(0)" class="password_preview dashicons dashicons-hidden" title="' . ur_string_translation( null, 'ur_show_password_attribute',
+							esc_attr__( 'Show Password', 'user-registration' ) ) . '"></a>';
 						}
 						?>
 						</span>
@@ -88,7 +89,8 @@ do_action( 'user_registration_before_change_password_form' );
 
 				<p>
 					<?php wp_nonce_field( 'save_change_password' ); ?>
-					<input type="submit" class="user-registration-Button button" name="save_change_password" value="<?php esc_attr_e( 'Save changes', 'user-registration' ); ?>" />
+					<input type="submit" class="user-registration-Button button" name="save_change_password" value="<?php echo ur_string_translation( null, 'ur_save_change_password_button',
+							esc_attr__( 'Save changes', 'user-registration' ) ); ?>" />
 					<input type="hidden" name="action" value="save_change_password" />
 				</p>
 

--- a/templates/myaccount/form-edit-password.php
+++ b/templates/myaccount/form-edit-password.php
@@ -32,28 +32,37 @@ do_action( 'user_registration_before_change_password_form' );
 					do_action( 'user_registration_change_password_form_start' );
 				?>
 				<fieldset>
-					<legend><?php _e( 'Change Password', 'user-registration' ); ?></legend>
+					<legend><?php
+					echo ur_string_translation( null, 'ur_change_password_title',
+					__( 'Change Password', 'user-registration' ) ); ?></legend>
 
 					<?php if ( apply_filters( 'user_registration_change_password_current_password_display', true ) ) { ?>
 					<p class="user-registration-form-row user-registration-form-row--wide form-row form-row-wide hide_show_password">
-						<label for="password_current"><?php _e( 'Current password', 'user-registration' ); ?></label>
+						<label for="password_current"><?php
+						echo ur_string_translation( null, 'ur_current_password_label',
+						__( 'Current password', 'user-registration' ) ); ?></label>
 						<span class="password-input-group">
 						<input type="password" class="user-registration-Input user-registration-Input--password input-text" name="password_current" id="password_current" />
 						<?php
 						if ( 'yes' === get_option( 'user_registration_login_option_hide_show_password', 'no' ) ) {
-							echo '<a href="javaScript:void(0)" class="password_preview dashicons dashicons-hidden" title="' . esc_attr__( 'Show Password', 'user-registration' ) . '"></a>';
+							echo '<a href="javaScript:void(0)" class="password_preview dashicons dashicons-hidden" title="' .
+							ur_string_translation( null, 'ur_show_password_attribute',
+							esc_attr__( 'Show Password', 'user-registration' ) ) . '"></a>';
 						}
 						?>
 						</span>
 					</p>
 					<?php } ?>
 					<p class="user-registration-form-row user-registration-form-row--wide form-row form-row-wide hide_show_password">
-						<label for="password_1"><?php _e( 'New password', 'user-registration' ); ?></label>
+						<label for="password_1"><?php echo ur_string_translation( null, 'ur_current_password_label',
+						__( 'New password', 'user-registration' ) ); ?></label>
 						<span class="password-input-group">
 						<input type="password" class="user-registration-Input user-registration-Input--password input-text" name="password_1" id="password_1" />
 						<?php
 						if ( 'yes' === get_option( 'user_registration_login_option_hide_show_password', 'no' ) ) {
-							echo '<a href="javaScript:void(0)" class="password_preview dashicons dashicons-hidden" title="' . esc_attr__( 'Show Password', 'user-registration' ) . '"></a>';
+							echo '<a href="javaScript:void(0)" class="password_preview dashicons dashicons-hidden" title="' .
+							ur_string_translation( null, 'ur_show_password_attribute',
+							esc_attr__( 'Show Password', 'user-registration' ) ) . '"></a>';
 						}
 						?>
 						</span>

--- a/templates/myaccount/form-edit-profile.php
+++ b/templates/myaccount/form-edit-profile.php
@@ -27,7 +27,7 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 		<div class="ur-form-row">
 			<div class="ur-form-grid">
 				<div class="user-registration-profile-fields">
-					<h2><?php _e( 'Profile Detail', 'user-registration' ); ?></h2>
+					<h2><?php echo ur_string_translation( null, 'ur_profile_details', esc_html__( 'Profile Detail', 'user-registration' ) ); ?></h2>
 					<div class="user-registration-profile-header">
 						<div class="user-registration-img-container" style="width:100%">
 							<?php
@@ -40,10 +40,10 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 							$max_size = wp_max_upload_size();
 							$max_size = size_format( $max_size );
 							?>
-							<p class="user-registration-tips"><?php echo __( 'Max size: ', 'user-registration' ) . $max_size; ?></p>
+							<p class="user-registration-tips"><?php echo  ur_string_translation( null, 'ur_max_size', esc_html__( 'Max size: ', 'user-registration' ) ) . $max_size; ?></p>
 						</div>
 						<header>
-								<p><strong><?php _e( 'Upload your new profile image.', 'user-registration' ); ?></strong></p>
+								<p><strong><?php echo  ur_string_translation( null, 'ur_upload_new_profile_picture', esc_html__( 'Upload your new profile image.', 'user-registration' )); ?></strong></p>
 							<div class="button-group">
 						<?php
 
@@ -65,11 +65,11 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 							?>
 						<input type="hidden" name="profile-pic-url" id="profile_pic_url" value="<?php echo $profile_picture_url; ?>" />
 						<input type="hidden" name="profile-default-image" value="<?php echo $gravatar_image; ?>" />
-						<button class="button profile-pic-remove" style="<?php echo ( $gravatar_image === $image ) ? 'display:none;' : ''; ?>"><?php echo __( 'Remove', 'user-registration' ); ?></php></button>
+						<button class="button profile-pic-remove" style="<?php echo ( $gravatar_image === $image ) ? 'display:none;' : ''; ?>"><?php echo ur_string_translation( null, 'ur_remove_profile_pic',  esc_html__( 'Remove', 'user-registration' ) ); ?></php></button>
 							<?php
 							if ( 'yes' === get_option( 'user_registration_ajax_form_submission_on_edit_profile', 'no' ) ) {
 								?>
-						<button type="button" class="button user_registration_profile_picture_upload hide-if-no-js" style="<?php echo ( $gravatar_image !== $image ) ? 'display:none;' : ''; ?>" ><?php echo __( 'Upload Picture', 'user-registration-advanced-fields' ); ?></button>
+						<button type="button" class="button user_registration_profile_picture_upload hide-if-no-js" style="<?php echo ( $gravatar_image !== $image ) ? 'display:none;' : ''; ?>" ><?php echo ur_string_translation( null, 'ur_upload_picture', esc_html__( 'Upload Picture', 'user-registration' ) ); ?></button>
 						<input type="file" id="ur-profile-pic" name="profile-pic" class="profile-pic-upload" accept="image/jpeg" style="display:none" />
 								<?php
 							} else {
@@ -83,7 +83,7 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 							<?php
 							if ( ! $profile_picture_url ) {
 								?>
-							<span><i><?php echo __( 'You can change your profile picture on', 'user-registration' ); ?> <a href="https://en.gravatar.com/"><?php _e( 'Gravatar', 'user-registration' ); ?></a></i></span>
+							<span><i><?php echo ur_string_translation( null, 'ur_profile_picture_message', __( 'You can change your profile picture on', 'user-registration' ) ); ?> <a href="https://en.gravatar.com/"><?php echo ur_string_translation( null, 'ur_gravatar', esc_html__( 'Gravatar', 'user-registration' ) ); ?></a></i></span>
 							<?php } ?>
 					</header>
 					</div>
@@ -225,12 +225,12 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 						<?php
 						if ( 'yes' === get_option( 'user_registration_ajax_form_submission_on_edit_profile', 'no' ) ) {
 							?>
-							<button type="submit" class="user-registration-submit-Button btn button <?php echo esc_attr( implode( ' ', $submit_btn_class ) ); ?>" name="save_account_details" ><span></span><?php esc_attr_e( 'Save changes', 'user-registration' ); ?></button>
+							<button type="submit" class="user-registration-submit-Button btn button <?php echo esc_attr( implode( ' ', $submit_btn_class ) ); ?>" name="save_account_details" ><span></span><?php echo ur_string_translation( null, 'ur_save_account_details', esc_attr__( 'Save changes', 'user-registration' ) ); ?></button>
 							<?php
 						} else {
 							wp_nonce_field( 'save_profile_details' );
 							?>
-							<input type="submit" class="user-registration-Button button <?php echo esc_attr( implode( ' ', $submit_btn_class ) ); ?>" name="save_account_details" value="<?php esc_attr_e( 'Save changes', 'user-registration' ); ?>" />
+							<input type="submit" class="user-registration-Button button <?php echo esc_attr( implode( ' ', $submit_btn_class ) ); ?>" name="save_account_details" value="<?php echo ur_string_translation( null, 'ur_save_account_details', esc_attr__( 'Save changes', 'user-registration' ) ); ?>" />
 							<input type="hidden" name="action" value="save_profile_details" />
 							<?php
 						}

--- a/templates/myaccount/form-login.php
+++ b/templates/myaccount/form-login.php
@@ -82,7 +82,8 @@ $hide_labels  = 'yes' === get_option( 'user_registration_login_options_hide_labe
 						<?php
 						if ( 'yes' === get_option( 'user_registration_login_option_hide_show_password', 'no' ) ) {
 							?>
-						<a href="javaScript:void(0)" class="password_preview dashicons dashicons-hidden" title="<?php echo __( 'Show password', 'user-registration' ); ?>"></a>
+						<a href="javaScript:void(0)" class="password_preview dashicons dashicons-hidden" title="<?php echo ur_string_translation( null, 'ur_show_password_attribute',
+							esc_attr__( 'Show Password', 'user-registration' ) ); ?>"></a>
 							<?php
 						}
 						?>

--- a/templates/myaccount/form-lost-password.php
+++ b/templates/myaccount/form-lost-password.php
@@ -26,10 +26,10 @@ ur_print_notices(); ?>
 	<form method="post" class="user-registration-ResetPassword lost_reset_password">
 		<div class="ur-form-row">
 			<div class="ur-form-grid">
-				<p><?php echo apply_filters( 'user_registration_lost_password_message', __( 'Lost your password? Please enter your username or email address. You will receive a link to create a new password via email.', 'user-registration' ) ); ?></p>
+				<p><?php echo  ur_string_translation( null, 'ur_lost_password_message',  apply_filters( 'user_registration_lost_password_message', __( 'Lost your password? Please enter your username or email address. You will receive a link to create a new password via email.', 'user-registration' ) ) ); ?></p>
 
 				<p class="user-registration-form-row user-registration-form-row--first form-row form-row-first">
-					<label for="user_login"><?php _e( 'Username or email', 'user-registration' ); ?></label>
+					<label for="user_login"><?php echo  ur_string_translation( null, 'ur_lost_password_username', esc_html__( 'Username or email', 'user-registration' ) ); ?></label>
 					<input class="user-registration-Input user-registration-Input--text input-text" type="text" name="user_login" id="user_login" />
 				</p>
 
@@ -39,7 +39,7 @@ ur_print_notices(); ?>
 
 				<p class="user-registration-form-row form-row">
 					<input type="hidden" name="ur_reset_password" value="true" />
-					<input type="submit" class="user-registration-Button button" value="<?php esc_attr_e( 'Reset password', 'user-registration' ); ?>" />
+					<input type="submit" class="user-registration-Button button" value="<?php echo  ur_string_translation( null, 'ur_reset_password_button', esc_attr__( 'Reset password', 'user-registration' ) ); ?>" />
 				</p>
 
 				<?php wp_nonce_field( 'lost_password' ); ?>

--- a/templates/myaccount/form-reset-password.php
+++ b/templates/myaccount/form-reset-password.php
@@ -26,14 +26,14 @@ ur_print_notices(); ?>
 <form method="post" class="user-registration-ResetPassword lost_reset_password" data-enable-strength-password="<?php echo $enable_strong_password; ?>" data-minimum-password-strength="<?php echo $minimum_password_strength; ?>">
 		<div class="ur-form-row">
 			<div class="ur-form-grid">
-				<p><?php echo apply_filters( 'user_registration_reset_password_message', __( 'Enter a new password below.', 'user-registration' ) ); ?></p>
+				<p><?php echo ur_string_translation( null, 'ur_reset_password_message', apply_filters( 'user_registration_reset_password_message', __( 'Enter a new password below.', 'user-registration' ) ) ); ?></p>
 
 				<p class="user-registration-form-row user-registration-form-row--first form-row form-row-first">
-					<label for="password_1"><?php _e( 'New password', 'user-registration' ); ?> <span class="required">*</span></label>
+					<label for="password_1"><?php echo ur_string_translation( null, 'ur_reset_new_password', esc_html__( 'New password', 'user-registration' ) ); ?> <span class="required">*</span></label>
 					<input type="password" class="user-registration-Input user-registration-Input--text input-text" name="password_1" id="password_1" />
 				</p>
 				<p class="user-registration-form-row user-registration-form-row--last form-row form-row-last">
-					<label for="password_2"><?php _e( 'Re-enter new password', 'user-registration' ); ?> <span class="required">*</span></label>
+					<label for="password_2"><?php echo ur_string_translation( null, 'ur_reset_reenter_password', esc_html__( 'Re-enter new password', 'user-registration' ) ); ?> <span class="required">*</span></label>
 					<input type="password" class="user-registration-Input user-registration-Input--text input-text" name="password_2" id="password_2" />
 				</p>
 
@@ -46,7 +46,7 @@ ur_print_notices(); ?>
 
 				<p class="user-registration-form-row form-row">
 					<input type="hidden" name="ur_reset_password" value="true" />
-					<input type="submit" class="user-registration-Button button" value="<?php esc_attr_e( 'Save', 'user-registration' ); ?>" />
+					<input type="submit" class="user-registration-Button button" value="<?php echo ur_string_translation( null, 'ur_reset_password_save_button', esc_attr__( 'Save', 'user-registration' ) ); ?>" />
 				</p>
 
 				<?php wp_nonce_field( 'reset_password' ); ?>

--- a/templates/myaccount/lost-password-confirmation.php
+++ b/templates/myaccount/lost-password-confirmation.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 ur_print_notices();
-ur_print_notice( __( 'Password reset email has been sent.', 'user-registration' ) );
+ur_print_notice( ur_string_translation( null, 'ur_reset_password_sent_notice', __( 'Password reset email has been sent.', 'user-registration' ) ) );
 ?>
 
-<p><?php echo apply_filters( 'user_registration_lost_password_message', __( 'A password reset email has been sent to the email address on file for your account, but may take several minutes to show up in your inbox. Please wait at least 10 minutes before attempting another reset.', 'user-registration' ) ); ?></p>
+<p><?php echo ur_string_translation( null, 'ur_reset_password_sent_message', apply_filters( 'user_registration_lost_password_message', __( 'A password reset email has been sent to the email address on file for your account, but may take several minutes to show up in your inbox. Please wait at least 10 minutes before attempting another reset.', 'user-registration' ) ) ); ?></p>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changes proposed in this Pull Request:
This PR covers all static strings which need to be translated in the frontend via WPML Plugin.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Visit site and check all screnaio like validation, success message, profile menu, dashboard content, password strenght button name, change password content, reset password content.
2. All above content strings must show in string translation list in user-registration domain.
3. Try to translate in different languages and check whether it's working or not.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - WPML compatibility for static strings
