### PR TITLE
Fix - Date Range not accepting end date

### DIFF
--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -1349,7 +1349,7 @@ function ur_get_logger() {
 	static $logger = null;
 	if ( null === $logger ) {
 		$class      = apply_filters( 'user_registration_logging_class', 'UR_Logger' );
-		$implements = class_implements( $class );
+		$implements = $class instanceof UR_Logger;
 		if ( is_array( $implements ) && in_array( 'UR_Logger_Interface', $implements ) ) {
 			if ( is_object( $class ) ) {
 				$logger = $class;
@@ -1910,7 +1910,7 @@ function ur_get_registration_source_id( $user_id ) {
  */
 function ur_falls_in_date_range( $target_date, $start_date = null, $end_date = null ) {
 	$start_ts       = strtotime( $start_date );
-	$end_ts         = strtotime( $end_date . " +1 Day" );
+	$end_ts         = strtotime( $end_date . ' +1 Day' );
 	$target_date_ts = strtotime( $target_date );
 
 	// If the starting and the ending date are set as same.

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -1910,7 +1910,7 @@ function ur_get_registration_source_id( $user_id ) {
  */
 function ur_falls_in_date_range( $target_date, $start_date = null, $end_date = null ) {
 	$start_ts       = strtotime( $start_date );
-	$end_ts         = strtotime( $end_date );
+	$end_ts         = strtotime( $end_date . " +1 Day" );
 	$target_date_ts = strtotime( $target_date );
 
 	// If the starting and the ending date are set as same.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This change is related to Content Restriction. In content restriction  *During* access rule, the users registered on end date were not getting access to the content. This pull request solves it.

Closes # .

### How to test the changes in this Pull Request:

1. Create a *During* access rule with end date set to today's date.
2. Register a new user and check if the new user can access the restricted content.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
