### PR TITLE
UR-352 Fix - File upload path permission denied due to non-existent file upload directory.

### DIFF
--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -419,6 +419,11 @@ class UR_AJAX {
 			$upload_dir = wp_upload_dir();
 			$upload_path = apply_filters( 'user_registration_profile_pic_upload_url', $upload_dir['basedir'] . '/user_registration_uploads/profile-pictures' ); /*Get path of upload dir of WordPress*/
 
+			// Checks if the upload directory exists and create one if not.
+			if ( ! file_exists( $upload_path ) ) {
+				wp_mkdir_p( $upload_path );
+			}
+
 			if ( ! is_writable( $upload_path ) ) {  /*Check if upload dir is writable*/
 				wp_send_json_error(
 					array(

--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -92,6 +92,11 @@ class UR_Form_Handler {
 					$upload_dir  = wp_upload_dir();
 					$upload_path = apply_filters( 'user_registration_profile_pic_upload_url', $upload_dir['basedir'] . '/user_registration_uploads/profile-pictures' ); /*Get path of upload dir of WordPress*/
 
+					// Checks if the upload directory exists and create one if not.
+					if ( ! file_exists( $upload_path ) ) {
+						wp_mkdir_p( $upload_path );
+					}
+
 					if ( ! wp_is_writable( $upload_path ) ) {  /*Check if upload dir is writable*/
 						ur_add_notice( 'Upload path permission deny.', 'error' );
 					}


### PR DESCRIPTION
### All Submissions:
* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously for some users the file upload directory `uploads/user_registration_uploads` was not created for some reason and when they tried to upload a file the upload path permission denied error appeared due to the non-existent upload file directory. This PR tries to fix this issue by checking if the directory exists and if not then creates one before uploading a file.

### How to test the changes in this Pull Request:
1. Replicate the issue for the profile picture and file upload field.
2. Switch to this branch and check if the issue is resolved.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - File upload path permission denied due to non-existent file upload directory.