### PR TITLE
Fix - Scroll to the first error message on form submit

### DIFF
--- a/assets/js/frontend/user-registration.js
+++ b/assets/js/frontend/user-registration.js
@@ -144,6 +144,15 @@
 						validClass: "user-registration-valid",
 						rules: rules,
 						messages: messages,
+						focusInvalid: false,
+						invalidHandler: function (form, validator) {
+							if (!validator.numberOfInvalids()) return;
+
+							// Scroll to first error message on submit..
+							$(window).scrollTop(
+								$(validator.errorList[0].element).offset().top
+							);
+						},
 						errorPlacement: function (error, element) {
 							if (element.is("#password_2")) {
 								element.parent().after(error);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The jquery validate automatic scroll to the first error message on the form submission is not working properly. This PR fixes this issue.

### How to test the changes in this Pull Request:

1. Without filling any fields submit the registration form having one or more required fields.
2. After clicking the submit button, the screen should be scrolled to the first error message position.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Scroll to the first error message on form submit.
