### PR TITLE
Fix - Disable logout confirmation issue with logout endpoint menu

### DIFF
--- a/includes/functions-ur-page.php
+++ b/includes/functions-ur-page.php
@@ -150,6 +150,13 @@ function ur_nav_menu_items( $items ) {
 			}
 		}
 	}
+	$customer_logout = get_option( 'user_registration_logout_endpoint', 'user-logout' );
+
+	foreach( $items as $item ) {
+    if( $item->title == "Logout" && $customer_logout && 'yes' === get_option( 'user_registration_disable_logout_confirmation', 'no' ) ) {
+         $item->url = wp_nonce_url(  $item->url, 'user-logout' );
+    }
+  }
 
 	return $items;
 }

--- a/includes/functions-ur-page.php
+++ b/includes/functions-ur-page.php
@@ -153,7 +153,7 @@ function ur_nav_menu_items( $items ) {
 	$customer_logout = get_option( 'user_registration_logout_endpoint', 'user-logout' );
 
 	foreach( $items as $item ) {
-    if( $item->title == "Logout" && $customer_logout && 'yes' === get_option( 'user_registration_disable_logout_confirmation', 'no' ) ) {
+    if( ! empty( $customer_logout )  && 'yes' === get_option( 'user_registration_disable_logout_confirmation', 'no' ) ) {
          $item->url = wp_nonce_url(  $item->url, 'user-logout' );
     }
   }


### PR DESCRIPTION

### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Previously, there was a issue when the user click in disable logout confirmation the confirmation message is showing, PR solve the issue when the user click in disable logout confirmation the confirmation message is not showing.

### How to test the changes in this Pull Request:

1.Go to Settings > General > My account Section
2.Check the Disable logout confirmation option.
3.Now go to my account page and click on the Logout endpoint. You should be directly logged out.
4.Now uncheck the option
5.Try to logout again. Logout confirmation message should show up.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Issue- Option to disable logout confirmation
