### PR TITLE
Fix - Form Duplication issue with anchor tag

### DIFF
--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -577,6 +577,7 @@ class UR_Form_Handler {
 
 			if ( $the_post && 'user_registration' === $the_post->post_type ) {
 				$the_post->post_content = str_replace( '"noopener noreferrer"', "'noopener noreferrer'", $the_post->post_content );
+				$the_post->post_content = str_replace( '"noopener"', "'noopener'", $the_post->post_content );
 
 				if ( isset( $args['publish'] ) ) {
 					if ( ( $args['publish'] && 'publish' === $the_post->post_type ) || ( ! $args['publish'] && 'publish' !== $the_post->post_type ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes, Form Duplication and Importing Form resulting empty/blank form. This issue occurs when we use anchor tag<a> tag in the description of any fields OR in HTML fields.  

### How to test the changes in this Pull Request:

1. Goto Form Builder in the description add a description with the anchor tag and save the form.
2. Now try to duplicate that form and see the result. All Fields must show.
3. Another way to Test this is to export the form and again try to import the same form. All fields must show.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Form Duplication issue with an anchor tag
