### PR TITLE
Fix - Hide label in edit profile

### DIFF
--- a/templates/myaccount/form-edit-profile.php
+++ b/templates/myaccount/form-edit-profile.php
@@ -111,6 +111,7 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 									}
 
 									foreach ( $grid_data as $grid_data_key => $single_item ) {
+
 										$key = 'user_registration_' . $single_item->general_setting->field_name;
 										if ( isset( $profile[ $key ] ) ) {
 											// If the conditional logic addon is installed.
@@ -185,6 +186,10 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 													if ( 'smart' === $field['phone_format'] ) {
 														unset( $field['input_mask'] );
 													}
+												}
+
+												if( 'yes' === $single_item->general_setting->hide_label ) {
+													unset( $field['label'] );
 												}
 
 												if ( 'select' === $single_item->field_key ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously when hide label was enabled it only worked on registration form but not in edit profile section of My Account. This PR fixes this issue

### How to test the changes in this Pull Request:
1. Navigate to the form builder. Select on any field and in the field options section enable hide label option.
2. Navigate to the registration form and the label of a specific field will be hidden by default.
3. Now navigate to the edit profile section of my account and see if the label is hidden there as well.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Hide label in edit profile.
