### PR TITLE
Enhance - Payment slider  in range field

### DIFF
--- a/includes/abstracts/abstract-ur-form-field.php
+++ b/includes/abstracts/abstract-ur-form-field.php
@@ -288,15 +288,13 @@ abstract class UR_Form_Field {
 
 			$form_data['username_character'] = isset( $data['advance_setting']->username_character ) ? $data['advance_setting']->username_character : "";
 		}
-		
-	
-
 		if( 'range' === $field_key ) {
 			$form_data['range_min'] =  ( isset( $data['advance_setting']->range_min) && "" !== $data['advance_setting']->range_min) ? $data['advance_setting']->range_min : "0";
 			$form_data['range_max'] =  ( isset( $data['advance_setting']->range_max)  && "" !== $data['advance_setting']->range_max ) ? $data['advance_setting']->range_max : "10";
 			$form_data['range_step'] =  isset( $data['advance_setting']->range_step) ? $data['advance_setting']->range_step : "";
 			$enable_prefix_postfix = isset( $data['advance_setting']->enable_prefix_postfix) ? $data['advance_setting']->enable_prefix_postfix : "false";
 			$enable_text_prefix_postfix = isset( $data['advance_setting']->enable_text_prefix_postfix) ? $data['advance_setting']->enable_text_prefix_postfix : "false";
+			$form_data['enable_payment_slider'] = isset( $data['advance_setting']->enable_payment_slider ) ? $data['advance_setting']->enable_payment_slider : "false";
 
 			if( "true" === $enable_prefix_postfix ) {
 

--- a/includes/abstracts/abstract-ur-form-field.php
+++ b/includes/abstracts/abstract-ur-form-field.php
@@ -288,6 +288,9 @@ abstract class UR_Form_Field {
 
 			$form_data['username_character'] = isset( $data['advance_setting']->username_character ) ? $data['advance_setting']->username_character : "";
 		}
+
+
+		
 		if( 'range' === $field_key ) {
 			$form_data['range_min'] =  ( isset( $data['advance_setting']->range_min) && "" !== $data['advance_setting']->range_min) ? $data['advance_setting']->range_min : "0";
 			$form_data['range_max'] =  ( isset( $data['advance_setting']->range_max)  && "" !== $data['advance_setting']->range_max ) ? $data['advance_setting']->range_max : "10";

--- a/includes/abstracts/abstract-ur-form-field.php
+++ b/includes/abstracts/abstract-ur-form-field.php
@@ -289,8 +289,6 @@ abstract class UR_Form_Field {
 			$form_data['username_character'] = isset( $data['advance_setting']->username_character ) ? $data['advance_setting']->username_character : "";
 		}
 
-
-		
 		if( 'range' === $field_key ) {
 			$form_data['range_min'] =  ( isset( $data['advance_setting']->range_min) && "" !== $data['advance_setting']->range_min) ? $data['advance_setting']->range_min : "0";
 			$form_data['range_max'] =  ( isset( $data['advance_setting']->range_max)  && "" !== $data['advance_setting']->range_max ) ? $data['advance_setting']->range_max : "10";

--- a/templates/myaccount/form-edit-profile.php
+++ b/templates/myaccount/form-edit-profile.php
@@ -187,6 +187,11 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 														}
 													}
 
+													// to hide the range as payment slider in edit profile
+													if("true" ===$field['enable_payment_slider']){
+														continue;
+													}
+
 												}
 
 												if ( 'phone' === $single_item->field_key ) {

--- a/templates/myaccount/form-edit-profile.php
+++ b/templates/myaccount/form-edit-profile.php
@@ -176,7 +176,6 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 													$field['range_step'] =  isset( $advance_data['advance_setting']->range_step) ? $advance_data['advance_setting']->range_step : "1";
 													$field['enable_payment_slider'] =  isset( $advance_data['advance_setting']->enable_payment_slider) ? $advance_data['advance_setting']->enable_payment_slider : "false";
 
-
 													if(  "true" === $advance_data['advance_setting']->enable_prefix_postfix) {
 														if( "true" === $advance_data['advance_setting']->enable_text_prefix_postfix ) {
 															$field['range_prefix'] = isset( $advance_data['advance_setting']->range_prefix) ? $advance_data['advance_setting']->range_prefix : "";
@@ -191,7 +190,6 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 													if("true" ===$field['enable_payment_slider']){
 														continue;
 													}
-
 												}
 
 												if ( 'phone' === $single_item->field_key ) {

--- a/templates/myaccount/form-edit-profile.php
+++ b/templates/myaccount/form-edit-profile.php
@@ -174,6 +174,8 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 													$field['range_min'] =  ( isset( $advance_data['advance_setting']->range_min) && "" !== $advance_data['advance_setting']->range_min )? $advance_data['advance_setting']->range_min : "0";
 													$field['range_max'] =  ( isset( $advance_data['advance_setting']->range_max) && "" !== $advance_data['advance_setting']->range_max ) ? $advance_data['advance_setting']->range_max : "10";
 													$field['range_step'] =  isset( $advance_data['advance_setting']->range_step) ? $advance_data['advance_setting']->range_step : "1";
+													$field['enable_payment_slider'] =  isset( $advance_data['advance_setting']->enable_payment_slider) ? $advance_data['advance_setting']->enable_payment_slider : "false";
+
 
 													if(  "true" === $advance_data['advance_setting']->enable_prefix_postfix) {
 														if( "true" === $advance_data['advance_setting']->enable_text_prefix_postfix ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Previously, There were no option to use range as a payment slider for payment method. This PR provides an option to use range as a payment slider.

### How to test the changes in this Pull Request:

1. Navigate to the form builder and drag and drop the range field.
2. In the Advance setting of field options of range field there will be option labelled as enable payment slider , enable the option.
3. Navigate to the registration form and verify whether range field working as payment slider or not.
4.  Also check if range is used as payment slider it will not visible in edit profile.

### PR:
https://github.com/wpeverest/user-registration-advanced-fields/pull/23
https://github.com/wpeverest/user-registration-stripe/pull/8
https://github.com/wpeverest/user-registration-payments/pull/8

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Enhance - Payment slider in range field
