### PR TITLE
UR-239 Fix - Email field empty when field visibility is readonly after profile update

### DIFF
--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -159,7 +159,7 @@ class UR_Form_Handler {
 						$_POST[ $key ] = (int) isset( $_POST[ $key ] );
 					}
 					break;
-					
+
 				case 'wysiwyg':
 					if ( isset( $_POST[ $key ] ) ) {
 						$_POST[ $key ] = sanitize_text_field( htmlentities( wp_unslash( $_POST[ $key ] ) ) ); // phpcs:ignore
@@ -170,7 +170,7 @@ class UR_Form_Handler {
 
 				case 'email':
 					if ( isset( $_POST[ $key ] ) ) {
-						$_POST[ $key ] = sanitize_text_field( htmlentities( wp_unslash( $_POST[ $key ] ) ) ); // phpcs:ignore
+						$_POST[ $key ] = sanitize_text_field( wp_unslash( $_POST[ $key ] ) ); // phpcs:ignore
 					} else {
 						$user_data = get_userdata($user_id);
 						$_POST[ $key ] = $user_data->data->user_email;

--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -154,11 +154,12 @@ class UR_Form_Handler {
 			switch ( $field['type'] ) {
 				case 'checkbox':
 					if ( isset( $_POST[ $key ] ) && is_array( $_POST[ $key ] ) ) {
-						$_POST[ $key ] = sanitize_text_field( wp_unslash( $_POST[ $key ] ) );
+						$_POST[ $key ] = wp_unslash( $_POST[ $key ] );
 					} else {
 						$_POST[ $key ] = (int) isset( $_POST[ $key ] );
 					}
 					break;
+					
 				case 'wysiwyg':
 					if ( isset( $_POST[ $key ] ) ) {
 						$_POST[ $key ] = sanitize_text_field( htmlentities( wp_unslash( $_POST[ $key ] ) ) ); // phpcs:ignore

--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -172,7 +172,7 @@ class UR_Form_Handler {
 					if ( isset( $_POST[ $key ] ) ) {
 						$_POST[ $key ] = sanitize_text_field( wp_unslash( $_POST[ $key ] ) ); // phpcs:ignore
 					} else {
-						$user_data = get_userdata($user_id);
+						$user_data = get_userdata( $user_id );
 						$_POST[ $key ] = $user_data->data->user_email;
 					}
 					break;

--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -154,7 +154,7 @@ class UR_Form_Handler {
 			switch ( $field['type'] ) {
 				case 'checkbox':
 					if ( isset( $_POST[ $key ] ) && is_array( $_POST[ $key ] ) ) {
-						$_POST[ $key ] = wp_unslash( $_POST[ $key ] );
+						$_POST[ $key ] = wp_unslash( $_POST[ $key ] ); // phpcs:ignore
 					} else {
 						$_POST[ $key ] = (int) isset( $_POST[ $key ] );
 					}

--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -170,7 +170,7 @@ class UR_Form_Handler {
 
 				case 'email':
 					if ( isset( $_POST[ $key ] ) ) {
-						$_POST[ $key ] = sanitize_text_field( wp_unslash( $_POST[ $key ] ) );
+						$_POST[ $key ] = sanitize_email( wp_unslash( $_POST[ $key ] ) );
 					} else {
 						$user_data = get_userdata( $user_id );
 						$_POST[ $key ] = $user_data->data->user_email;

--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -167,6 +167,15 @@ class UR_Form_Handler {
 					}
 					break;
 
+				case 'email':
+					if ( isset( $_POST[ $key ] ) ) {
+						$_POST[ $key ] = sanitize_text_field( htmlentities( wp_unslash( $_POST[ $key ] ) ) ); // phpcs:ignore
+					} else {
+						$user_data = get_userdata($user_id);
+						$_POST[ $key ] = $user_data->data->user_email;
+					}
+					break;
+
 				default:
 					$_POST[ $key ] = isset( $_POST[ $key ] ) ? wp_unslash( $_POST[ $key ] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 					break;

--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -170,7 +170,7 @@ class UR_Form_Handler {
 
 				case 'email':
 					if ( isset( $_POST[ $key ] ) ) {
-						$_POST[ $key ] = sanitize_text_field( wp_unslash( $_POST[ $key ] ) ); // phpcs:ignore
+						$_POST[ $key ] = sanitize_text_field( wp_unslash( $_POST[ $key ] ) );
 					} else {
 						$user_data = get_userdata( $user_id );
 						$_POST[ $key ] = $user_data->data->user_email;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Previously, When field visibility is set to read only in user email and the submission type is POST then when the user used to update the profile details the email field value. This PR will resolve these issues.

### How to test the changes in this Pull Request:

1. First Navigate to form builder and go to field option of user email and enable field visibility read-only to profile details. 
2. then navigate user registration settings and disable ajax submission on edit profile.
3. then login and update the profile and verify whether it is working as expected or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Email field empty when field visibility is readonly after profile update.
