### PR TITLE
Fix - String translation in edit profile

### DIFF
--- a/templates/myaccount/form-edit-profile.php
+++ b/templates/myaccount/form-edit-profile.php
@@ -282,7 +282,7 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 													$choices     = isset( $advance_data['advance_setting']->choices ) ? explode( ',', $advance_data['advance_setting']->choices ) : array();
 													$option_data = isset( $advance_data['general_setting']->options ) ? $advance_data['general_setting']->options : $choices;
 													$options = array();
-													
+
 													if ( is_array( $option_data ) ) {
 														foreach ( $option_data as $index_data => $option ) {
 															$options[ $option ] = ur_string_translation($form_id,'user_registration_' . $advance_data['general_setting']->field_name . '_option_' . ( ++$index_data ), $option );

--- a/templates/myaccount/form-edit-profile.php
+++ b/templates/myaccount/form-edit-profile.php
@@ -139,6 +139,8 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 												$single_item = class_exists( 'URCL_Field_Settings' ) && method_exists( URCL_Field_Settings::class, 'migrate_to_logic_map_schema' ) ? URCL_Field_Settings::migrate_to_logic_map_schema( $single_item ) : $single_item;
 											}
 
+											$user_id = get_current_user_id();
+											$form_id = ur_get_form_id_by_userid( $user_id );
 											$field                      = $profile[ $key ];
 											$field['input_class']       = array( 'ur-edit-profile-field ' );
 											$advance_data               = array(
@@ -211,7 +213,7 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 														unset( $field['input_mask'] );
 													}
 												}
