### PR TITLE
UR-189 Fix - Resend verification not working when ajax login is enabled

### DIFF
--- a/includes/class-ur-user-approval.php
+++ b/includes/class-ur-user-approval.php
@@ -148,7 +148,7 @@ class UR_User_Approval {
 			if ( $this->is_admin_creation_process() ) {
 				$status = UR_Admin_User_Manager::APPROVED;
 			}
-           // update user status when login using social connect
+			// update user status when login using social connect
 			if ( get_user_meta( $user_id, 'user_registration_social_connect_bypass_current_password', false ) ) {
 				$status = UR_Admin_User_Manager::APPROVED;
 			}
@@ -165,16 +165,16 @@ class UR_User_Approval {
 	/**
 	 * Check the status of an user on login.
 	 *
-	 * @param mixed $user Users.
-	 * @param string  $password Password.
+	 * @param mixed  $user Users.
+	 * @param string $password Password.
 	 *
 	 * @return \WP_Error
 	 */
 	public function check_status_on_login( $user, $password ) {
 
-		if( ! $user instanceof WP_User ) {
+		if ( ! $user instanceof WP_User ) {
 			return $user;
-		 }
+		}
 
 		$form_id = ur_get_form_id_by_userid( $user->ID );
 
@@ -205,7 +205,14 @@ class UR_User_Approval {
 
 			do_action( 'ur_user_before_check_email_status_on_login', $status['user_status'], $user );
 
-			$url      = ( ! empty( $_SERVER['HTTPS'] ) ) ? 'https://' . $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI'] : 'http://' . $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI'];
+			$url      = ( ! empty( $_SERVER['HTTPS'] ) ) ? 'https://' . $_SERVER['SERVER_NAME'] : 'http://' . $_SERVER['SERVER_NAME'];
+
+			if ( get_option( 'ur_login_ajax_submission' ) ) {
+				$url .= $_SERVER['HTTP_REFERER'];
+			} else {
+				$url .= $_SERVER['REQUEST_URI'];
+			}
+
 			$url      = substr( $url, 0, strpos( $url, '?' ) );
 			$instance = new UR_Email_Confirmation();
 			$url      = wp_nonce_url( $url . '?ur_resend_id=' . $instance->crypt_the_string( $user->ID . '_' . time(), 'e' ) . '&ur_resend_token=true', 'ur_resend_token' );
@@ -250,9 +257,9 @@ class UR_User_Approval {
 		if ( 'admin_approval' === ur_get_single_post_meta( $form_id, 'user_registration_form_setting_login_options', get_option( 'user_registration_general_setting_login_options', 'default' ) ) ) {
 
 			// Try to hide the not approved users from any theme or plugin request in frontend.
-			$disable_pre_get = apply_filters( 'user_registration_disable_pre_get_users', 'no');
+			$disable_pre_get = apply_filters( 'user_registration_disable_pre_get_users', 'no' );
 
-			if( 'no' === $disable_pre_get ){
+			if ( 'no' === $disable_pre_get ) {
 				add_action( 'pre_get_users', array( $this, 'hide_not_approved_users_in_frontend' ) );
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously when a user is registered through the email confirmation option and tries to login with his unverified account, then a Resend Verification error message is shown to him, and when clicked he is sent a verification email which was working properly in case of normal login process but was not working if login ajax was enabled. This PR fixes this issue.

### How to test the changes in this Pull Request:

1. First of all check to verify if a verification email is being sent in case of normal login submission.
2. Now enable ajax login and verify if the above-mentioned issue is solved or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Resend verification not working when ajax login is enabled.
