### PR TITLE
UR-373 Fix - Error thrown when uploaded file is not found in upload directory

### DIFF
--- a/templates/myaccount/form-edit-profile.php
+++ b/templates/myaccount/form-edit-profile.php
@@ -299,11 +299,11 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 														foreach ( $attachment_ids as $attachment_key => $attachment_id ) {
 															$attachment_url = get_attached_file( $attachment_id );
 
-															if ( '' !== $attachment_url ) {
-																if ( ! file_exists( $attachment_url ) ) {
-																	unset( $attachment_ids[ $attachment_key ] );
-																}
+															// Check to see if file actually exists or not.
+															if ( '' !== $attachment_url && file_exists( $attachment_url ) ) {
+																break;
 															}
+															unset( $attachment_ids[ $attachment_key ] );
 														}
 
 														$field['value'] = ! empty( $attachment_ids ) ? implode( ',', $attachment_ids ) : '';

--- a/templates/myaccount/form-edit-profile.php
+++ b/templates/myaccount/form-edit-profile.php
@@ -293,14 +293,14 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 													}
 
 													// Remove files attachment id from user meta if file is deleted by admin.
-													if( '' !== $field['value'] ) {
-														$attachment_ids = explode( ',', $field['value']);
+													if ( '' !== $field['value'] ) {
+														$attachment_ids = explode( ',', $field['value'] );
 
-														foreach ($attachment_ids as $attachment_key => $attachment_id) {
+														foreach ( $attachment_ids as $attachment_key => $attachment_id ) {
 															$attachment_url = get_attached_file( $attachment_id );
 
-															if( '' !== $attachment_url ) {
-																if( !file_exists($attachment_url) ) {
+															if ( '' !== $attachment_url ) {
+																if ( !file_exists( $attachment_url ) ) {
 																	unset( $attachment_ids[$attachment_key] );
 																}
 															}

--- a/templates/myaccount/form-edit-profile.php
+++ b/templates/myaccount/form-edit-profile.php
@@ -300,13 +300,13 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 															$attachment_url = get_attached_file( $attachment_id );
 
 															if ( '' !== $attachment_url ) {
-																if ( !file_exists( $attachment_url ) ) {
-																	unset( $attachment_ids[$attachment_key] );
+																if ( ! file_exists( $attachment_url ) ) {
+																	unset( $attachment_ids[ $attachment_key ] );
 																}
 															}
 														}
 
-														$field['value'] = !empty( $attachment_ids ) ? implode(",", $attachment_ids ) : '';
+														$field['value'] = ! empty( $attachment_ids ) ? implode( ',', $attachment_ids ) : '';
 														update_user_meta( get_current_user_id(), 'user_registration_' . $single_item->general_setting->field_name, $field['value'] );
 													}
 												}

--- a/templates/myaccount/form-edit-profile.php
+++ b/templates/myaccount/form-edit-profile.php
@@ -301,7 +301,7 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 
 															// Check to see if file actually exists or not.
 															if ( '' !== $attachment_url && file_exists( $attachment_url ) ) {
-																break;
+																continue;
 															}
 															unset( $attachment_ids[ $attachment_key ] );
 														}

--- a/templates/myaccount/form-edit-profile.php
+++ b/templates/myaccount/form-edit-profile.php
@@ -291,6 +291,24 @@ do_action( 'user_registration_before_edit_profile_form' ); ?>
 													if ( isset( $advance_data['advance_setting']->valid_file_type ) ) {
 														$field['valid_file_type'] = $advance_data['advance_setting']->valid_file_type;
 													}
+
+													// Remove files attachment id from user meta if file is deleted by admin.
+													if( '' !== $field['value'] ) {
+														$attachment_ids = explode( ',', $field['value']);
+
+														foreach ($attachment_ids as $attachment_key => $attachment_id) {
+															$attachment_url = get_attached_file( $attachment_id );
+
+															if( '' !== $attachment_url ) {
+																if( !file_exists($attachment_url) ) {
+																	unset( $attachment_ids[$attachment_key] );
+																}
+															}
+														}
+
+														$field['value'] = !empty( $attachment_ids ) ? implode(",", $attachment_ids ) : '';
+														update_user_meta( get_current_user_id(), 'user_registration_' . $single_item->general_setting->field_name, $field['value'] );
+													}
 												}
 
 												if ( isset( $advance_data['general_setting']->required ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
I uploaded the file using file upload and deleted the file from the media library. Still getting text.png file or error on file upload (edit profile). For more clarification, check this screenshot [Screenshot](https://prnt.sc/r94Ru8rDC3ZJ)
This PR fixes this issue.

### How to test the changes in this Pull Request:

1. Do the testing according to the issue described and check if no error is thrown and verify other files can be uploaded.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Error thrown when uploaded file is not found in upload directory.