-												
+
 												if ( isset( $single_item->general_setting->hide_label ) ) {
 												if( 'yes' === $single_item->general_setting->hide_label ) {
 													unset( $field['label'] );
@@ -219,10 +221,35 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 											   }
 
 												if ( 'select' === $single_item->field_key ) {
+													$option_data = isset( $advance_data['advance_setting']->options ) ? explode( ',', $advance_data['advance_setting']->options ) : array();
+													$option_advance_data = isset( $advance_data['general_setting']->options ) ? $advance_data['general_setting']->options : $option_data;
+													$options     = array();
+
+													if ( is_array( $option_data ) ) {
+														foreach ( $option_data as $index_data => $option ) {
+															$options[ $option ] = ur_string_translation( $form_id, 'user_registration_' . $advance_data['general_setting']->field_name . '_option_' . ( ++$index_data ), $option );
+														}
+														$field['options'] = $options;
+													}
+
 													$field['placeholder'] = $single_item->general_setting->placeholder;
 													if ( isset( $field['placeholder'] ) ) {
 														unset( $field['placeholder'] );
 													}
+												}
+
+												if ( 'radio' === $single_item->field_key ) {
+													$option_data = isset( $advance_data['advance_setting']->options ) ? explode( ',', $advance_data['advance_setting']->options ) : array();
+													$option_advance_data = isset( $advance_data['general_setting']->options ) ? $advance_data['general_setting']->options : $option_data;
+													$options     = array();
+
+													if ( is_array( $option_data ) ) {
+														foreach ( $option_data as $index_data => $option ) {
+															$options[ $option ] = ur_string_translation( $form_id, 'user_registration_' . $advance_data['general_setting']->field_name . '_option_' . ( ++$index_data ), $option );
+														}
+														$field['options'] = $options;
+													}
+
 												}
 
 												if ( 'file' === $single_item->field_key ) {
@@ -251,6 +278,17 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 
 												// Add choice_limit setting valur in order to limit choice fields.
 												if( "checkbox" === $single_item->field_key || "multi_select2" === $single_item->field_key){
+													$choices     = isset( $advance_data['advance_setting']->choices ) ? explode( ',', $advance_data['advance_setting']->choices ) : array();
+													$option_data = isset( $advance_data['general_setting']->options ) ? $advance_data['general_setting']->options : $choices;
+
+													$options = array();
+													if ( is_array( $option_data ) ) {
+														foreach ( $option_data as $index_data => $option ) {
+															$options[ $option ] = ur_string_translation($form_id,'user_registration_' . $advance_data['general_setting']->field_name . '_option_' . ( ++$index_data ), $option );
+														}
+
+														$field['options'] = $options;
+													}
 													if( isset( $advance_data["advance_setting"]->choice_limit)) {
 														$field["choice_limit"] = $advance_data["advance_setting"]->choice_limit;
 													}

--- a/templates/myaccount/form-edit-profile.php
+++ b/templates/myaccount/form-edit-profile.php
@@ -278,20 +278,20 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 												}
 
 												// Add choice_limit setting valur in order to limit choice fields.
-												if( "checkbox" === $single_item->field_key || "multi_select2" === $single_item->field_key){
+												if( "checkbox" === $single_item->field_key || "multi_select2" === $single_item->field_key) {
 													$choices     = isset( $advance_data['advance_setting']->choices ) ? explode( ',', $advance_data['advance_setting']->choices ) : array();
 													$option_data = isset( $advance_data['general_setting']->options ) ? $advance_data['general_setting']->options : $choices;
-													$options = array();
+													$options 	 = array();
 
 													if ( is_array( $option_data ) ) {
 														foreach ( $option_data as $index_data => $option ) {
-															$options[ $option ] = ur_string_translation($form_id,'user_registration_' . $advance_data['general_setting']->field_name . '_option_' . ( ++$index_data ), $option );
+															$options[ $option ] = ur_string_translation( $form_id,'user_registration_' . $advance_data['general_setting']->field_name . '_option_' . ( ++$index_data ), $option );
 														}
 
 														$field['options'] = $options;
 													}
 
-													if( isset( $advance_data["advance_setting"]->choice_limit)) {
+													if( isset( $advance_data["advance_setting"]->choice_limit) ) {
 														$field["choice_limit"] = $advance_data["advance_setting"]->choice_limit;
 													}
 												}

--- a/templates/myaccount/form-edit-profile.php
+++ b/templates/myaccount/form-edit-profile.php
@@ -139,8 +139,8 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 												$single_item = class_exists( 'URCL_Field_Settings' ) && method_exists( URCL_Field_Settings::class, 'migrate_to_logic_map_schema' ) ? URCL_Field_Settings::migrate_to_logic_map_schema( $single_item ) : $single_item;
 											}
 
-											$user_id = get_current_user_id();
-											$form_id = ur_get_form_id_by_userid( $user_id );
+											$user_id				    = get_current_user_id();
+											$form_id 					= ur_get_form_id_by_userid( $user_id );
 											$field                      = $profile[ $key ];
 											$field['input_class']       = array( 'ur-edit-profile-field ' );
 											$advance_data               = array(
@@ -221,9 +221,9 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 											   }
 
 												if ( 'select' === $single_item->field_key ) {
-													$option_data = isset( $advance_data['advance_setting']->options ) ? explode( ',', $advance_data['advance_setting']->options ) : array();
+													$option_data 		 = isset( $advance_data['advance_setting']->options ) ? explode( ',', $advance_data['advance_setting']->options ) : array();
 													$option_advance_data = isset( $advance_data['general_setting']->options ) ? $advance_data['general_setting']->options : $option_data;
-													$options     = array();
+													$options     		 = array();
 
 													if ( is_array( $option_data ) ) {
 														foreach ( $option_data as $index_data => $option ) {
@@ -233,15 +233,16 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 													}
 
 													$field['placeholder'] = $single_item->general_setting->placeholder;
+
 													if ( isset( $field['placeholder'] ) ) {
 														unset( $field['placeholder'] );
 													}
 												}
 
 												if ( 'radio' === $single_item->field_key ) {
-													$option_data = isset( $advance_data['advance_setting']->options ) ? explode( ',', $advance_data['advance_setting']->options ) : array();
+													$option_data 		 = isset( $advance_data['advance_setting']->options ) ? explode( ',', $advance_data['advance_setting']->options ) : array();
 													$option_advance_data = isset( $advance_data['general_setting']->options ) ? $advance_data['general_setting']->options : $option_data;
-													$options     = array();
+													$options             = array();
 
 													if ( is_array( $option_data ) ) {
 														foreach ( $option_data as $index_data => $option ) {
@@ -280,8 +281,8 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 												if( "checkbox" === $single_item->field_key || "multi_select2" === $single_item->field_key){
 													$choices     = isset( $advance_data['advance_setting']->choices ) ? explode( ',', $advance_data['advance_setting']->choices ) : array();
 													$option_data = isset( $advance_data['general_setting']->options ) ? $advance_data['general_setting']->options : $choices;
-
 													$options = array();
+													
 													if ( is_array( $option_data ) ) {
 														foreach ( $option_data as $index_data => $option ) {
 															$options[ $option ] = ur_string_translation($form_id,'user_registration_' . $advance_data['general_setting']->field_name . '_option_' . ( ++$index_data ), $option );
@@ -289,6 +290,7 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 
 														$field['options'] = $options;
 													}
+
 													if( isset( $advance_data["advance_setting"]->choice_limit)) {
 														$field["choice_limit"] = $advance_data["advance_setting"]->choice_limit;
 													}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously, when the users Translate the fields option (like checkbox, radio, select) in any other languages using polylang in the edit profile the string changes will not appear. This PR solve this issue
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1.  Navigate to the form builder and drag and drop the checkbox field.
2.  Install the Polylang Plugin and translate the string like( first choice).
3. Now, check whether the string is translated or not in edit profile.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - String translation in edit profile
