### PR TITLE
Fix - Export users fails due to form name with dash.

### DIFF
--- a/includes/admin/class-ur-admin-export-users.php
+++ b/includes/admin/class-ur-admin-export-users.php
@@ -73,7 +73,9 @@ class UR_Admin_Export_Users {
 		$columns = $this->generate_columns( $form_id );
 		$rows    = $this->generate_rows( $users, $form_id );
 
-		$form_name = strtolower( str_replace( ' ', '-', get_the_title( $form_id ) ) );
+		$form_name = str_replace( ' &#8211; ', '-', get_the_title( $form_id ) );
+		$form_name = str_replace( '&#8211;', '-', $form_name );
+		$form_name = strtolower( str_replace( ' ', '-', $form_name) );
 		$file_name = $form_name . '-' . current_time( 'Y-m-d_H:i:s' ) . '.csv';
 
 		if ( ob_get_contents() ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR fixes the form name with ( - ) dash causes export user not working.

### How to test the changes in this Pull Request:

1. Create a form with a form name such as "Application - Form ".
2. Now try to export the user with this form. You will notice that the downloaded file is not in CSV format. This issue is fixed in this PR.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Export users fail due to form name with a dash.
