### PR TITLE
UR-70 Fix - Cannot unhide labels

### DIFF
--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -1056,6 +1056,7 @@
 							init: function () {
 								this.single_row();
 								this.manage_required_fields();
+								this.manage_label_hidden_fields();
 							},
 							single_row: function () {
 								if (
@@ -1199,6 +1200,28 @@
 									.eq("0")
 									.css({});
 								return grid_lists;
+							},
+							/**
+							 * Hides label of fields if hide label option is enabled.
+							 */
+							manage_label_hidden_fields: function () {
+								$('select[data-field="hide_label"]').each(
+									function () {
+										if ($(this).val() === "yes") {
+											$(this)
+												.closest(".ur-selected-item")
+												.find(".ur-label")
+												.find("label")
+												.hide();
+										} else {
+											$(this)
+												.closest(".ur-selected-item")
+												.find(".ur-label")
+												.find("label")
+												.show();
+										}
+									}
+								);
 							},
 							/**
 							 * Information about required fields
@@ -3264,6 +3287,21 @@
 			 */
 			trigger_general_setting_hide_label: function ($label) {
 				var wrapper = $(".ur-selected-item.ur-item-active");
+				wrapper
+					.find(".ur-general-setting-block")
+					.find(
+						'select[data-field="' +
+							$label.attr("data-field") +
+							'"] option:selected'
+					)
+					.removeAttr("selected");
+
+				if ("yes" === $label.val()) {
+					wrapper.find(".ur-label").find("label").hide();
+				} else {
+					wrapper.find(".ur-label").find("label").show();
+				}
+
 				wrapper
 					.find(".ur-general-setting-block")
 					.find(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously, when users change the hide label for a certain field, it was not being dynamically hidden/shown in the form builder and its proper value was not being saved after the update. This PR fixes this issue.

### How to test the changes in this Pull Request:

1. Navigate to form builder and verify if the hide label option is working properly.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Cannot unhide labels.