### PR TITLE
Fix - Reset password button not working

### DIFF
--- a/assets/js/frontend/user-registration-form-validator.js
+++ b/assets/js/frontend/user-registration-form-validator.js
@@ -4,10 +4,6 @@
 
 	user_registration_form_selector = $(".ur-frontend-form form");
 
-	if (user_registration_form_selector.hasClass("login")) {
-		return;
-	}
-
 	var field_selector = "";
 
 	if (user_registration_form_selector.hasClass("edit-profile")) {
@@ -209,13 +205,14 @@
 					},
 					submitHandler: function (form) {
 						/**
-						 * Return `true` for `Change Password` form and `Edit Profile` when ajax submission is off to allow submission
+						 * Return `true` for `Change Password`, `login` form and `Edit Profile` when ajax submission is off to allow submission
 						 */
 						if (
 							$(form).hasClass("edit-password") ||
 							($(form).hasClass("edit-profile") &&
 								"no" ===
-									user_registration_params.ajax_submission_on_edit_profile)
+									user_registration_params.ajax_submission_on_edit_profile) ||
+							$(form).hasClass("login")
 						) {
 							return true;
 						}

--- a/assets/js/frontend/user-registration-form-validator.js
+++ b/assets/js/frontend/user-registration-form-validator.js
@@ -212,7 +212,9 @@
 							($(form).hasClass("edit-profile") &&
 								"no" ===
 									user_registration_params.ajax_submission_on_edit_profile) ||
-							$(form).hasClass("login")
+							$(form)
+								.hasClass("login")
+								.not(".lost_reset_password")
 						) {
 							return true;
 						}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously when separate login and registration form shortcode used on the same page, then if the page is set as default my account page, then when we try to reset the password then the reset button doesn't work. This PR fixes this issue.

### How to test the changes in this Pull Request:

1. Use separate login and registration shortcodes on the same page and set this page as default my account page from settings.
2. Navigate to the page and click on lost password.
3. When the lost password page appears, verify whether or not the reset button is working.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Reset password button not working
