### PR TITLE
UR-274 Enhance - Keyboard shortcut in form builder

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
 	"parser": "babel-eslint",
-	"extends": "react",
+	"extends": "eslint",
 	"env": {
 	  "browser": true,
 	  "node": true

--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -26,7 +26,10 @@
 					if (event.ctrlKey || event.metaKey) {
 						if (
 							"s" ===
-							String.fromCharCode(event.which).toLowerCase()
+								String.fromCharCode(
+									event.which
+								).toLowerCase() ||
+							83 === event.which
 						) {
 							event.preventDefault();
 							URFormBuilder.ur_save_form();
@@ -34,7 +37,21 @@
 						}
 					}
 				});
-
+				// preview the form on key event
+				$(window).on("keydown", function (e) {
+					if (e.ctrlKey || e.metaKey) {
+						if (
+							"p" ===
+								String.fromCharCode(e.which).toLowerCase() ||
+							80 === e.which
+						) {
+							e.preventDefault();
+							window.open(
+								user_registration_form_builder_data.ur_preview
+							);
+						}
+					}
+				});
 				// Save the form when Update Form button is clicked.
 				$(".ur_save_form_action_button").on("click", function () {
 					URFormBuilder.ur_save_form();

--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -22,51 +22,59 @@
 					URFormBuilder.handle_selected_item($(this));
 				});
 
