### PR TITLE
Tweak - Prevent core login for woocommerce shortcode

### DIFF
--- a/includes/frontend/class-ur-frontend.php
+++ b/includes/frontend/class-ur-frontend.php
@@ -101,9 +101,15 @@ class UR_Frontend {
 
 		if ( ! empty( $login_page ) ) {
 			$matched = preg_match( '/\[user_registration_my_account(\s\S+){0,3}\]|\[user_registration_login(\s\S+){0,3}\]/', $login_page->post_content );
+			if(1 > absint( $matched )) {
+				$matched = preg_match( '/\[woocommerce_my_account(\s\S+){0,3}\]/', $login_page->post_content );
+			}
 			$page_id = $login_page->ID;
 		} elseif ( ! empty( $myaccount_page ) ) {
 			$matched = preg_match( '/\[user_registration_my_account(\s\S+){0,3}\]|\[user_registration_login(\s\S+){0,3}\]/', $myaccount_page->post_content );
+			if(1 > absint( $matched )) {
+				$matched = preg_match( '/\[woocommerce_my_account(\s\S+){0,3}\]/', $myaccount_page->post_content );
+			}
 			$page_id = $myaccount_page->ID;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When we enable prevent core login there we need to provide a my-account page, so how we can redirect to that myaccount page when trying to visit wp-login.php
But, If we use woocommerce myaccount instead of user-registration-myaccount then it will not redirect.
This PR fixes this issue.

### How to test the changes in this Pull Request:

1. In our settings Select Login Page with woocommerce my-account shortcode. 
2. Now visit wp-login.php URL here WordPress will redirect to your login page.

Note: Allows on User Registration and Woocommerce my-account shortcodes.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Prevent core login for woocommerce myaccount shortcode
