### PR TITLE
Tweak - Hide unrelated admin notices from settings page

### DIFF
--- a/includes/admin/class-ur-admin-notices.php
+++ b/includes/admin/class-ur-admin-notices.php
@@ -165,7 +165,8 @@ class UR_Admin_Notices {
 		$pages_to_exclude = array(
 			'add-new-registration',
 			'user-registration-settings',
-			'user-registration-email-templates'
+			'user-registration-email-templates',
+			'user-registration-mailchimp'
 		);
 
 		// Return on other than user registraion builder page.

--- a/includes/admin/class-ur-admin-notices.php
+++ b/includes/admin/class-ur-admin-notices.php
@@ -161,8 +161,14 @@ class UR_Admin_Notices {
 	public static function hide_unrelated_notices() {
 		global $wp_filter;
 
+		// Array to define pages where notices are to be excluded.
+		$pages_to_exclude = array(
+			'add-new-registration',
+			'user-registration-settings',
+		);
+
 		// Return on other than user registraion builder page.
-		if ( empty( $_REQUEST['page'] ) || 'add-new-registration' !== $_REQUEST['page'] ) {
+		if ( empty( $_REQUEST['page'] ) || ! in_array( $_REQUEST['page'], $pages_to_exclude ) ) {
 			return;
 		}
 
@@ -170,7 +176,16 @@ class UR_Admin_Notices {
 			if ( ! empty( $wp_filter[ $wp_notice ]->callbacks ) && is_array( $wp_filter[ $wp_notice ]->callbacks ) ) {
 				foreach ( $wp_filter[ $wp_notice ]->callbacks as $priority => $hooks ) {
 					foreach ( $hooks as $name => $arr ) {
-						unset( $wp_filter[ $wp_notice ]->callbacks[ $priority ][ $name ] );
+
+						// Remove all notices if the page is form builder page.
+						if ( 'add-new-registration' === $_REQUEST['page'] ) {
+							unset( $wp_filter[ $wp_notice ]->callbacks[ $priority ][ $name ] );
+						} else {
+							// Remove all notices except user registration plugins notices.
+							if ( ! strpos( $name, 'user_registation_missing_notice' ) ) {
+								unset( $wp_filter[ $wp_notice ]->callbacks[ $priority ][ $name ] );
+							}
+						}
 					}
 				}
 			}

--- a/includes/admin/class-ur-admin-notices.php
+++ b/includes/admin/class-ur-admin-notices.php
@@ -165,6 +165,7 @@ class UR_Admin_Notices {
 		$pages_to_exclude = array(
 			'add-new-registration',
 			'user-registration-settings',
+			'user-registration-email-templates'
 		);
 
 		// Return on other than user registraion builder page.
@@ -182,7 +183,7 @@ class UR_Admin_Notices {
 							unset( $wp_filter[ $wp_notice ]->callbacks[ $priority ][ $name ] );
 						} else {
 							// Remove all notices except user registration plugins notices.
-							if ( ! strpos( $name, 'user_registation_missing_notice' ) ) {
+							if ( ! strstr( $name, 'user_registration_' ) ) {
 								unset( $wp_filter[ $wp_notice ]->callbacks[ $priority ][ $name ] );
 							}
 						}

--- a/includes/admin/class-ur-admin-user-list-manager.php
+++ b/includes/admin/class-ur-admin-user-list-manager.php
@@ -29,8 +29,8 @@ class UR_Admin_User_List_Manager {
 
 		// -------------------- ACTIONS & FILTERS --------------------
 		add_action( 'load-users.php', array( $this, 'trigger_query_actions' ) );
-		add_action( 'admin_notices', array( $this, 'display_admin_notices' ), 99 );
-		add_action( 'admin_notices', array( $this, 'pending_users_notices' ) );
+		add_action( 'admin_notices', array( $this, 'user_registration_display_admin_notices' ), 99 );
+		add_action( 'admin_notices', array( $this, 'user_registration_pending_users_notices' ) );
 
 		// Functions about users listing.
 		add_action( 'restrict_manage_users', array( $this, 'add_status_filter' ) );
@@ -138,7 +138,7 @@ class UR_Admin_User_List_Manager {
 	}
 
 	// Display a notice to admin notifying the pending users.
-	public function pending_users_notices() {
+	public function user_registration_pending_users_notices() {
 		$user_query = new WP_User_Query(
 			array(
 				'meta_key'   => 'ur_user_status',
@@ -154,9 +154,20 @@ class UR_Admin_User_List_Manager {
 	}
 
 	/**
+	 * Deprecates old plugin missing notice.
+	 *
+	 * @deprecated 1.9.0
+	 *
+	 * @return void
+	*/
+	public function pending_users_notices() {
+		ur_deprecated_function( 'UR_Admin_User_List_Manager::pending_users_notices', '1.9.0', 'UR_Admin_User_List_Manager::user_registration_pending_users_notices' );
+	}
+
+	/**
 	 * Display a notice to admin if some users have been approved or denied
 	 */
-	public function display_admin_notices() {
+	public function user_registration_display_admin_notices() {
 		$screen = get_current_screen();
 
 		if ( $screen->id != 'users' ) {
@@ -176,6 +187,17 @@ class UR_Admin_User_List_Manager {
 		if ( ! empty( $message ) ) {
 			echo '<div id="user-approvation-result" class="notice notice-success is-dismissible"><p><strong>' . $message . '</strong></p></div>';
 		}
+	}
+
+	/**
+	 * Deprecates old plugin missing notice.
+	 *
+	 * @deprecated 1.9.0
+	 *
+	 * @return void
+	*/
+	public function display_admin_notices() {
+		ur_deprecated_function( 'UR_Admin_User_List_Manager::display_admin_notices', '1.9.0', 'UR_Admin_User_List_Manager::user_registration_display_admin_notices' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR hides unrelated admin notices from the User Registration Settings page and only displays our plugin's important notices.

### How to test the changes in this Pull Request:

1. After switching to this branch visit the User Registration Settings page.
2. There you can see only our plugin and its addons notices are shown and all other plugins notices are not displayed.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Hide unrelated admin notices from the settings page.