### PR TITLE
UR-392 Tweak - Replace incremental file name function with wordpress default

### DIFF
--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -437,7 +437,7 @@ class UR_AJAX {
 			$upload_path = $upload_path . '/';
 			$file_ext    = strtolower( pathinfo( $upload['name'], PATHINFO_EXTENSION ) );
 
-			$file_name = user_registration_incremental_file_name( $upload_path, $upload );
+			$file_name = wp_unique_filename( $upload_path, $upload['name'] );
 
 			$file_path = $upload_path . sanitize_file_name( $file_name );
 

--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -104,7 +104,7 @@ class UR_Form_Handler {
 					$upload_path = $upload_path . '/';
 					$file_ext    = strtolower( pathinfo( $upload['name'], PATHINFO_EXTENSION ) );
 
-					$file_name = user_registration_incremental_file_name( $upload_path, $upload );
+					$file_name = wp_unique_filename( $upload_path, $upload['name'] );
 
 					$file_path = $upload_path . sanitize_file_name( $file_name );
 

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -2613,32 +2613,3 @@ if ( ! function_exists( 'ur_delete_user_files_on_user_delete' ) ) {
 		}
 	}
 }
-
-if ( ! function_exists( 'user_registration_incremental_file_name' ) ) {
-
-	/**
-	 * Create a incremental file name
-	 *
-	 * @param [type] $upload_path Path to the upload directory.
-	 * @param [type] $file Uploaded file.
-	 */
-	function user_registration_incremental_file_name( $upload_path, $file ) {
-
-		$file_name = sanitize_file_name( $file['name'] );
-		$file_ext  = strtolower( pathinfo( $file['name'], PATHINFO_EXTENSION ) );
-
-		$file_counter = 0;
-		while ( file_exists( $upload_path . $file_name ) ) {
-			$file_name = pathinfo( $file_name, PATHINFO_FILENAME );
-
-			if ( 0 === $file_counter ) {
-				$file_name = $file_name . '-' . $file_counter;
-			}
-
-			$file_name = substr( $file_name, 0, strpos( $file_name, '-' ) );
-			$file_name = $file_name . '-' . ( $file_counter++ ) . '.' . $file_ext;
-		}
-
-		return $file_name;
-	}
-}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The custom code that was used to increment file name was not working for some users so need to use the WordPress-provided `wp_unique_filename` function to make it more reliable.

### How to test the changes in this Pull Request:
1. Check if duplicate files are renamed correctly.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Replace incremental file name function with WordPress default.