### PR TITLE
UR-390 Fix - Redirection after registration not working with block

### DIFF
--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -74,6 +74,7 @@ function ur_login_template_redirect() {
  * @since  1.5.1
  */
 function ur_registration_template_redirect() {
+
 	// Return if the user is not logged in.
 	if ( is_user_logged_in() === false ) {
 		return;
@@ -81,6 +82,7 @@ function ur_registration_template_redirect() {
 
 	$current_user    = wp_get_current_user();
 	$current_user_id = $current_user->ID;
+	$form_id = 0;
 
 	// Donot redirect for admins.
 	if ( in_array( 'administrator', wp_get_current_user()->roles ) ) {
@@ -91,11 +93,26 @@ function ur_registration_template_redirect() {
 
 		$post_content = isset( $post->post_content ) ? $post->post_content : '';
 
+		$shortcodes = parse_blocks( $post_content );
+		$matched = false;
+		foreach ( $shortcodes as $shortcode ) {
+			if ( ! empty( $shortcode['blockName'] ) ) {
+				if ( 'user-registration/form-selector' === $shortcode['blockName'] && isset( $shortcode['attrs']['formId'] ) ) {
+					$matched = true;
+					$form_id = $shortcode['attrs']['formId'];
+
+				}
+			}
+		}
+
 		if ( has_shortcode( $post_content, 'user_registration_form' ) ) {
 
 			$attributes = ur_get_shortcode_attr( $post_content );
 			$form_id    = isset( $attributes[0]['id'] ) ? $attributes[0]['id'] : 0;
+			$matched = true;
+		}
 
+		if( $matched ) {
 			preg_match_all( '!\d+!', $form_id, $form_id );
 
 			$redirect_url = ur_get_single_post_meta( $form_id[0][0], 'user_registration_form_setting_redirect_options', '' );

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -112,7 +112,7 @@ function ur_registration_template_redirect() {
 			$matched = true;
 		}
 
-		if( $matched ) {
+		if ( $matched ) {
 			preg_match_all( '!\d+!', $form_id, $form_id );
 
 			$redirect_url = ur_get_single_post_meta( $form_id[0][0], 'user_registration_form_setting_redirect_options', '' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When registration form is embed using our gutenberg block then the following code is not firing when user is logged in. i.e Must redirect to google when user tries to visit registration page while logged into the system.

`add_filter( 'user_registration_redirect_from_registration_page', function( $redirect_url, $current_user ) {
    $redirect_url = 'https://www.google.com';
    return $redirect_url;
}, 10, 2 );`

### How to test the changes in this Pull Request:

1. Switch to this branch and check if issue is resolved.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Redirection after registration not working with block.