### PR TITLE
Fix - WYSIWYG field value save and sanitization in edit-profile

### DIFF
--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -221,6 +221,13 @@ class UR_AJAX {
 						$single_field[ $key ] = ( json_decode( $single_field[ $key ] ) !== null ) ? json_decode( $single_field[ $key ] ) : $single_field[ $key ];
 					}
 					break;
+				case 'wysiwyg' :
+					if ( isset($single_field[ $key ] ) ) {
+						$single_field[ $key ] = sanitize_text_field( htmlentities( $single_field[ $key ] ) );
+					} else {
+						$single_field[ $key ] = '';
+					}
+					break;
 				default:
 					$single_field[ $key ] = isset( $single_field[ $key ] ) ? ur_clean( $single_field[ $key ] ) : '';
 					break;

--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -135,6 +135,7 @@ class UR_Form_Handler {
 			if ( ! isset( $field['type'] ) ) {
 				$field['type'] = 'text';
 			}
+
 			// Get Value.
 			switch ( $field['type'] ) {
 				case 'checkbox':
@@ -144,6 +145,14 @@ class UR_Form_Handler {
 						$_POST[ $key ] = (int) isset( $_POST[ $key ] );
 					}
 					break;
+				case 'wysiwyg' :
+					if ( isset( $_POST[ $key ] ) ) {
+						$_POST[ $key ] = sanitize_text_field( htmlentities( $_POST[$key] ) );
+					} else {
+						$_POST[ $key ] = '';
+					}
+					break;
+
 				default:
 					$_POST[ $key ] = isset( $_POST[ $key ] ) ? ur_clean( $_POST[ $key ] ) : '';
 					break;
@@ -191,13 +200,13 @@ class UR_Form_Handler {
 					}
 				}
 			}
+
 		}// End foreach().
 
 		do_action( 'user_registration_after_save_profile_validation', $user_id, $profile );
 
 		if ( 0 === ur_notice_count( 'error' ) ) {
 			$user_data = array();
-
 			foreach ( $profile as $key => $field ) {
 				$new_key = str_replace( 'user_registration_', '', $key );
 
@@ -217,6 +226,8 @@ class UR_Form_Handler {
 					$disabled = isset( $field['custom_attributes']['disabled'] ) ? $field['custom_attributes']['disabled'] : '';
 
 					if ( $disabled !== 'disabled' ) {
+						// error_log( print_r( $_POST[ $key ], true ) );
+
 						update_user_meta( $user_id, $update_key, $_POST[ $key ] );
 					}
 				}

--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -226,8 +226,6 @@ class UR_Form_Handler {
 					$disabled = isset( $field['custom_attributes']['disabled'] ) ? $field['custom_attributes']['disabled'] : '';
 
 					if ( $disabled !== 'disabled' ) {
-						// error_log( print_r( $_POST[ $key ], true ) );
-
 						update_user_meta( $user_id, $update_key, $_POST[ $key ] );
 					}
 				}

--- a/includes/frontend/class-ur-frontend-form-handler.php
+++ b/includes/frontend/class-ur-frontend-form-handler.php
@@ -335,6 +335,8 @@ class UR_Frontend_Form_Handler {
 
 				if ( isset( $data->extra_params['field_key'] ) && ( $data->extra_params['field_key'] === 'checkbox' || $data->extra_params['field_key'] === 'learndash_course' ) ) {
 					$data->value = ( json_decode( $data->value ) !== null ) ? json_decode( $data->value ) : $data->value;
+				} else if( isset( $data->extra_params['field_key'] ) && ( $data->extra_params['field_key'] === 'wysiwyg' ) ) {
+					$data->value = sanitize_text_field( htmlentities( $data->value ) );
 				}
 				update_user_meta( $user_id, $field_name, $data->value );
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously when the WYSIWYG field value is updated from the edit profile page, the updated values do not reflect the input value. This PR fixes this issue and tends to sanitize HTML elements entered in the WYSIWYG field.

### How to test the changes in this Pull Request:

1. Register a user using the WYSIWYG field.
2. Visit the edit profile page and try to update the WYSIWYG field value.
3. After the update check whether the updated values are correct.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - WYSIWYG field value save and sanitization in edit-profile.
