### PR TITLE
UR-205 Fix - Profile picture remove, update and save on the edit profile page

### DIFF
--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -198,7 +198,7 @@ class UR_AJAX {
 		$single_field = array();
 
 		if ( isset( $_POST['form_data'] ) ) {
-			$form_data = json_decode( stripslashes( $_POST['form_data'] ) );
+			$form_data = json_decode( wp_unslash( $_POST['form_data'] ) );
 			foreach ( $form_data as $data ) {
 				$single_field[ $data->field_name ] = isset( $data->value ) ? $data->value : '';
 				$data->field_name                  = substr( $data->field_name, 18 );

--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -86,7 +86,7 @@ class UR_AJAX {
 
 		$form_id           = isset( $_POST['form_id'] ) ? absint( $_POST['form_id'] ) : 0;
 		$nonce             = isset( $_POST['ur_frontend_form_nonce'] ) ? $_POST['ur_frontend_form_nonce'] : '';
-		$captcha_response  = isset( $_POST['captchaResponse'] ) ? ur_clean( wp_unslash($_POST['captchaResponse']) ) : '';
+		$captcha_response  = isset( $_POST['captchaResponse'] ) ? ur_clean( wp_unslash( $_POST['captchaResponse'] ) ) : '';
 		$flag              = wp_verify_nonce( $nonce, 'ur_frontend_form_id-' . $form_id );
 		$recaptcha_enabled = ur_get_form_setting_by_key( $form_id, 'user_registration_form_setting_enable_recaptcha_support', 'no' );
 		$recaptcha_version = get_option( 'user_registration_integration_setting_recaptcha_version' );
@@ -207,9 +207,13 @@ class UR_AJAX {
 
 		if ( isset( $single_field['user_registration_profile_pic_url'] ) ) {
 			if ( 'no' === get_option( 'user_registration_disable_profile_picture', 'no' ) ) {
-				if ( wp_http_validate_url( $single_field['user_registration_profile_pic_url'] ) ) {
-					$profile_pic_url = esc_url_raw( $single_field['user_registration_profile_pic_url'] );
-					update_user_meta( $user_id, 'user_registration_profile_pic_url', $profile_pic_url );
+				if ( '' === $single_field['user_registration_profile_pic_url'] ) {
+					update_user_meta( $user_id, 'user_registration_profile_pic_url', '' );
+				} else {
+					if ( wp_http_validate_url( $single_field['user_registration_profile_pic_url'] ) ) {
+						$profile_pic_url = esc_url_raw( $single_field['user_registration_profile_pic_url'] );
+						update_user_meta( $user_id, 'user_registration_profile_pic_url', $profile_pic_url );
+					}
 				}
 			}
 		}
@@ -241,7 +245,7 @@ class UR_AJAX {
 					}
 					break;
 				default:
-					$single_field[ $key ] = isset( $single_field[ $key ] ) ? sanitize_text_field( ( $single_field[ $key ] ) ): '';
+					$single_field[ $key ] = isset( $single_field[ $key ] ) ? sanitize_text_field( ( $single_field[ $key ] ) ) : '';
 					break;
 			}
 
@@ -284,9 +288,9 @@ class UR_AJAX {
 				if ( in_array( $new_key, ur_get_user_table_fields() ) ) {
 
 					if ( $new_key === 'display_name' ) {
-						$user_data['display_name'] = sanitize_text_field( ($single_field[ $key ]));
+						$user_data['display_name'] = sanitize_text_field( ( $single_field[ $key ] ) );
 					} else {
-						$user_data[ $new_key ] = sanitize_text_field( $single_field[ $key ]);
+						$user_data[ $new_key ] = sanitize_text_field( $single_field[ $key ] );
 					}
 				} else {
 					$update_key = $key;
@@ -683,8 +687,8 @@ class UR_AJAX {
 
 			$post_data = array(
 				'post_type'      => 'user_registration',
-				'post_title'     => sanitize_text_field( $form_name),
-				'post_content'   => wp_json_encode( $post_data, JSON_UNESCAPED_UNICODE |  JSON_UNESCAPED_SLASHES ),
+				'post_title'     => sanitize_text_field( $form_name ),
+				'post_content'   => wp_json_encode( $post_data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ),
 				'post_status'    => 'publish',
 				'comment_status' => 'closed',   // if you prefer
 				'ping_status'    => 'closed',      // if you prefer
@@ -921,7 +925,7 @@ class UR_AJAX {
 	 * @return void
 	 **/
 	public static function dismiss_notice() {
-		$notice_type = isset($_POST["notice_type"]) ? $_POST["notice_type"] : '';
+		$notice_type = isset( $_POST['notice_type'] ) ? $_POST['notice_type'] : '';
 		check_admin_referer( $notice_type . '-nonce', 'security' );
 
 		if ( ! empty( $_POST['dismissed'] ) ) {

--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -37,7 +37,7 @@ class UR_Form_Handler {
 	 */
 	public static function redirect_reset_password_link() {
 		if ( is_ur_account_page() && ! empty( $_GET['key'] ) && ! empty( $_GET['login'] ) ) {
-			$value = sprintf( '%s:%s', sanitize_text_field(wp_unslash( $_GET['login'] )), sanitize_text_field(wp_unslash( $_GET['key'] ) ) );
+			$value = sprintf( '%s:%s', sanitize_text_field( wp_unslash( $_GET['login'] ) ), sanitize_text_field( wp_unslash( $_GET['key'] ) ) );
 			UR_Shortcode_My_Account::set_reset_password_cookie( $value );
 
 			wp_safe_redirect( add_query_arg( 'show-reset-form', 'true', ur_lostpassword_url() ) );
@@ -66,72 +66,74 @@ class UR_Form_Handler {
 		if ( $user_id <= 0 ) {
 			return;
 		}
-
 		if ( has_action( 'uraf_profile_picture_buttons' ) ) {
 			if ( isset( $_POST['profile_pic_url'] ) ) {
-				if( wp_http_validate_url( $_POST['profile_pic_url'] )) {
-					$profile_pic_url = esc_url_raw( $_POST['profile_pic_url']);
-					update_user_meta( $user_id, 'user_registration_profile_pic_url',  $profile_pic_url );
+				if ( '' === $_POST['profile_pic_url'] ) {
+					update_user_meta( $user_id, 'user_registration_profile_pic_url', '' );
+				} else {
+					if ( wp_http_validate_url( $_POST['profile_pic_url'] ) ) {
+						$profile_pic_url = esc_url_raw( $_POST['profile_pic_url'] );
+						update_user_meta( $user_id, 'user_registration_profile_pic_url', $profile_pic_url );
+					}
 				}
 			}
 		} else {
 			if ( isset( $_FILES['profile-pic'] ) ) {
 
-			  if ( isset( $_FILES['profile-pic'] ) && $_FILES['profile-pic']['size'] ) {
+				if ( isset( $_FILES['profile-pic'] ) && $_FILES['profile-pic']['size'] ) {
 
-				if ( ! function_exists( 'wp_handle_upload' ) ) {
-					require_once ABSPATH . 'wp-admin/includes/file.php';
-				}
-
-				$upload           = $_FILES['profile-pic'];
-				$upload_overrides = array(
-					'action' => 'save_profile_details',
-				);
-				$uploaded         = wp_handle_upload( $upload, $upload_overrides );
-
-				if ( $uploaded && ! isset( $uploaded['error'] ) ) {
-					$image = wp_get_image_editor( $uploaded['file'] );
-
-					if ( ! is_wp_error( $image ) ) {
-						$image->resize( 150, 150, true );
-						$image->save( $uploaded['file'] );
+					if ( ! function_exists( 'wp_handle_upload' ) ) {
+						require_once ABSPATH . 'wp-admin/includes/file.php';
 					}
-					if( wp_http_validate_url( $uploaded['url'] )) {
-						$profile_pic_url = esc_url_raw( $uploaded['url'] );
-						update_user_meta( $user_id, 'user_registration_profile_pic_url',  $profile_pic_url );
+
+					$upload           = $_FILES['profile-pic'];
+					$upload_overrides = array(
+						'action' => 'save_profile_details',
+					);
+					$uploaded         = wp_handle_upload( $upload, $upload_overrides );
+
+					if ( $uploaded && ! isset( $uploaded['error'] ) ) {
+						$image = wp_get_image_editor( $uploaded['file'] );
+
+						if ( ! is_wp_error( $image ) ) {
+							$image->resize( 150, 150, true );
+							$image->save( $uploaded['file'] );
+						}
+						if ( wp_http_validate_url( $uploaded['url'] ) ) {
+							$profile_pic_url = esc_url_raw( $uploaded['url'] );
+							update_user_meta( $user_id, 'user_registration_profile_pic_url', $profile_pic_url );
+						}
+					} else {
+						ur_add_notice( $uploaded['error'], 'error' );
 					}
-				} else {
-					ur_add_notice( $uploaded['error'], 'error' );
-				}
-			}
-			 elseif ( UPLOAD_ERR_NO_FILE !== $_FILES['profile-pic']['error'] ) {
+				} elseif ( UPLOAD_ERR_NO_FILE !== $_FILES['profile-pic']['error'] ) {
 
-				switch ( $_FILES['profile-pic']['error'] ) {
-					case UPLOAD_ERR_INI_SIZE:
-						ur_add_notice( esc_html__( 'File size exceed, please check your file size.', 'user-registration' ), 'error' );
-						break;
-					default:
-						ur_add_notice( esc_html__( 'Something went wrong while uploading, please contact your site administrator.', 'user-registration' ), 'error' );
-						break;
-				}
-			} elseif ( empty( $_POST['profile-pic-url'] ) ) {
-				$upload_dir  = wp_upload_dir();
-				$profile_url = get_user_meta( $user_id, 'user_registration_profile_pic_url', true );
-
-				// Check if profile already set?
-				if ( $profile_url ) {
-
-					// Then delete file and user meta.
-					$profile_url = $upload_dir['basedir'] . explode( '/uploads', $profile_url )[1];
-
-					if ( ! empty( $profile_url ) && file_exists( $profile_url ) ) {
-						@unlink( $profile_url );
+					switch ( $_FILES['profile-pic']['error'] ) {
+						case UPLOAD_ERR_INI_SIZE:
+							 ur_add_notice( esc_html__( 'File size exceed, please check your file size.', 'user-registration' ), 'error' );
+							break;
+						default:
+							 ur_add_notice( esc_html__( 'Something went wrong while uploading, please contact your site administrator.', 'user-registration' ), 'error' );
+							break;
 					}
-					delete_user_meta( $user_id, 'user_registration_profile_pic_url' );
+				} elseif ( empty( $_POST['profile-pic-url'] ) ) {
+					$upload_dir  = wp_upload_dir();
+					$profile_url = get_user_meta( $user_id, 'user_registration_profile_pic_url', true );
+
+					// Check if profile already set?
+					if ( $profile_url ) {
+
+						// Then delete file and user meta.
+						$profile_url = $upload_dir['basedir'] . explode( '/uploads', $profile_url )[1];
+
+						if ( ! empty( $profile_url ) && file_exists( $profile_url ) ) {
+							@unlink( $profile_url );
+						}
+						delete_user_meta( $user_id, 'user_registration_profile_pic_url' );
+					}
 				}
 			}
 		}
-	}
 
 		$form_id_array = get_user_meta( $user_id, 'ur_form_id' );
 		$form_id       = 0;
@@ -156,16 +158,16 @@ class UR_Form_Handler {
 						$_POST[ $key ] = (int) isset( $_POST[ $key ] );
 					}
 					break;
-				case 'wysiwyg' :
+				case 'wysiwyg':
 					if ( isset( $_POST[ $key ] ) ) {
-						$_POST[ $key ] = sanitize_text_field( htmlentities( $_POST[$key] ) );
+						$_POST[ $key ] = sanitize_text_field( htmlentities( $_POST[ $key ] ) );
 					} else {
 						$_POST[ $key ] = '';
 					}
 					break;
 
 				default:
-					$_POST[ $key ] = isset( $_POST[ $key ] ) ? sanitize_text_field(( $_POST[ $key ] ) ) : '';
+					$_POST[ $key ] = isset( $_POST[ $key ] ) ? sanitize_text_field( ( $_POST[ $key ] ) ) : '';
 					break;
 			}
 
@@ -253,7 +255,7 @@ class UR_Form_Handler {
 
 			do_action( 'user_registration_save_profile_details', $user_id, $form_id );
 
-			wp_safe_redirect(home_url( add_query_arg( array(), $wp->request ) ));
+			wp_safe_redirect( home_url( add_query_arg( array(), $wp->request ) ) );
 			exit;
 		}
 	}
@@ -313,7 +315,7 @@ class UR_Form_Handler {
 		} elseif ( ! $bypass_current_password && ! wp_check_password( $pass_cur, $current_user->user_pass, $current_user->ID ) ) {
 			ur_add_notice( __( 'Your current password is incorrect.', 'user-registration' ), 'error' );
 			$save_pass = false;
-		} elseif ( wp_check_password($pass1, $current_user->user_pass,$current_user->ID) && $current_user ) {
+		} elseif ( wp_check_password( $pass1, $current_user->user_pass, $current_user->ID ) && $current_user ) {
 			ur_add_notice( __( 'New password must not be same as old password', 'user-registration' ), 'error' );
 			$save_pass = false;
 		}
@@ -351,7 +353,7 @@ class UR_Form_Handler {
 
 		// Custom error messages.
 		$messages = array(
-			'empty_username'	   => get_option( 'user_registration_message_username_required', __( 'Username is required.', 'user-registration' ) ),
+			'empty_username'       => get_option( 'user_registration_message_username_required', __( 'Username is required.', 'user-registration' ) ),
 			'empty_password'       => get_option( 'user_registration_message_empty_password', null ),
 			'invalid_username'     => get_option( 'user_registration_message_invalid_username', null ),
 			'unknown_email'        => get_option( 'user_registration_message_unknown_email', __( 'A user could not be found with this email address.', 'user-registration' ) ),
@@ -359,9 +361,9 @@ class UR_Form_Handler {
 			'denied_access'        => get_option( 'user_registration_message_denied_account', null ),
 		);
 
-		$nonce_value     = isset( $_POST['_wpnonce'] ) ? sanitize_key($_POST['_wpnonce']) : '';
+		$nonce_value     = isset( $_POST['_wpnonce'] ) ? sanitize_key( $_POST['_wpnonce'] ) : '';
 		$nonce_value     = isset( $_POST['user-registration-login-nonce'] ) ? $_POST['user-registration-login-nonce'] : $nonce_value;
-		$recaptcha_value = isset( $_POST['g-recaptcha-response'] ) ? sanitize_text_field( wp_unslash( $_POST['g-recaptcha-response'] ) ): '';
+		$recaptcha_value = isset( $_POST['g-recaptcha-response'] ) ? sanitize_text_field( wp_unslash( $_POST['g-recaptcha-response'] ) ) : '';
 		$recaptcha_enabled = get_option( 'user_registration_login_options_enable_recaptcha', 'no' );
 		$recaptcha_version = get_option( 'user_registration_integration_setting_recaptcha_version' );
 		$secret_key        = 'v3' === $recaptcha_version ? get_option( 'user_registration_integration_setting_recaptcha_site_secret_v3' ) : get_option( 'user_registration_integration_setting_recaptcha_site_secret' );
@@ -374,7 +376,7 @@ class UR_Form_Handler {
 					'remember'      => isset( $_POST['rememberme'] ),
 				);
 
-				$username         = sanitize_user(trim( $_POST['username'] ) );
+				$username         = sanitize_user( trim( $_POST['username'] ) );
 				$validation_error = new WP_Error();
 				$validation_error = apply_filters( 'user_registration_process_login_errors', $validation_error, $_POST['username'], $_POST['password'] );
 
@@ -422,15 +424,15 @@ class UR_Form_Handler {
 				}
 
 				// To check the specific login
-				if ( "email" === get_option('user_registration_general_setting_login_options_with',array()) ) {
+				if ( 'email' === get_option( 'user_registration_general_setting_login_options_with', array() ) ) {
 					$user_data = get_user_by( 'email', $username );
 					$creds['user_login'] = isset( $user_data->user_email ) ? $user_data->user_email : is_email( $username );
-			    } elseif ("username" === get_option( 'user_registration_general_setting_login_options_with',array() ) ) {
+				} elseif ( 'username' === get_option( 'user_registration_general_setting_login_options_with', array() ) ) {
 					$user_data = get_user_by( 'login', $username );
-					$creds['user_login'] = isset( $user_data->user_login ) ? $user_data->user_login : !is_email( $username );
-			    } else {
-					$creds['user_login'] =  $username;
-			 	}
+					$creds['user_login'] = isset( $user_data->user_login ) ? $user_data->user_login : ! is_email( $username );
+				} else {
+					$creds['user_login'] = $username;
+				}
 
 				// Perform the login
 				$user = wp_signon( apply_filters( 'user_registration_login_credentials', $creds ), is_ssl() );
@@ -483,7 +485,7 @@ class UR_Form_Handler {
 	 * Handle lost password form.
 	 */
 	public static function process_lost_password() {
-		if ( isset( $_POST['ur_reset_password'] ) && isset( $_POST['user_login'] ) && isset( $_POST['_wpnonce'] ) && wp_verify_nonce( sanitize_key($_POST['_wpnonce']), 'lost_password' ) ) {
+		if ( isset( $_POST['ur_reset_password'] ) && isset( $_POST['user_login'] ) && isset( $_POST['_wpnonce'] ) && wp_verify_nonce( sanitize_key( $_POST['_wpnonce'] ), 'lost_password' ) ) {
 			$success = UR_Shortcode_My_Account::retrieve_password();
 
 			// If successful, redirect to my account with query arg set

--- a/templates/myaccount/form-edit-profile.php
+++ b/templates/myaccount/form-edit-profile.php
@@ -138,6 +138,10 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 											if ( class_exists( 'UserRegistrationConditionalLogic' ) ) {
 												// Migrate the conditional logic to logic_map schema.
 												$single_item = class_exists( 'URCL_Field_Settings' ) && method_exists( URCL_Field_Settings::class, 'migrate_to_logic_map_schema' ) ? URCL_Field_Settings::migrate_to_logic_map_schema( $single_item ) : $single_item;
+
+												if ( 'profile_picture' === $single_item->field_key ) {
+													continue;
+												}
 											}
 
 											$user_id                    = get_current_user_id();
@@ -179,6 +183,7 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 											<div class="ur-field-item field-<?php echo esc_attr( $single_item->field_key ); ?>"  <?php echo $cl_props; ?> data-field-id="<?php echo esc_attr( $field_id ); ?>">
 												<?php
 												$readonly_fields = ur_readonly_profile_details_fields();
+
 												if ( array_key_exists( $field['field_key'], $readonly_fields ) ) {
 													$field['custom_attributes']['readonly'] = 'readonly';
 													if ( isset( $readonly_fields[ $field['field_key'] ] ['value'] ) ) {

--- a/templates/myaccount/form-edit-profile.php
+++ b/templates/myaccount/form-edit-profile.php
@@ -37,6 +37,8 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 								$gravatar_image      = get_avatar_url( get_current_user_id(), $args = null );
 								$profile_picture_url = get_user_meta( get_current_user_id(), 'user_registration_profile_pic_url', true );
 								$image               = ( ! empty( $profile_picture_url ) ) ? $profile_picture_url : $gravatar_image;
+								$max_size = wp_max_upload_size();
+								$max_upload_size = $max_size;
 
 								foreach ( $form_data_array as $data ) {
 									foreach ( $data as $grid_key => $grid_data ) {
@@ -47,18 +49,16 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 												if ( ! empty( $single_item->advance_setting->valid_file_type ) ) {
 													$edit_profile_valid_file_type = implode( ', ', $single_item->advance_setting->valid_file_type );
 												}
-												$max_upload_size = isset( $single_item->advance_setting->max_upload_size ) ? $single_item->advance_setting->max_upload_size : '';
+												$max_upload_size = isset( $single_item->advance_setting->max_upload_size ) && '' !== $single_item->advance_setting->max_upload_size ? $single_item->advance_setting->max_upload_size : $max_size;
 											}
 										}
 									}
 								}
+
 								?>
 									<img class="profile-preview" alt="profile-picture" src="<?php echo esc_url( $image ); ?>" style='max-width:96px; max-height:96px;' >
-									<?php
-									$max_size = wp_max_upload_size();
-									$max_size = size_format( $max_size );
-									?>
-									<p class="user-registration-tips"><?php echo esc_html__( 'Max size: ', 'user-registration' ) . esc_attr( $max_size ); ?></p>
+
+									<p class="user-registration-tips"><?php echo esc_html__( 'Max size: ', 'user-registration' ) . esc_attr( size_format( $max_upload_size ) ); ?></p>
 								</div>
 								<header>
 									<p><strong><?php echo esc_html( apply_filters( 'user_registration_upload_new_profile_image_message', esc_html__( 'Upload your new profile image.', 'user-registration' ) ) ); ?></strong></p>

--- a/templates/myaccount/form-edit-profile.php
+++ b/templates/myaccount/form-edit-profile.php
@@ -27,7 +27,7 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 		<div class="ur-form-row">
 			<div class="ur-form-grid">
 				<div class="user-registration-profile-fields">
-					<h2><?php _e( 'Profile Detail', 'user-registration' ); ?></h2>
+					<h2><?php esc_html_e( 'Profile Detail', 'user-registration' ); ?></h2>
 					<?php
 					if ( 'no' === get_option( 'user_registration_disable_profile_picture', 'no' ) ) {
 						?>
@@ -70,7 +70,7 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 											<div class="uraf-profile-picture-upload">
 												<p class="form-row " id="profile_pic_url_field" data-priority="">
 													<span class="uraf-profile-picture-upload-node" style="height: 0;width: 0;margin: 0;padding: 0;float: left;border: 0;overflow: hidden;">
-													<input type="file" id="ur-profile-pic" name="profile-pic" class="profile-pic-upload" size="<?php echo esc_attr( $max_upload_size ); ?> accept="<?php echo esc_html( $edit_profile_valid_file_type ); ?>" style="<?php echo esc_attr( ( $gravatar_image !== $image ) ? 'display:none;' : '' ); ?>" />
+													<input type="file" id="ur-profile-pic" name="profile-pic" class="profile-pic-upload" size="<?php echo esc_attr( $max_upload_size ); ?>" accept="<?php echo esc_attr( $edit_profile_valid_file_type ); ?>" style="<?php echo esc_attr( ( $gravatar_image !== $image ) ? 'display:none;' : '' ); ?>" />
 													<?php echo '<input type="text" class="uraf-profile-picture-input input-text ur-frontend-field" name="profile_pic_url" id="profile_pic_url" value="' . esc_url( $profile_picture_url ) . '" />'; ?>
 													</span>
 													<?php do_action( 'uraf_profile_picture_buttons' ); ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When removing and saving changes in the edit profile, the old image is still appearing i.e was not removed completely, and also users were unable to update new images due to wrong escaping used. This PR fixes these issues.

### How to test the changes in this Pull Request:

1. Verify if profile picture remove, save and update are working properly on the edit profile page.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Profile picture remove, update and save on the edit profile page.
