### PR TITLE
Fix - Profile picture field visible in edit-profile when gutenberg myaccount shortcode used

### DIFF
--- a/assets/js/admin/gutenberg/form-block.build.js
+++ b/assets/js/admin/gutenberg/form-block.build.js
@@ -178,10 +178,10 @@ registerBlockType("user-registration/form-selector", {
 					value: shortcode,
 					options: [{ label: "Select Shortcode", value: "" }, {
 						label: "Login Shortcode",
-						value: "login_shortcode"
+						value: "user_registration_login"
 					}, {
 						label: "My Account Shortcode",
-						value: "myaccount_shortcode"
+						value: "user_registration_my_account"
 					}],
 					onChange: selectLoginForm
 				}), wp.element.createElement(TextControl, {
@@ -235,10 +235,10 @@ registerBlockType("user-registration/form-selector", {
 					selected: shortcode,
 					options: [{ label: "Select Shortcode", value: "" }, {
 						label: "Login Shortcode",
-						value: "login_shortcode"
+						value: "user_registration_login"
 					}, {
 						label: "My Account Shortcode",
-						value: "myaccount_shortcode"
+						value: "user_registration_my_account"
 					}],
 					onChange: selectLoginForm
 				})

--- a/assets/js/admin/gutenberg/form-block.js
+++ b/assets/js/admin/gutenberg/form-block.js
@@ -113,11 +113,11 @@ registerBlockType("user-registration/form-selector", {
 									{ label: "Select Shortcode", value: "" },
 									{
 										label: "Login Shortcode",
-										value: "login_shortcode",
+										value: "user_registration_login",
 									},
 									{
 										label: "My Account Shortcode",
-										value: "myaccount_shortcode",
+										value: "user_registration_my_account",
 									},
 								]}
 								onChange={selectLoginForm}
@@ -182,11 +182,11 @@ registerBlockType("user-registration/form-selector", {
 								{ label: "Select Shortcode", value: "" },
 								{
 									label: "Login Shortcode",
-									value: "login_shortcode",
+									value: "user_registration_login",
 								},
 								{
 									label: "My Account Shortcode",
-									value: "myaccount_shortcode",
+									value: "user_registration_my_account",
 								},
 							]}
 							onChange={selectLoginForm}

--- a/includes/class-ur-form-block.php
+++ b/includes/class-ur-form-block.php
@@ -154,7 +154,7 @@ class UR_Form_Block {
 				$parameters["logout_redirect"] = $attr['logoutUrl'];
 			}
 
-			if('login_shortcode'=== $shortcode ) {
+			if('user_registration_login'=== $shortcode ) {
 				return UR_Shortcodes::login(
 					$parameters
 				);

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -314,8 +314,20 @@ function ur_help_tip( $tip, $allow_html = false, $classname = 'user-registration
  */
 function ur_post_content_has_shortcode( $tag = '' ) {
 	global $post;
+	$new_shortcode = '';
 
-	return ( is_singular() || is_front_page() ) && is_a( $post, 'WP_Post' ) && has_shortcode( $post->post_content, $tag );
+	if( is_object( $post ) ) {
+		$blocks = parse_blocks( $post->post_content );
+		foreach( $blocks as $block ) {
+			if ( 'core/shortcode' === $block['blockName'] && isset( $block['innerHTML'] ) ) {
+				$new_shortcode = $block['innerHTML'];
+			} elseif ( 'user-registration/form-selector' === $block['blockName'] && isset( $block['attrs']['shortcode'] ) ) {
+				$new_shortcode = "[". $block['attrs']['shortcode'] . "]";
+			}
+		}
+	}
+
+	return ( is_singular() || is_front_page() ) && is_a( $post, 'WP_Post' ) && has_shortcode( $new_shortcode, $tag );
 }
 
 /**

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -318,15 +318,16 @@ function ur_post_content_has_shortcode( $tag = '' ) {
 
 	if( is_object( $post ) ) {
 		$blocks = parse_blocks( $post->post_content );
-
 		foreach( $blocks as $block ) {
+
 			if ( 'core/shortcode' === $block['blockName'] && isset( $block['innerHTML'] ) ) {
 				$new_shortcode = $block['innerHTML'];
 			} elseif ( 'user-registration/form-selector' === $block['blockName'] && isset( $block['attrs']['shortcode'] ) ) {
 				$new_shortcode = "[". $block['attrs']['shortcode'] . "]";
 			}
+			
 		}
-		
+
 	}
 
 	return ( is_singular() || is_front_page() ) && is_a( $post, 'WP_Post' ) && has_shortcode( $new_shortcode, $tag );

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -325,9 +325,8 @@ function ur_post_content_has_shortcode( $tag = '' ) {
 			} elseif ( 'user-registration/form-selector' === $block['blockName'] && isset( $block['attrs']['shortcode'] ) ) {
 				$new_shortcode = "[". $block['attrs']['shortcode'] . "]";
 			}
-			
-		}
 
+		}
 	}
 
 	return ( is_singular() || is_front_page() ) && is_a( $post, 'WP_Post' ) && has_shortcode( $new_shortcode, $tag );

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -318,6 +318,7 @@ function ur_post_content_has_shortcode( $tag = '' ) {
 
 	if( is_object( $post ) ) {
 		$blocks = parse_blocks( $post->post_content );
+
 		foreach( $blocks as $block ) {
 			if ( 'core/shortcode' === $block['blockName'] && isset( $block['innerHTML'] ) ) {
 				$new_shortcode = $block['innerHTML'];
@@ -325,6 +326,7 @@ function ur_post_content_has_shortcode( $tag = '' ) {
 				$new_shortcode = "[". $block['attrs']['shortcode'] . "]";
 			}
 		}
+		
 	}
 
 	return ( is_singular() || is_front_page() ) && is_a( $post, 'WP_Post' ) && has_shortcode( $new_shortcode, $tag );

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -800,8 +800,17 @@ function ur_logout_url( $redirect = '' ) {
 
 	global $post;
 	$post_content = isset( $post->post_content ) ? $post->post_content : '';
+	$blocks = parse_blocks( $post_content );
+	foreach( $blocks as $block ) {
+		if ( 'core/shortcode' === $block['blockName'] && isset( $block['innerHTML'] ) ) {
+			$new_shortcode = $block['innerHTML'];
+		} elseif ( 'user-registration/form-selector' === $block['blockName'] && isset( $block['attrs']['shortcode'] ) ) {
+			$new_shortcode = "[". $block['attrs']['shortcode'] . "]";
+		}
+	}
+
 	if ( ( ur_post_content_has_shortcode( 'user_registration_login' ) || ur_post_content_has_shortcode( 'user_registration_my_account' ) ) && is_user_logged_in() ) {
-		preg_match( '/' . get_shortcode_regex() . '/s', $post_content, $matches );
+		preg_match( '/' . get_shortcode_regex() . '/s', $new_shortcode, $matches );
 
 		$attributes = shortcode_parse_atts($matches[3]);
 		/**

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -801,13 +801,14 @@ function ur_logout_url( $redirect = '' ) {
 	global $post;
 	$post_content = isset( $post->post_content ) ? $post->post_content : '';
 	$blocks = parse_blocks( $post_content );
-	
 	foreach( $blocks as $block ) {
+
 		if ( 'core/shortcode' === $block['blockName'] && isset( $block['innerHTML'] ) ) {
 			$new_shortcode = $block['innerHTML'];
 		} elseif ( 'user-registration/form-selector' === $block['blockName'] && isset( $block['attrs']['shortcode'] ) ) {
 			$new_shortcode = "[". $block['attrs']['shortcode'] . "]";
 		}
+
 	}
 
 	if ( ( ur_post_content_has_shortcode( 'user_registration_login' ) || ur_post_content_has_shortcode( 'user_registration_my_account' ) ) && is_user_logged_in() ) {

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -801,6 +801,7 @@ function ur_logout_url( $redirect = '' ) {
 	global $post;
 	$post_content = isset( $post->post_content ) ? $post->post_content : '';
 	$blocks = parse_blocks( $post_content );
+	
 	foreach( $blocks as $block ) {
 		if ( 'core/shortcode' === $block['blockName'] && isset( $block['innerHTML'] ) ) {
 			$new_shortcode = $block['innerHTML'];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously when we use Gutenberg block shortcode for my account page the profile picture field is visible in the edit profile of my account. This PR will fix this issue.

### How to test the changes in this Pull Request:

1. First Navigate to pages and add a new page then add a block ie (+) sign and search for user registration.
2. then choose the log-in form option and select My Account shortcode then publish the page.
3. then navigate to User Registration settings then navigate to my account section of the General tab.
4. then select my account page which you have created using Gutenberg in step 1.
5. then drag and drop the profile picture field in the form builder and save the form.
6. then navigate to edit profile of my account dashboard and see if the profile picture field is visible or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Profile picture field visible in edit-profile when gutenberg myaccount shortcode used.
