### PR TITLE
Enhance - Reset Button in UR Form

### DIFF
--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -189,7 +189,6 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 
 		$args = wp_parse_args( $args, $defaults );
 		$args = apply_filters( 'user_registration_form_field_args', $args, $key, $value );
-		
 
 		if ( true === $args['required'] ) {
 			$args['class'][] = 'validate-required';
@@ -201,8 +200,6 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 		if ( is_null( $value ) || empty($value)) {
 			$value = $args['default'];
 		}
-
-
 
 		// Custom attribute handling
 		$custom_attributes         = array();

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -189,7 +189,7 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 
 		$args = wp_parse_args( $args, $defaults );
 		$args = apply_filters( 'user_registration_form_field_args', $args, $key, $value );
-		;
+		
 
 		if ( true === $args['required'] ) {
 			$args['class'][] = 'validate-required';

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -189,6 +189,7 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 
 		$args = wp_parse_args( $args, $defaults );
 		$args = apply_filters( 'user_registration_form_field_args', $args, $key, $value );
+		;
 
 		if ( true === $args['required'] ) {
 			$args['class'][] = 'validate-required';
@@ -197,9 +198,11 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 			$args['required'] = $required = '';
 		}
 
-		if ( is_null( $value ) ) {
+		if ( is_null( $value ) || empty($value)) {
 			$value = $args['default'];
 		}
+
+
 
 		// Custom attribute handling
 		$custom_attributes         = array();

--- a/templates/form-registration.php
+++ b/templates/form-registration.php
@@ -142,8 +142,8 @@ do_action( 'user_registration_before_registration_form', $form_id );
 								echo ur_string_translation( $form_id, 'user_registration_form_setting_form_submit_label', $submit );
 							?>
 						</button>
-
 						<?php do_action( 'user_registration_after_form_buttons', $form_id ); ?>
+						<?php do_action( 'user_registration_after_submit_buttons', $form_id ); ?>
 					</div>
 					<?php
 			}

--- a/templates/form-registration.php
+++ b/templates/form-registration.php
@@ -134,7 +134,6 @@ do_action( 'user_registration_before_registration_form', $form_id );
 						$submit_btn_class = apply_filters( 'user_registration_form_submit_btn_class', array(), $form_id );
 						$submit_btn_class = array_merge( $submit_btn_class, (array) ur_get_form_setting_by_key( $form_id, 'user_registration_form_setting_form_submit_class' ) );
 						?>
-
 						<button type="submit" class="btn button ur-submit-button <?php echo esc_attr( implode( ' ', $submit_btn_class ) ); ?>">
 							<span></span>
 							<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:
In this PR, a reset button is added in UR form in frontend .Which clear the form to set the default values

### How to test the changes in this Pull Request:

1. Navigate to User registration Form builder  Form Settings > Extras Setting > Enable Reset Button
2. Fill the UR Form with default values.
3. Click the reset button, the confirmation dialog box will appear to clear the values click Yes and to cancel click in the cancel 
  button.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Enhance - Reset Button in UR Form