-				$(window).on("keydown", function (event) {
-					if (event.ctrlKey || event.metaKey) {
-						if (
-							"s" ===
-								String.fromCharCode(
-									event.which
-								).toLowerCase() ||
-							83 === event.which
-						) {
-							event.preventDefault();
-							URFormBuilder.ur_save_form();
-							return false;
+				// Run keyboard shortcuts action in form builder area only.
+				if (user_registration_form_builder_data.is_form_builder) {
+					$(window).on("keydown", function (event) {
+						if (event.ctrlKey || event.metaKey) {
+							if (
+								"s" ===
+									String.fromCharCode(
+										event.which
+									).toLowerCase() ||
+								83 === event.which
+							) {
+								event.preventDefault();
+								URFormBuilder.ur_save_form();
+								return false;
+							}
 						}
-					}
-				});
-				// preview the form on key event
-				$(window).on("keydown", function (e) {
-					if (e.ctrlKey || e.metaKey) {
-						if (
-							"p" ===
-								String.fromCharCode(e.which).toLowerCase() ||
-							80 === e.which
-						) {
-							e.preventDefault();
-							window.open(
-								user_registration_form_builder_data.ur_preview
-							);
+					});
+					// preview the form on key event
+					$(window).on("keydown", function (e) {
+						if (e.ctrlKey || e.metaKey) {
+							if (
+								"p" ===
+									String.fromCharCode(
+										e.which
+									).toLowerCase() ||
+								80 === e.which
+							) {
+								e.preventDefault();
+								window.open(
+									user_registration_form_builder_data.ur_preview
+								);
+							}
 						}
-					}
-				});
-				// View user list table on key event.
-				$(window).on("keydown", function (e) {
-					if (e.ctrlKey || e.metaKey) {
-						if (
-							"u" ===
-								String.fromCharCode(e.which).toLowerCase() ||
-							85 === e.which
-						) {
-							e.preventDefault();
-							window.open(
-								user_registration_form_builder_data.ur_user_list_table
-							);
+					});
+					// View user list table on key event.
+					$(window).on("keydown", function (e) {
+						if (e.ctrlKey || e.metaKey) {
+							if (
+								"u" ===
+									String.fromCharCode(
+										e.which
+									).toLowerCase() ||
+								85 === e.which
+							) {
+								e.preventDefault();
+								window.open(
+									user_registration_form_builder_data.ur_user_list_table
+								);
+							}
 						}
-					}
-				});
+					});
+				}
+
 				// Save the form when Update Form button is clicked.
 				$(".ur_save_form_action_button").on("click", function () {
 					URFormBuilder.ur_save_form();

--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -52,6 +52,21 @@
 						}
 					}
 				});
+				// View user list table on key event.
+				$(window).on("keydown", function (e) {
+					if (e.ctrlKey || e.metaKey) {
+						if (
+							"u" ===
+								String.fromCharCode(e.which).toLowerCase() ||
+							85 === e.which
+						) {
+							e.preventDefault();
+							window.open(
+								user_registration_form_builder_data.ur_user_list_table
+							);
+						}
+					}
+				});
 				// Save the form when Update Form button is clicked.
 				$(".ur_save_form_action_button").on("click", function () {
 					URFormBuilder.ur_save_form();

--- a/includes/admin/class-ur-admin-assets.php
+++ b/includes/admin/class-ur-admin-assets.php
@@ -265,11 +265,11 @@ class UR_Admin_Assets {
 				'ur_preview'                     => add_query_arg(
 					array(
 						'ur_preview' => 'true',
-						'form_id'    => absint( $_GET['edit-registration'] ), //phpcs:ignore;
+						'form_id'    => isset( $_GET['edit-registration'] ) ? absint( $_GET['edit-registration'] ) : 0, //phpcs:ignore;
 					),
 					home_url()
 				),
-				'ur_user_list_table'             => admin_url( 'users.php?ur_specific_form_user=' . absint( $_GET['edit-registration'] ) . '&ur_user_filter_action=Filter' ), //phpcs:ignore;
+				'ur_user_list_table'             => admin_url( 'users.php?ur_specific_form_user=' . isset( $_GET['edit-registration'] ) ? absint( $_GET['edit-registration'] ) : 0 . '&ur_user_filter_action=Filter' ), //phpcs:ignore;
 			);
 
 			wp_localize_script(

--- a/includes/admin/class-ur-admin-assets.php
+++ b/includes/admin/class-ur-admin-assets.php
@@ -269,6 +269,7 @@ class UR_Admin_Assets {
 					),
 					home_url()
 				),
+				'ur_user_list_table'	         => admin_url( 'users.php?ur_specific_form_user='.absint( $_GET['edit-registration'] ).'&ur_user_filter_action=Filter'),
 			);
 
 			wp_localize_script(

--- a/includes/admin/class-ur-admin-assets.php
+++ b/includes/admin/class-ur-admin-assets.php
@@ -262,6 +262,13 @@ class UR_Admin_Assets {
 				'i18n_admin'                     => self::get_i18n_admin_data(),
 				'add_new'                        => esc_html__( 'Add New', 'user-registration' ),
 				'max_upload_size_ini'            => wp_max_upload_size() / 1024,
+				'ur_preview'					 => add_query_arg(
+					array(
+						'ur_preview' => 'true',
+						'form_id'    => absint( $_GET['edit-registration'] ),
+					),
+					home_url()
+				),
 			);
 
 			wp_localize_script(

--- a/includes/admin/class-ur-admin-assets.php
+++ b/includes/admin/class-ur-admin-assets.php
@@ -256,6 +256,7 @@ class UR_Admin_Assets {
 				'number_of_grid'                 => UR_Config::$ur_form_grid,
 				'active_grid'                    => UR_Config::$default_active_grid,
 				'is_edit_form'                   => isset( $_GET['edit-registration'] ) ? true : false, //phpcs:ignore WordPress.Security.NonceVerification
+				'is_form_builder'                => ( isset( $_GET['page'] ) && 'add-new-registration' === $_GET['page'] ) ? true : false, //phpcs:ignore WordPress.Security.NonceVerification
 				'post_id'                        => $form_id,
 				'admin_url'                      => admin_url( 'admin.php?page=add-new-registration&edit-registration=' ),
 				'form_required_fields'           => ur_get_required_fields(),

--- a/includes/admin/class-ur-admin-assets.php
+++ b/includes/admin/class-ur-admin-assets.php
@@ -262,14 +262,14 @@ class UR_Admin_Assets {
 				'i18n_admin'                     => self::get_i18n_admin_data(),
 				'add_new'                        => esc_html__( 'Add New', 'user-registration' ),
 				'max_upload_size_ini'            => wp_max_upload_size() / 1024,
-				'ur_preview'					 => add_query_arg(
+				'ur_preview'                     => add_query_arg(
 					array(
 						'ur_preview' => 'true',
-						'form_id'    => absint( $_GET['edit-registration'] ),
+						'form_id'    => absint( $_GET['edit-registration'] ), //phpcs:ignore;
 					),
 					home_url()
 				),
-				'ur_user_list_table'	         => admin_url( 'users.php?ur_specific_form_user='.absint( $_GET['edit-registration'] ).'&ur_user_filter_action=Filter'),
+				'ur_user_list_table'             => admin_url( 'users.php?ur_specific_form_user=' . absint( $_GET['edit-registration'] ) . '&ur_user_filter_action=Filter' ), //phpcs:ignore;
 			);
 
 			wp_localize_script(

--- a/includes/admin/class-ur-admin-assets.php
+++ b/includes/admin/class-ur-admin-assets.php
@@ -247,7 +247,8 @@ class UR_Admin_Assets {
 			wp_enqueue_script( 'jquery-ui-widget' );
 			wp_enqueue_script( 'ur-copy' );
 
-			$params = array(
+			$form_id = isset( $_GET['edit-registration'] ) ? absint( $_GET['edit-registration'] ) : 0;//phpcs:ignore WordPress.Security.NonceVerification
+			$params  = array(
 				'required_form_html'             => self::get_form_required_html(),
 				'ajax_url'                       => admin_url( 'admin-ajax.php' ),
 				'user_input_dropped'             => wp_create_nonce( 'user_input_dropped_nonce' ),
@@ -255,7 +256,7 @@ class UR_Admin_Assets {
 				'number_of_grid'                 => UR_Config::$ur_form_grid,
 				'active_grid'                    => UR_Config::$default_active_grid,
 				'is_edit_form'                   => isset( $_GET['edit-registration'] ) ? true : false, //phpcs:ignore WordPress.Security.NonceVerification
-				'post_id'                        => isset( $_GET['edit-registration'] ) ? absint( $_GET['edit-registration'] ) : 0, //phpcs:ignore WordPress.Security.NonceVerification
+				'post_id'                        => $form_id,
 				'admin_url'                      => admin_url( 'admin.php?page=add-new-registration&edit-registration=' ),
 				'form_required_fields'           => ur_get_required_fields(),
 				'form_one_time_draggable_fields' => ur_get_one_time_draggable_fields(),
@@ -265,11 +266,11 @@ class UR_Admin_Assets {
 				'ur_preview'                     => add_query_arg(
 					array(
 						'ur_preview' => 'true',
-						'form_id'    => isset( $_GET['edit-registration'] ) ? absint( $_GET['edit-registration'] ) : 0, //phpcs:ignore;
+						'form_id'    => $form_id,
 					),
 					home_url()
 				),
-				'ur_user_list_table'             => admin_url( 'users.php?ur_specific_form_user=' . isset( $_GET['edit-registration'] ) ? absint( $_GET['edit-registration'] ) : 0 . '&ur_user_filter_action=Filter' ), //phpcs:ignore;
+				'ur_user_list_table'             => admin_url( 'users.php?ur_specific_form_user=' . $form_id . '&ur_user_filter_action=Filter' ), //phpcs:ignore;
 			);
 
 			wp_localize_script(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously there was no keyboard shortcut in the form builder to preview and view users for that form. This PR enhances this feature.

### How to test the changes in this Pull Request:

1. Go to the form builder.
2. Ctrl + P: Open the form preview in a new browser tab.
3. Ctrl + U: View users for the form in a new browser tab.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhance - Keyboard shortcut in the form builder.
