### PR TITLE
UR-265 Enhance - Active status on emails settings

### DIFF
--- a/includes/admin/settings/class-ur-settings-email.php
+++ b/includes/admin/settings/class-ur-settings-email.php
@@ -178,6 +178,7 @@ if ( ! class_exists( 'UR_Settings_Email' ) ) :
 				'user_registration_email_setting_columns',
 				array(
 					'name'    => __( 'Email', 'user-registration' ),
+					'status'  => __( 'Status', 'user-registration' ),
 					'actions' => __( 'Configure', 'user-registration' ),
 				)
 			);
@@ -191,10 +192,17 @@ if ( ! class_exists( 'UR_Settings_Email' ) ) :
 
 			$emails = $this->get_emails();
 			foreach ( $emails as $email ) {
+				$status = ! ur_string_to_bool( get_option( 'user_registration_email_setting_disable_email', false ) ) ? ur_string_to_bool( get_option( 'user_registration_enable_' . $email->id, true ) ) : false;
 				$settings .= '<tr><td class="ur-email-settings-table">';
 				$settings .= '<a href="' . esc_url( admin_url( 'admin.php?page=user-registration-settings&tab=email&section=ur_settings_' . $email->id . '' ) ) .
 												'">' . esc_html__( $email->title, 'user-registration' ) . '</a>';
-				$settings .=  ur_help_tip( __( $email->description, 'user-registration' ) );
+				$settings .= ur_help_tip( __( $email->description, 'user-registration' ) );
+				$settings .= '</td>';
+				$settings .= '<td class="ur-email-settings-table">';
+				$label = $status ? __( 'Active', 'user-registration' ) : __( 'Inactive', 'user-registration' );
+				$settings .= '<label style="' . ( $status ? 'color:green;font-weight:500;' : 'color:red;font-weight:500;' ) . '">';
+				$settings .= esc_html( $label );
+				$settings .= '</label>';
 				$settings .= '</td>';
 				$settings .= '<td class="ur-email-settings-table">';
 				$settings .= '<a class="button tips" data-tip="' . esc_attr__( 'Configure', 'user-registration' ) . '" href="' . esc_url( admin_url( 'admin.php?page=user-registration-settings&tab=email&section=ur_settings_' . $email->id . '' ) ) . '"><span class="dashicons dashicons-admin-generic"></span> </a>';

--- a/includes/admin/settings/class-ur-settings-email.php
+++ b/includes/admin/settings/class-ur-settings-email.php
@@ -192,14 +192,14 @@ if ( ! class_exists( 'UR_Settings_Email' ) ) :
 
 			$emails = $this->get_emails();
 			foreach ( $emails as $email ) {
-				$status = ! ur_string_to_bool( get_option( 'user_registration_email_setting_disable_email', false ) ) ? ur_string_to_bool( get_option( 'user_registration_enable_' . $email->id, true ) ) : false;
+				$status    = ! ur_string_to_bool( get_option( 'user_registration_email_setting_disable_email', false ) ) ? ur_string_to_bool( get_option( 'user_registration_enable_' . $email->id, true ) ) : false;
 				$settings .= '<tr><td class="ur-email-settings-table">';
 				$settings .= '<a href="' . esc_url( admin_url( 'admin.php?page=user-registration-settings&tab=email&section=ur_settings_' . $email->id . '' ) ) .
-												'">' . esc_html__( $email->title, 'user-registration' ) . '</a>';
-				$settings .= ur_help_tip( __( $email->description, 'user-registration' ) );
+												'">' . esc_html( $email->title ) . '</a>';
+				$settings .= ur_help_tip( $email->description );
 				$settings .= '</td>';
 				$settings .= '<td class="ur-email-settings-table">';
-				$label = $status ? __( 'Active', 'user-registration' ) : __( 'Inactive', 'user-registration' );
+				$label     = $status ? __( 'Active', 'user-registration' ) : __( 'Inactive', 'user-registration' );
 				$settings .= '<label style="' . ( $status ? 'color:green;font-weight:500;' : 'color:red;font-weight:500;' ) . '">';
 				$settings .= esc_html( $label );
 				$settings .= '</label>';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously we do not have a way to show active/inactive status on the User Registration -> Settings -> Emails table. This PR provides this feature.

### How to test the changes in this Pull Request:

1. Navigate to User Registration -> Settings -> Emails.
2. Active or Inactive status will be shown for each table in the status column.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhance - Active status on emails settings.
