### PR TITLE
UR-324 Fix - Email templates content overrider text not saving

### DIFF
--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -1064,13 +1064,13 @@
 						subject: email_body_item
 							.find(".uret_subject_input")
 							.val(),
-						content: email_body_item
-							.find(
-								"#user_registration_" +
+						content: tinymce
+							.get(
+								"user_registration_" +
 									$(this).prop("id") +
 									"_content"
 							)
-							.val(),
+							.getContent(),
 					};
 				});
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously when we change the content of email overrider and without clicking anywhere directly click on update form then the contents were not saved. This PR fixes this issue.

### How to test the changes in this Pull Request:
Try to replicate the above issue and verify if this PR fixes this issue or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Email templates content overrider text not saving.
