### PR TITLE
Fix - Issues due to wrong phpcs fix

### DIFF
--- a/assets/js/frontend/user-registration.js
+++ b/assets/js/frontend/user-registration.js
@@ -949,9 +949,9 @@
 					 * @since  1.8.5
 					 */
 					edit_profile_event: function () {
-						$("form.user-registration-EditProfileForm").on(
-							"submit",
-							function (event) {
+						$("form.user-registration-EditProfileForm")
+							.off("submit")
+							.on("submit", function (event) {
 								var $this = $(this);
 
 								// Validator messages.
@@ -1153,8 +1153,7 @@
 										);
 									},
 								});
-							}
-						);
+							});
 					},
 				};
 				form.init();

--- a/includes/admin/class-ur-admin-settings.php
+++ b/includes/admin/class-ur-admin-settings.php
@@ -727,11 +727,11 @@ class UR_Admin_Settings {
 					$option_name = sanitize_text_field( current( array_keys( $option_name_array ) ) );
 
 					$setting_name = key( $option_name_array[ $option_name ] );
-					$raw_value    = isset( $_POST[ $option_name ][ $setting_name ] ) ? sanitize_text_field( wp_unslash( $_POST[ $option_name ][ $setting_name ] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification
+					$raw_value    = isset( $_POST[ $option_name ][ $setting_name ] ) ? wp_unslash( $_POST[ $option_name ][ $setting_name ] ) : null; // phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 				} else {
 					$option_name  = sanitize_text_field( $option['id'] );
 					$setting_name = '';
-					$raw_value    = isset( $_POST[ $option['id'] ] ) ? sanitize_text_field( wp_unslash( $_POST[ $option['id'] ] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification
+					$raw_value    = isset( $_POST[ $option['id'] ] ) ? wp_unslash( $_POST[ $option['id'] ] ) : null; // phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 				}
 
 				// Format the value based on option type.

--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -282,7 +282,7 @@ class UR_AJAX {
 					}
 					break;
 				default:
-					$single_field[ $key ] = isset( $single_field[ $key ] ) ? sanitize_text_field( ( $single_field[ $key ] ) ) : '';
+					$single_field[ $key ] = isset( $single_field[ $key ] ) ? $single_field[ $key ] : '';
 					break;
 			}
 

--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -168,12 +168,12 @@ class UR_Form_Handler {
 					break;
 
 				default:
-					$_POST[ $key ] = isset( $_POST[ $key ] ) ? sanitize_text_field( wp_unslash( $_POST[ $key ] ) ) : '';
+					$_POST[ $key ] = isset( $_POST[ $key ] ) ? wp_unslash( $_POST[ $key ] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 					break;
 			}
 
 			// Hook to allow modification of value.
-			$_POST[ $key ] = apply_filters( 'user_registration_process_myaccount_field_' . $key, sanitize_text_field( wp_unslash( $_POST[ $key ] ) ) );
+			$_POST[ $key ] = apply_filters( 'user_registration_process_myaccount_field_' . $key, wp_unslash( $_POST[ $key ] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 			$disabled = false;
 			if ( isset( $field['custom_attributes'] ) && isset( $field['custom_attributes']['readonly'] ) && isset( $field['custom_attributes']['disabled'] ) ) {
@@ -181,7 +181,7 @@ class UR_Form_Handler {
 					$disabled = true;
 				}
 			}
-			error_log( print_r( $_POST, true ) );
+
 			// Validation: Required fields.
 			if ( ! empty( $field['required'] ) && empty( $_POST[ $key ] ) && ! $disabled ) {
 				/* translators: %s - Field Label */
@@ -217,7 +217,7 @@ class UR_Form_Handler {
 				}
 			}
 			// Action to add extra validation to edit profile fields.
-			do_action( 'user_registration_validate_' . $key, sanitize_text_field( wp_unslash( $_POST[ $key ] ) ) );
+			do_action( 'user_registration_validate_' . $key, wp_unslash( $_POST[ $key ] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		}
 
@@ -233,7 +233,7 @@ class UR_Form_Handler {
 					if ( 'display_name' === $new_key ) {
 						$user_data['display_name'] = sanitize_text_field( wp_unslash( $_POST[ $key ] ) );
 					} else {
-						$user_data[ $new_key ] = sanitize_text_field( wp_unslash( $_POST[ $key ] ) );
+						$user_data[ $new_key ] = wp_unslash( $_POST[ $key ] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 					}
 				} else {
 					$update_key = $key;
@@ -244,7 +244,7 @@ class UR_Form_Handler {
 					$disabled = isset( $field['custom_attributes']['disabled'] ) ? $field['custom_attributes']['disabled'] : '';
 
 					if ( 'disabled' !== $disabled ) {
-						update_user_meta( $user_id, $update_key, sanitize_text_field( wp_unslash( $_POST[ $key ] ) ) );
+						update_user_meta( $user_id, $update_key, wp_unslash( $_POST[ $key ] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 					}
 				}
 			}

--- a/templates/form-registration.php
+++ b/templates/form-registration.php
@@ -101,7 +101,7 @@ do_action( 'user_registration_before_registration_form', $form_id );
 												}
 											}
 											?>
-															<div <?php echo esc_attr( $cl_props ); ?> data-field-id="<?php echo esc_attr( $field_id ); ?>" class="ur-field-item field-<?php echo esc_attr( $single_item->field_key ); ?> <?php echo esc_attr( ! empty( $single_item->advance_setting->custom_class ) ? $single_item->advance_setting->custom_class : '' ); ?>">
+															<div <?php echo $cl_props; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> data-field-id="<?php echo esc_attr( $field_id ); ?>" class="ur-field-item field-<?php echo esc_attr( $single_item->field_key ); ?> <?php echo esc_attr( ! empty( $single_item->advance_setting->custom_class ) ? $single_item->advance_setting->custom_class : '' ); ?>">
 													<?php
 														$frontend->user_registration_frontend_form( $single_item, $form_id );
 														$is_field_exists = true;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
After the release of v2.1.4, we have found multiple issues related to wrong phpcs fixes. The issues are
1. Go to Settings-> Email and open any email, click on save changes, the email contents will appear inline stripping html tags.
2. Conditional logic in fields not working.
3. Multi select2 value not being saved in edit profile.
4. Multiple profiles updated email to admin

This PR fixes these issues.

### How to test the changes in this Pull Request:

1. Go to Settings-> Email and open any email, click on save changes, verify if email contents appear inline or not.
2. Check if conditional logic in fields is working properly.
3. Check if multi select2 values are being saved in the edit profile.
4. Check if multiple emails are being received or not when the user updates profile details.
5. Check if all field values are being saved or not in both registration form and edit profile ( both ajax and norma submissions ).

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry
> Fix - Issues due to wrong phpcs fix.