### PR TITLE
Enhance - Password strength meter in reset

### DIFF
--- a/assets/js/frontend/password-strength-meter.js
+++ b/assets/js/frontend/password-strength-meter.js
@@ -12,7 +12,7 @@ jQuery(function ($) {
 			var $this = this;
 			$(document.body).on(
 				"keyup change",
-				'input[name="user_pass"], .user-registration-EditAccountForm input[name="password_1"], input[name="password_1"].user-registration-Input--password',
+				'input[name="user_pass"], .user-registration-EditAccountForm input[name="password_1"], input[name="password_1"].user-registration-Input--password,.user-registration-ResetPassword input[name="password_1"]',
 				function () {
 					var enable_strength_password = $(this)
 						.closest("form")
@@ -32,6 +32,7 @@ jQuery(function ($) {
 			var wrapper = self.closest("form"),
 				field = $(self, wrapper);
 
+
 			ur_password_strength_meter.includeMeter(wrapper, field);
 			ur_password_strength_meter.checkPasswordStrength(wrapper, field);
 		},
@@ -47,7 +48,9 @@ jQuery(function ($) {
 				"data-minimum-password-strength"
 			);
 
+
 			var meter = wrapper.find(".user-registration-password-strength");
+
 			var password_field = wrapper.find(".password-input-group");
 			if ("" === field.val()) {
 				meter.remove();

--- a/includes/functions-ur-page.php
+++ b/includes/functions-ur-page.php
@@ -150,6 +150,13 @@ function ur_nav_menu_items( $items ) {
 			}
 		}
 	}
+	$customer_logout = get_option( 'user_registration_logout_endpoint', 'user-logout' );
+
+	foreach( $items as $item ) {
+    if( $item->title == "Logout" && $customer_logout && 'yes' === get_option( 'user_registration_disable_logout_confirmation', 'no' ) ) {
+         $item->url = wp_nonce_url(  $item->url, 'user-logout' );
+    }
+  }
 
 	return $items;
 }

--- a/templates/myaccount/form-reset-password.php
+++ b/templates/myaccount/form-reset-password.php
@@ -28,7 +28,7 @@ ur_print_notices(); ?>
 			<div class="ur-form-grid">
 				<p><?php echo apply_filters( 'user_registration_reset_password_message', __( 'Enter a new password below.', 'user-registration' ) ); ?></p>
 
-				<p class="user-registration-form-row user-registration-form-row--first form-row form-row-first">
+				<p class="user-registration-form-row user-registration-form-row--first form-row form-row-first password-input-group">
 					<label for="password_1"><?php _e( 'New password', 'user-registration' ); ?> <span class="required">*</span></label>
 					<input type="password" class="user-registration-Input user-registration-Input--text input-text" name="password_1" id="password_1" />
 				</p>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously, there was no weakness validation in password reset field. This  PR provides functionality to check the weakness of password.


### How to test the changes in this Pull Request:

1.Click on the Lost password using the my account page.
2.Enter the email to receive the link password reset page
3.Chek your email and click on the link. 

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?



### Changelog entry

> Enhance-password strength meter in reset