### PR TITLE
Fix- Reset password currently accepts same old password

### DIFF
--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -515,6 +515,9 @@ class UR_Form_Handler {
 				ur_add_notice( __( 'Passwords do not match.', 'user-registration' ), 'error' );
 			}
 
+			if ( wp_check_password( $posted_fields['password_1'], $user->user_pass, $user->ID ) ) {
+				ur_add_notice( __( 'New password must not be same as old password.', 'user-registration' ), 'error' );
+			}
 			$errors = new WP_Error();
 
 			do_action( 'validate_password_reset', $errors, $user );

--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -300,6 +300,9 @@ class UR_Form_Handler {
 		} elseif ( ! $bypass_current_password && ! wp_check_password( $pass_cur, $current_user->user_pass, $current_user->ID ) ) {
 			ur_add_notice( __( 'Your current password is incorrect.', 'user-registration' ), 'error' );
 			$save_pass = false;
+		} elseif ( wp_check_password($pass1, $current_user->user_pass,$current_user->ID) && $current_user ) {
+			ur_add_notice( __( 'New password must not be same as old password' ), 'error' );
+			$save_pass = false;
 		}
 
 		if ( $pass1 && $save_pass ) {

--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -301,7 +301,7 @@ class UR_Form_Handler {
 			ur_add_notice( __( 'Your current password is incorrect.', 'user-registration' ), 'error' );
 			$save_pass = false;
 		} elseif ( wp_check_password($pass1, $current_user->user_pass,$current_user->ID) && $current_user ) {
-			ur_add_notice( __( 'New password must not be same as old password' ), 'error' );
+			ur_add_notice( __( 'New password must not be same as old password', 'user-registration' ), 'error' );
 			$save_pass = false;
 		}
 

--- a/templates/myaccount/form-reset-password.php
+++ b/templates/myaccount/form-reset-password.php
@@ -28,13 +28,27 @@ ur_print_notices(); ?>
 			<div class="ur-form-grid">
 				<p><?php echo apply_filters( 'user_registration_reset_password_message', __( 'Enter a new password below.', 'user-registration' ) ); ?></p>
 
-				<p class="user-registration-form-row user-registration-form-row--first form-row form-row-first password-input-group">
+				<p class="user-registration-form-row user-registration-form-row--wide form-row form-row-wide hide_show_password">
 					<label for="password_1"><?php _e( 'New password', 'user-registration' ); ?> <span class="required">*</span></label>
+					<span class="password-input-group">
 					<input type="password" class="user-registration-Input user-registration-Input--text input-text" name="password_1" id="password_1" />
+					<?php
+						if ( 'yes' === get_option( 'user_registration_login_option_hide_show_password', 'no' ) ) {
+							echo '<a href="javaScript:void(0)" class="password_preview dashicons dashicons-hidden" title="' . esc_attr__( 'Show Password', 'user-registration' ) . '"></a>';
+						}
+					?>
+					</span>
 				</p>
-				<p class="user-registration-form-row user-registration-form-row--last form-row form-row-last">
+				<p class="user-registration-form-row user-registration-form-row--wide form-row form-row-wide hide_show_password">
 					<label for="password_2"><?php _e( 'Re-enter new password', 'user-registration' ); ?> <span class="required">*</span></label>
+					<span class="password-input-group">
 					<input type="password" class="user-registration-Input user-registration-Input--text input-text" name="password_2" id="password_2" />
+					<?php
+						if ( 'yes' === get_option( 'user_registration_login_option_hide_show_password', 'no' ) ) {
+							echo '<a href="javaScript:void(0)" class="password_preview dashicons dashicons-hidden" title="' . esc_attr__( 'Show Password', 'user-registration' ) . '"></a>';
+						}
+					?>
+					</span>
 				</p>
 
 				<input type="hidden" name="reset_key" value="<?php echo esc_attr( $args['key'] ); ?>" />


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
When we try to reset the password using 'forgot/lost your password?' the same old password is accepted without any notice as well as in the change password of my Account section. 

### How to test the changes in this Pull Request:

1. Navigate to my Account section and navigate to forgot/lost your password?.
2. Now you are asked to enter your username/email and click on reset password. 
3. Now you will receive a password reset email in your registered email address and when you click on the click here link.
4. Now Enter new password page appears and when you try to enter the same old password as a new password error message appears your new password must not be the same as the old password.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Reset password currently accepts same old password.
