### PR TITLE
Feature - Prevent concurrent login

### DIFF
--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -156,6 +156,17 @@
 		}
 	);
 
+	// show select role when prevent concurrent login is enabled
+	$("#user_registration_login_options_prevent_concurrent_login").on("change",function() {
+		$enable = $("#user_registration_login_options_prevent_concurrent_login");
+		if($enable.prop("checked")) {
+			$enable.closest('tr').next('tr').show();
+		} else {
+			$enable.closest('tr').next('tr').hide();
+		}
+	})
+	.trigger("change");
+
 	// Change span with file name when user selects a file.
 	$(".user-registration-custom-file__input").on("change", function () {
 		var file = $(".user-registration-custom-file__input").prop("files")[0];

--- a/includes/admin/settings/class-ur-settings-general.php
+++ b/includes/admin/settings/class-ur-settings-general.php
@@ -474,6 +474,17 @@ if ( ! class_exists( 'UR_Settings_General' ) ) :
 					),
 
 					array(
+						'title'      => __( 'Prevent Concurrent Login', 'user-registration' ),
+						'desc'       => __( 'Enable Prevent Concurrent Login', 'user-registration' ),
+						'id'         => 'user_registration_login_options_prevent_concurrent_login',
+						'type'       => 'checkbox',
+						'desc_tip'   => __( 'Check to enable prevent concurrent login.', 'user-registration' ),
+						'css'        => 'min-width: 350px;',
+						'default'    => 'no',
+						'desc_field' => __( 'This options lets you enable to make sure that only one user can login with that user account at a time.', 'user-registration' ),
+					),
+
+						array(
 						'title'      => __( 'Prevent Core Login', 'user-registration' ),
 						'desc'       => __( 'Enable Prevent Core Login', 'user-registration' ),
 						'id'         => 'user_registration_login_options_prevent_core_login',

--- a/includes/admin/settings/class-ur-settings-general.php
+++ b/includes/admin/settings/class-ur-settings-general.php
@@ -378,6 +378,10 @@ if ( ! class_exists( 'UR_Settings_General' ) ) :
 		 * @return array
 		 */
 		public function get_login_options_settings() {
+			$all_roles = ur_get_default_admin_roles();
+			$all_roles_except_admin = $all_roles;
+			unset( $all_roles_except_admin['administrator'] );
+
 			$settings = apply_filters(
 				'user_registration_login_options_settings',
 				array(
@@ -481,7 +485,19 @@ if ( ! class_exists( 'UR_Settings_General' ) ) :
 						'desc_tip'   => __( 'Check to enable prevent concurrent login.', 'user-registration' ),
 						'css'        => 'min-width: 350px;',
 						'default'    => 'no',
-						'desc_field' => __( 'This options lets you enable to make sure that only one user can login with that user account at a time.<br><strong>Note: </strong>This option will only work for Subscriber and Customer role.', 'user-registration' ),
+						'desc_field' => __( 'This options lets you enable to make sure that only one user can login with that user account at a time.', 'user-registration' ),
+					),
+
+					array(
+						'title'    => __( 'Select Role to Prevent Concurrent Login', 'user-registration' ),
+						'desc'     => __( 'This option lets you limit which roles you are willing to prevent Concurrent Login.', 'user-registration' ),
+						'id'       => 'user_registration_login_options_prevent_concurrent_login_user_roles',
+						'default'  => array( 'subscriber' ),
+						'type'     => 'multiselect',
+						'class'    => 'ur-enhanced-select',
+						'css'      => 'min-width: 350px;',
+						'desc_tip' => true,
+						'options'  => $all_roles_except_admin,
 					),
 
 						array(

--- a/includes/admin/settings/class-ur-settings-general.php
+++ b/includes/admin/settings/class-ur-settings-general.php
@@ -379,8 +379,6 @@ if ( ! class_exists( 'UR_Settings_General' ) ) :
 		 */
 		public function get_login_options_settings() {
 			$all_roles = ur_get_default_admin_roles();
-			$all_roles_except_admin = $all_roles;
-			unset( $all_roles_except_admin['administrator'] );
 
 			$settings = apply_filters(
 				'user_registration_login_options_settings',
@@ -497,7 +495,7 @@ if ( ! class_exists( 'UR_Settings_General' ) ) :
 						'class'    => 'ur-enhanced-select',
 						'css'      => 'min-width: 350px;',
 						'desc_tip' => true,
-						'options'  => $all_roles_except_admin,
+						'options'  => $all_roles,
 					),
 
 						array(

--- a/includes/admin/settings/class-ur-settings-general.php
+++ b/includes/admin/settings/class-ur-settings-general.php
@@ -481,7 +481,7 @@ if ( ! class_exists( 'UR_Settings_General' ) ) :
 						'desc_tip'   => __( 'Check to enable prevent concurrent login.', 'user-registration' ),
 						'css'        => 'min-width: 350px;',
 						'default'    => 'no',
-						'desc_field' => __( 'This options lets you enable to make sure that only one user can login with that user account at a time.', 'user-registration' ),
+						'desc_field' => __( 'This options lets you enable to make sure that only one user can login with that user account at a time.<br><strong>Note: </strong>This option will only work for Subscriber and Customer role.', 'user-registration' ),
 					),
 
 						array(

--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -459,14 +459,12 @@ class UR_AJAX {
 		}
 		$concurrent_loggedin_meta = get_user_meta($user_data->ID,'concurrent_loggedin_meta',true);
 
-		if ( ! in_array( 'administrator', $user_data->roles, true ) ) {
-			if ( array_intersect( $user_data->roles, $option_roles ) ) {
-				if ( $concurrent_loggedin_meta && '1' === $concurrent_loggedin_meta ) {
-					wp_send_json_error( array( 'message' => 'User is currently loggedin in another device. Please logout from another device to continue.' ) );
-					return;
-				} else {
-					update_user_meta( $user_data->ID, 'concurrent_loggedin_meta', 1, );
-				}
+		if ( array_intersect( $user_data->roles, $option_roles ) ) {
+			if ( $concurrent_loggedin_meta && '1' === $concurrent_loggedin_meta ) {
+				wp_send_json_error( array( 'message' => 'User is currently loggedin in another device. Please logout from another device to continue.' ) );
+				return;
+			} else {
+				update_user_meta( $user_data->ID, 'concurrent_loggedin_meta', 1, );
 			}
 		}
 	}

--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -453,16 +453,20 @@ class UR_AJAX {
 		} else {
 			$user_data = get_user_by( 'login', $info['user_login'] );
 		}
-		$role = array( 'subscriber','customer' );
+		$option_roles = get_option( 'user_registration_login_options_prevent_concurrent_login_user_roles', array() );
+		if ( ! is_array( $option_roles ) ) {
+			$option_roles = array();
+		}
 		$concurrent_loggedin_meta = get_user_meta($user_data->ID,'concurrent_loggedin_meta',true);
 
-		if ( in_array( implode( "", $user_data->roles ), $role ) ) {
-
-			if ( $concurrent_loggedin_meta && '1' === $concurrent_loggedin_meta ) {
-				wp_send_json_error( array( 'message' => 'User is currently loggedin in another device. Please logout from another device to continue.' ) );
-				return;
-			} else {
-				update_user_meta( $user_data->ID, 'concurrent_loggedin_meta', 1, );
+		if ( ! in_array( 'administrator', $user_data->roles, true ) ) {
+			if ( array_intersect( $user_data->roles, $option_roles ) ) {
+				if ( $concurrent_loggedin_meta && '1' === $concurrent_loggedin_meta ) {
+					wp_send_json_error( array( 'message' => 'User is currently loggedin in another device. Please logout from another device to continue.' ) );
+					return;
+				} else {
+					update_user_meta( $user_data->ID, 'concurrent_loggedin_meta', 1, );
+				}
 			}
 		}
 	}

--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -421,17 +421,21 @@ class UR_Form_Handler {
 					} else {
 						$user_data = get_user_by( 'login', $username );
 					}
-					$role = array( 'subscriber','customer' );
+					$option_roles = get_option( 'user_registration_login_options_prevent_concurrent_login_user_roles', array() );
+					if ( ! is_array( $option_roles ) ) {
+						$option_roles = array();
+					}
 					$concurrent_loggedin_meta = get_user_meta($user_data->ID,'concurrent_loggedin_meta',true);
 
-					if ( in_array( implode( "", $user_data->roles ), $role ) ) {
-
-						if ( $concurrent_loggedin_meta && '1' === $concurrent_loggedin_meta ) {
-							ur_add_notice( apply_filters( 'login_errors', 'User is currently loggedin in another device. Please logout from another device to continue.' ), 'error' );
-							return;
-						} else {
-							update_user_meta( $user_data->ID, 'concurrent_loggedin_meta', 1, );
-						}
+					if ( ! in_array( 'administrator', $user_data->roles, true ) ) {
+						if ( array_intersect( $user_data->roles, $option_roles ) ) {
+							if ( $concurrent_loggedin_meta && '1' === $concurrent_loggedin_meta ) {
+								ur_add_notice( apply_filters( 'login_errors', 'User is currently loggedin in another device. Please logout from another device to continue.' ), 'error' );
+								return;
+							} else {
+								update_user_meta( $user_data->ID, 'concurrent_loggedin_meta', 1, );
+							}
+					    }
 					}
 				}
 				// Perform the login

--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -427,15 +427,13 @@ class UR_Form_Handler {
 					}
 					$concurrent_loggedin_meta = get_user_meta($user_data->ID,'concurrent_loggedin_meta',true);
 
-					if ( ! in_array( 'administrator', $user_data->roles, true ) ) {
-						if ( array_intersect( $user_data->roles, $option_roles ) ) {
-							if ( $concurrent_loggedin_meta && '1' === $concurrent_loggedin_meta ) {
-								ur_add_notice( apply_filters( 'login_errors', 'User is currently loggedin in another device. Please logout from another device to continue.' ), 'error' );
-								return;
-							} else {
-								update_user_meta( $user_data->ID, 'concurrent_loggedin_meta', 1, );
-							}
-					    }
+					if ( array_intersect( $user_data->roles, $option_roles ) ) {
+						if ( $concurrent_loggedin_meta && '1' === $concurrent_loggedin_meta ) {
+							ur_add_notice( apply_filters( 'login_errors', 'User is currently loggedin in another device. Please logout from another device to continue.' ), 'error' );
+							return;
+						} else {
+							update_user_meta( $user_data->ID, 'concurrent_loggedin_meta', 1, );
+						}
 					}
 				}
 				// Perform the login

--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -411,7 +411,29 @@ class UR_Form_Handler {
 						add_user_to_blog( get_current_blog_id(), $user_data->ID, 'customer' );
 					}
 				}
+				//check user already logged in with same account at another device
+				$concurrent_loggedin_option = get_option( 'user_registration_login_options_prevent_concurrent_login', 'no' );
 
+				if ( isset( $concurrent_loggedin_option ) && 'yes' === $concurrent_loggedin_option ) {
+
+					if ( is_email( $username ) && apply_filters( 'user_registration_get_username_from_email', true ) ) {
+						$user_data = get_user_by( 'email', $username );
+					} else {
+						$user_data = get_user_by( 'login', $username );
+					}
+					$role = array( 'subscriber','customer' );
+					$concurrent_loggedin_meta = get_user_meta($user_data->ID,'concurrent_loggedin_meta',true);
+
+					if ( in_array( implode( "", $user_data->roles ), $role ) ) {
+
+						if ( $concurrent_loggedin_meta && '1' === $concurrent_loggedin_meta ) {
+							ur_add_notice( apply_filters( 'login_errors', 'User is currently loggedin in another device. Please logout from another device to continue.' ), 'error' );
+							return;
+						} else {
+							update_user_meta( $user_data->ID, 'concurrent_loggedin_meta', 1, );
+						}
+					}
+				}
 				// Perform the login
 				$user = wp_signon( apply_filters( 'user_registration_login_credentials', $creds ), is_ssl() );
 

--- a/includes/class-ur-session-handler.php
+++ b/includes/class-ur-session-handler.php
@@ -219,7 +219,8 @@ class UR_Session_Handler extends UR_Session {
 		ur_setcookie( $this->_cookie, '', time() - YEAR_IN_SECONDS, apply_filters( 'ur_session_use_secure_cookie', false ) );
 
 		$this->delete_session( $this->_customer_id );
-
+		// update concurrent login meta after logout
+		update_user_meta( $this->_customer_id, 'concurrent_loggedin_meta', 0, );
 		// Clear data
 		$this->_data        = array();
 		$this->_dirty       = false;

--- a/includes/frontend/class-ur-frontend-form-handler.php
+++ b/includes/frontend/class-ur-frontend-form-handler.php
@@ -113,6 +113,7 @@ class UR_Frontend_Form_Handler {
 				} else {
 
 					if ( 'auto_login' === $login_option ) {
+						update_user_meta( $user_id, 'concurrent_loggedin_meta', 1, );
 						wp_clear_auth_cookie();
 						wp_set_auth_cookie( $user_id );
 						$success_params['auto_login'] = true;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Do not allow the user to log in from the same account at the same time on other devices.

### How to test the changes in this Pull Request:

1. Navigate to User Registration settings and navigate to the Login options of the general tab.
2. Now check to enable prevent concurrent log in and select the user role which you wish to prevent it from concurrent login.
3. Now when you logged in and again you try to log in with the same account then it will show an error message that you are currently logged in on another device. 

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Feature - Prevent concurrent login.
