### PR TITLE
Fix - Hide/Show password conflict with form re-initialization

### DIFF
--- a/assets/js/frontend/user-registration.js
+++ b/assets/js/frontend/user-registration.js
@@ -1538,64 +1538,6 @@
 				});
 			}
 		});
-
-		$(document).on("click", ".password_preview", function (e) {
-			e.preventDefault();
-			var current_task = $(this).hasClass("dashicons-hidden")
-				? "show"
-				: "hide";
-			var $password_field = $(this)
-				.closest(".user-registration-form-row")
-				.find('input[name="password"]');
-
-			// Hide/show password for user registration form
-			if ($password_field.length === 0) {
-				$password_field = $(this)
-					.closest(".field-user_pass")
-					.find('input[name="user_pass"]');
-			}
-			if ($password_field.length === 0) {
-				$password_field = $(this)
-					.closest(".field-user_confirm_password")
-					.find('input[name="user_confirm_password"]');
-			}
-
-			// Hide/show password for edit password form
-			if ($password_field.length === 0) {
-				$password_field = $(this)
-					.closest(".user-registration-form-row")
-					.find('input[name="password_current"]');
-			}
-			if ($password_field.length === 0) {
-				$password_field = $(this)
-					.closest(".user-registration-form-row")
-					.find('input[name="password_1"]');
-			}
-			if ($password_field.length === 0) {
-				$password_field = $(this)
-					.closest(".user-registration-form-row")
-					.find('input[name="password_2"]');
-			}
-
-			if ($password_field.length > 0) {
-				switch (current_task) {
-					case "show":
-						$password_field.attr("type", "text");
-						$(this)
-							.removeClass("dashicons-hidden")
-							.addClass("dashicons-visibility");
-						$(this).attr("title", ursL10n.hide_password_title);
-						break;
-					case "hide":
-						$password_field.attr("type", "password");
-						$(this)
-							.removeClass("dashicons-visibility")
-							.addClass("dashicons-hidden");
-						$(this).attr("title", ursL10n.show_password_title);
-						break;
-				}
-			}
-		});
 	};
 
 	user_registration_form_init();
@@ -1694,3 +1636,65 @@ function ur_includes(arr, item) {
 	}
 	return false;
 }
+
+(function ($) {
+	$(document).on("click", ".password_preview", function (e) {
+		e.preventDefault();
+		var ursL10n = user_registration_params.ursL10n;
+
+		var current_task = $(this).hasClass("dashicons-hidden")
+			? "show"
+			: "hide";
+		var $password_field = $(this)
+			.closest(".user-registration-form-row")
+			.find('input[name="password"]');
+
+		// Hide/show password for user registration form
+		if ($password_field.length === 0) {
+			$password_field = $(this)
+				.closest(".field-user_pass")
+				.find('input[name="user_pass"]');
+		}
+		if ($password_field.length === 0) {
+			$password_field = $(this)
+				.closest(".field-user_confirm_password")
+				.find('input[name="user_confirm_password"]');
+		}
+
+		// Hide/show password for edit password form
+		if ($password_field.length === 0) {
+			$password_field = $(this)
+				.closest(".user-registration-form-row")
+				.find('input[name="password_current"]');
+		}
+		if ($password_field.length === 0) {
+			$password_field = $(this)
+				.closest(".user-registration-form-row")
+				.find('input[name="password_1"]');
+		}
+		if ($password_field.length === 0) {
+			$password_field = $(this)
+				.closest(".user-registration-form-row")
+				.find('input[name="password_2"]');
+		}
+
+		if ($password_field.length > 0) {
+			switch (current_task) {
+				case "show":
+					$password_field.attr("type", "text");
+					$(this)
+						.removeClass("dashicons-hidden")
+						.addClass("dashicons-visibility");
+					$(this).attr("title", ursL10n.hide_password_title);
+					break;
+				case "hide":
+					$password_field.attr("type", "password");
+					$(this)
+						.removeClass("dashicons-visibility")
+						.addClass("dashicons-hidden");
+					$(this).attr("title", ursL10n.show_password_title);
+					break;
+			}
+		}
+	});
+})(jQuery);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
After the release of v1.9.0, the hide/show icon in the password field stopped working. This PR fixes this issue.

### How to test the changes in this Pull Request:

1. Enable hide/show password setting.
2. Navigate to the registration form in the front end and verify whether or not the hide/show icon in the password field is working properly.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Hide/Show password conflict with form re-initialization.
