### PR TITLE
UR-247 Fix- Admin approval keeps switching to pending from user profile

### DIFF
--- a/includes/admin/class-ur-admin-user-list-manager.php
+++ b/includes/admin/class-ur-admin-user-list-manager.php
@@ -650,9 +650,6 @@ class UR_Admin_User_List_Manager {
 		if ( isset( $_POST['ur_user_user_status'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$new_status = sanitize_text_field( wp_unslash( $_POST['ur_user_user_status'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
 			$user_manager->save_status( $new_status );
-		} elseif ( isset( $_POST['ur_user_email_confirmation_status'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$new_status = sanitize_text_field( wp_unslash( $_POST['ur_user_email_confirmation_status'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
-			return update_user_meta( absint( $user_id ), 'ur_confirm_email', $new_status );
 		}
 	}
 }

--- a/includes/admin/class-ur-admin-user-list-manager.php
+++ b/includes/admin/class-ur-admin-user-list-manager.php
@@ -299,7 +299,7 @@ class UR_Admin_User_List_Manager {
 			$status       = $user_manager->get_user_status();
 
 			if ( ! empty( $status ) ) {
-					return UR_Admin_User_Manager::get_status_label( $status['user_status'] );
+				return UR_Admin_User_Manager::get_status_label( $status['user_status'] );
 			}
 		} elseif ( 'ur_user_user_registered_source' === $column_name ) {
 			$user_metas = get_user_meta( $user_id );
@@ -388,7 +388,7 @@ class UR_Admin_User_List_Manager {
 			<option value=""><?php esc_html_e( 'All UR Forms', 'user-registration' ); ?></option>
 
 		<?php
-				$all_forms = ur_get_all_user_registration_form();
+			$all_forms = ur_get_all_user_registration_form();
 
 		foreach ( $all_forms as $form_id => $form_name ) {
 			echo '<option value="' . esc_attr( $form_id ) . '" ' . esc_attr( selected( $form_id, $specific_form_filter_value ) ) . ' >' . esc_html( $form_name ) . '</option>';
@@ -608,21 +608,21 @@ class UR_Admin_User_List_Manager {
 					<td>
 
 						<select id="ur_user_user_status" name="ur_user_user_status">
-						<?php
-						$available_statuses = array( UR_Admin_User_Manager::APPROVED, UR_Admin_User_Manager::PENDING, UR_Admin_User_Manager::DENIED );
-						foreach ( $available_statuses as $status ) :
-							?>
+					<?php
+					$available_statuses = array( UR_Admin_User_Manager::APPROVED, UR_Admin_User_Manager::PENDING, UR_Admin_User_Manager::DENIED );
+					foreach ( $available_statuses as $status ) :
+						?>
 							<option
 								value="<?php echo esc_attr( $status ); ?>"<?php esc_attr( selected( $status, $user_status['user_status'] ) ); ?>><?php echo esc_html( UR_Admin_User_Manager::get_status_label( $status ) ); ?></option>
 							<?php
-						endforeach;
-						?>
+							endforeach;
+					?>
 						</select>
 						<span class="description"><?php esc_html_e( 'If user has access to sign in or not.', 'user-registration' ); ?></span>
 					</td>
 				</tr>
 			</table>
-							<?php
+						<?php
 	}
 
 	/**
@@ -643,13 +643,21 @@ class UR_Admin_User_List_Manager {
 			return false;
 		}
 
-		if ( get_user_meta( $user_id, 'ur_user_status', true ) == $_POST['ur_user_user_status'] ) { // phpcs:ignore WordPress.Security.NonceVerification
+		$user_status       = get_user_meta( $user_id, 'ur_user_status', true );
+		$user_email_status = get_user_meta( $user_id, 'ur_confirm_email', true );
+
+		if ( '' === $user_email_status && $user_status == $_POST['ur_user_user_status'] ) { // phpcs:ignore WordPress.Security.NonceVerification
+			return false;
+		} elseif ( '' !== $user_email_status && $user_status == $_POST['ur_user_user_status'] && $user_email_status == $_POST['ur_user_user_status'] ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return false;
 		}
 
 		if ( isset( $_POST['ur_user_user_status'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$new_status = sanitize_text_field( wp_unslash( $_POST['ur_user_user_status'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
 			$user_manager->save_status( $new_status );
+		} elseif ( isset( $_POST['ur_user_email_confirmation_status'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			$new_status = sanitize_text_field( wp_unslash( $_POST['ur_user_email_confirmation_status'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+			return update_user_meta( absint( $user_id ), 'ur_confirm_email', $new_status );
 		}
 	}
 }

--- a/includes/admin/class-ur-admin-user-manager.php
+++ b/includes/admin/class-ur-admin-user-manager.php
@@ -32,6 +32,7 @@ class UR_Admin_User_Manager {
 
 	/**
 	 * WP user object
+	 *
 	 * @var \WP_User
 	 */
 	private $user;
@@ -48,7 +49,7 @@ class UR_Admin_User_Manager {
 	 *
 	 * @param null $user user.
 	 *
-	 * @throws Exception. // phpcs:ignore
+	 * @throws Exception .
 	 */
 	public function __construct( $user = null ) {
 		if ( is_null( $user ) ) {
@@ -68,8 +69,8 @@ class UR_Admin_User_Manager {
 	/**
 	 * Save a new status for the user
 	 *
-	 * @param $status status.
-	 * @param $alert_user alert status.
+	 * @param string $status status.
+	 * @param int    $alert_user alert_user.
 	 *
 	 * @return bool|int $meta_status meta status.
 	 */
@@ -160,7 +161,7 @@ class UR_Admin_User_Manager {
 		$user_email_status = get_user_meta( $this->user->ID, 'ur_confirm_email', true );
 		$admin_approval_after_email_confirmation_status = get_user_meta( $this->user->ID, 'ur_admin_approval_after_email_confirmation', true );
 
-		$result            = '';
+		$result = '';
 
 		if ( '' === $user_status && '' === $user_email_status ) {
 			// If the exact_value is true, allow to understand if an user has status "approved" or has registered when the plugin wash not active.
@@ -225,9 +226,9 @@ class UR_Admin_User_Manager {
 		$user_status = $this->get_user_status();
 
 		if ( is_array( $user_status ) ) {
-			return ( self::APPROVED == $user_status['user_status'] );
+			return ( self::APPROVED === $user_status['user_status'] );
 		}
-		return ( self::APPROVED == $user_status );
+		return ( self::APPROVED === $user_status );
 	}
 
 	/**
@@ -239,9 +240,9 @@ class UR_Admin_User_Manager {
 		$user_status = $this->get_user_status();
 
 		if ( is_array( $user_status ) ) {
-			return ( self::PENDING == $user_status['user_status'] );
+			return ( self::PENDING === $user_status['user_status'] );
 		}
-		return ( self::PENDING == $user_status );
+		return ( self::PENDING === $user_status );
 	}
 
 	/**
@@ -253,9 +254,9 @@ class UR_Admin_User_Manager {
 		$user_status = $this->get_user_status();
 
 		if ( is_array( $user_status ) ) {
-			return ( self::DENIED == $user_status['user_status'] );
+			return ( self::DENIED === $user_status['user_status'] );
 		}
-		return ( self::DENIED == $user_status );
+		return ( self::DENIED === $user_status );
 	}
 
 	/**
@@ -276,7 +277,7 @@ class UR_Admin_User_Manager {
 		// If the first_access_flag is equal to "" it means that user has registered when the plugin was not active, then don't reset.
 		// If the first_access_flag is equal to 1 it means that user has has already loggedin at least one time, then don't reset.
 		$first_access_flag = $this->get_first_access_flag();
-		if ( $first_access_flag == 1 ) {
+		if ( 1 === $first_access_flag ) {
 			return $password;
 		}
 
@@ -319,19 +320,19 @@ class UR_Admin_User_Manager {
 	/**
 	 * Check if the instanced user can change status of the user passed by parameter
 	 *
-	 * @param $user_id
+	 * @param int $user_id user_id.
 	 *
 	 * @return bool
 	 */
 	public function can_change_status_of( $user_id ) {
 
-		// The instanced user is not able to update statuses at all
+		// The instanced user is not able to update statuses at all.
 		if ( ! $this->is_allowed_to_change_users_status() ) {
 			return false;
 		}
 
 		// The instanced user is the same user who the status have to be changed.
-		if ( $this->user->ID == $user_id ) {
+		if ( $this->user->ID === $user_id ) {
 			return false;
 		}
 
@@ -347,7 +348,7 @@ class UR_Admin_User_Manager {
 	/**
 	 * Check if the approval status of the instanced user can be changd by the user passed by parameter
 	 *
-	 * @param null|int|\WP_User $user if this value is null, it is considered the current user
+	 * @param null|int|\WP_User $user if this value is null, it is considered the current user.
 	 *
 	 * @return bool
 	 */
@@ -363,7 +364,7 @@ class UR_Admin_User_Manager {
 	 * Check if a certain user (passed by parameter) is allowed to change approval status of other users
 	 * If user id is not passed by parameter, it will be user the current user id
 	 *
-	 * @param null $user_id
+	 * @param null $user_id user_id.
 	 *
 	 * @return bool
 	 */
@@ -376,20 +377,22 @@ class UR_Admin_User_Manager {
 	}
 
 	/**
-	 * @param int $status
+	 * Get status label
+	 *
+	 * @param string $status status.
 	 *
 	 * @return string
 	 */
 	public static function get_status_label( $status ) {
-		if ( $status == self::APPROVED ) {
+		if ( self::APPROVED == $status ) {
 			$label = esc_html__( 'approved', 'user-registration' );
 		}
 
-		if ( $status == self::PENDING ) {
+		if ( self::PENDING == $status ) {
 			$label = esc_html__( 'pending', 'user-registration' );
 		}
 
-		if ( $status == self::DENIED ) {
+		if ( self::DENIED == $status ) {
 			$label = esc_html__( 'denied', 'user-registration' );
 		}
 
@@ -399,11 +402,11 @@ class UR_Admin_User_Manager {
 	/**
 	 * Check if the status passed by parameter is a valid status
 	 *
-	 * @param $status
+	 * @param string $status status.
 	 *
 	 * @return bool
 	 */
 	public static function validate_status( $status ) {
-		return ( $status == self::APPROVED || $status == self::PENDING || $status == self::DENIED );
+		return ( self::APPROVED === $status || self::PENDING === $status || self::DENIED === $status );
 	}
 }

--- a/includes/admin/class-ur-admin-user-manager.php
+++ b/includes/admin/class-ur-admin-user-manager.php
@@ -86,6 +86,8 @@ class UR_Admin_User_Manager {
 				$action_label = 'approved';
 				if ( 'admin_approval_after_email_confirmation' === $login_option ) {
 					update_user_meta( $this->user->ID, 'ur_admin_approval_after_email_confirmation', 'true' );
+				} elseif ( 'email_confirmation' === $login_option ) {
+					update_user_meta( $this->user->ID, 'ur_confirm_email', $status );
 				}
 				break;
 
@@ -93,6 +95,8 @@ class UR_Admin_User_Manager {
 				$action_label = 'pending';
 				if ( 'admin_approval_after_email_confirmation' === $login_option ) {
 					update_user_meta( $this->user->ID, 'ur_admin_approval_after_email_confirmation', 'false' );
+				} elseif ( 'email_confirmation' === $login_option ) {
+					update_user_meta( $this->user->ID, 'ur_confirm_email', $status );
 				}
 				break;
 
@@ -100,6 +104,8 @@ class UR_Admin_User_Manager {
 				$action_label = 'denied';
 				if ( 'admin_approval_after_email_confirmation' === $login_option ) {
 					update_user_meta( $this->user->ID, 'ur_admin_approval_after_email_confirmation', 'false' );
+				} elseif ( 'email_confirmation' === $login_option ) {
+					update_user_meta( $this->user->ID, 'ur_confirm_email', $status );
 				}
 				break;
 		}

--- a/includes/admin/class-ur-admin-user-manager.php
+++ b/includes/admin/class-ur-admin-user-manager.php
@@ -5,8 +5,6 @@
  * @class    UR_Admin_User_Manager
  * @version  1.0.0
  * @package  UserRegistration/Admin
- * @category Admin
- * @author   WPEverest
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -33,7 +31,10 @@ class UR_Admin_User_Manager {
 	const DENIED = - 1;
 
 	/**
+	 * WP user object
+	 *
 	 * @var \WP_User
+	 *
 	 */
 	private $user;
 
@@ -49,7 +50,7 @@ class UR_Admin_User_Manager {
 	 *
 	 * @param null $user
 	 *
-	 * @throws Exception
+	 * @throws Exception // phpcs:ignore
 	 */
 	public function __construct( $user = null ) {
 		if ( is_null( $user ) ) {
@@ -69,9 +70,10 @@ class UR_Admin_User_Manager {
 	/**
 	 * Save a new status for the user
 	 *
-	 * @param $status
+	 * @param $status status
+	 * @param $alert_user alert status
 	 *
-	 * @return bool|int
+	 * @return bool|int $meta_status meta status
 	 */
 	public function save_status( $status, $alert_user = true ) {
 
@@ -147,7 +149,7 @@ class UR_Admin_User_Manager {
 	 *
 	 * @param bool $exact_value
 	 *
-	 * @return int|mixed
+	 * @return int|mixed $user_status user status
 	 */
 	public function get_user_status( $exact_value = false ) {
 
@@ -225,9 +227,9 @@ class UR_Admin_User_Manager {
 		$user_status = $this->get_user_status();
 
 		if ( is_array( $user_status ) ) {
-			return ( $user_status['user_status'] == self::APPROVED );
+			return ( self::APPROVED == $user_status['user_status'] );
 		}
-		return ( $user_status == self::APPROVED );
+		return ( self::APPROVED == $user_status );
 	}
 
 	/**
@@ -239,9 +241,9 @@ class UR_Admin_User_Manager {
 		$user_status = $this->get_user_status();
 
 		if ( is_array( $user_status ) ) {
-			return ( $user_status['user_status'] == self::PENDING );
+			return ( self::PENDING == $user_status['user_status'] );
 		}
-		return ( $user_status == self::PENDING );
+		return ( self::PENDING  == $user_status );
 	}
 
 	/**
@@ -253,9 +255,9 @@ class UR_Admin_User_Manager {
 		$user_status = $this->get_user_status();
 
 		if ( is_array( $user_status ) ) {
-			return ( $user_status['user_status'] == self::DENIED );
+			return ( self::DENIED == $user_status['user_status'] );
 		}
-		return ( $user_status == self::DENIED );
+		return ( self::DENIED == $user_status );
 	}
 
 	/**

--- a/includes/admin/class-ur-admin-user-manager.php
+++ b/includes/admin/class-ur-admin-user-manager.php
@@ -32,9 +32,7 @@ class UR_Admin_User_Manager {
 
 	/**
 	 * WP user object
-	 *
 	 * @var \WP_User
-	 *
 	 */
 	private $user;
 
@@ -48,9 +46,9 @@ class UR_Admin_User_Manager {
 	/**
 	 * UR_Admin_User_Manager constructor.
 	 *
-	 * @param null $user
+	 * @param null $user user.
 	 *
-	 * @throws Exception // phpcs:ignore
+	 * @throws Exception. // phpcs:ignore
 	 */
 	public function __construct( $user = null ) {
 		if ( is_null( $user ) ) {
@@ -70,10 +68,10 @@ class UR_Admin_User_Manager {
 	/**
 	 * Save a new status for the user
 	 *
-	 * @param $status status
-	 * @param $alert_user alert status
+	 * @param $status status.
+	 * @param $alert_user alert status.
 	 *
-	 * @return bool|int $meta_status meta status
+	 * @return bool|int $meta_status meta status.
 	 */
 	public function save_status( $status, $alert_user = true ) {
 
@@ -147,9 +145,9 @@ class UR_Admin_User_Manager {
 	 * If the status is not present (user registered when plugin was not active)
 	 * then it return an empty string if $exact_value == true, otherwise it return approved flag
 	 *
-	 * @param bool $exact_value
+	 * @param bool $exact_value exact value.
 	 *
-	 * @return int|mixed $user_status user status
+	 * @return int|mixed $user_status user status.
 	 */
 	public function get_user_status( $exact_value = false ) {
 
@@ -243,7 +241,7 @@ class UR_Admin_User_Manager {
 		if ( is_array( $user_status ) ) {
 			return ( self::PENDING == $user_status['user_status'] );
 		}
-		return ( self::PENDING  == $user_status );
+		return ( self::PENDING == $user_status );
 	}
 
 	/**
@@ -269,14 +267,14 @@ class UR_Admin_User_Manager {
 	public function reset_password() {
 		$password = '';
 
-		// If the password reset has been programmatically removed, don't reset
+		// If the password reset has been programmatically removed, don't reset.
 		$avoid_password_reset = apply_filters( 'ur_avoid_password_reset', false );
 		if ( $avoid_password_reset ) {
 			return $password;
 		}
 
-		// If the first_access_flag is equal to "" it means that user has registered when the plugin was not active, then don't reset
-		// If the first_access_flag is equal to 1 it means that user has has already loggedin at least one time, then don't reset
+		// If the first_access_flag is equal to "" it means that user has registered when the plugin was not active, then don't reset.
+		// If the first_access_flag is equal to 1 it means that user has has already loggedin at least one time, then don't reset.
 		$first_access_flag = $this->get_first_access_flag();
 		if ( $first_access_flag == 1 ) {
 			return $password;
@@ -332,13 +330,13 @@ class UR_Admin_User_Manager {
 			return false;
 		}
 
-		// The instanced user is the same user who the status have to be changed
+		// The instanced user is the same user who the status have to be changed.
 		if ( $this->user->ID == $user_id ) {
 			return false;
 		}
 
 		// If the changer user has the capability "edit_users" but not "manage_options" (isn't an admin),
-		// then allow to edit the status of another user only if him hasn't capability "manage_options" (isn't an admin)
+		// then allow to edit the status of another user only if him hasn't capability "manage_options" (isn't an admin).
 		if ( ! user_can( $this->user, 'manage_options' ) && user_can( $user_id, 'manage_options' ) ) {
 			return false;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pull) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When the **user login option** is set to **Email confirmation after Registration** and a user register via the registration form and somehow the user didn't receive an email confirmation. If an admin tries to approve the user manually from the wp users table then it works but if we visit the user profile and try to change the approval status to approved and save it. It defaults back to pending. This PR will fix this issue.

### How to test the changes in this Pull Request:

1. Navigate to user registration form builder and then form setting.
2. In the general tab, select the user login option as **Email confirmation after registration** and update the form.
3. then do register via the registration form and then navigate to the wp users table and visit the user profile then change the approval status and save it.
4. verify whether it is working as expected or not. 

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix- Admin approval keeps switching to pending from user profile.
