### PR TITLE
UR-378 Fix - Required field not working when conditional logic enabled.

### DIFF
--- a/includes/form/class-ur-form-field-checkbox.php
+++ b/includes/form/class-ur-form-field-checkbox.php
@@ -62,12 +62,13 @@ class UR_Form_Field_Checkbox extends UR_Form_Field {
 	 * @param $form_id
 	 */
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
-		$is_condition_enabled = isset( $single_form_field->advance_setting->enable_conditional_logic ) ? $single_form_field->advance_setting->enable_conditional_logic : '0';
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
-		if ( $is_condition_enabled !== '1' && 'yes' == $required && empty( $value ) ) {
+		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {

--- a/includes/form/class-ur-form-field-checkbox.php
+++ b/includes/form/class-ur-form-field-checkbox.php
@@ -3,8 +3,6 @@
  * UR_Form_Field_Checkbox.
  *
  * @package  UserRegistration/Form
- * @category Admin
- * @author   WPEverest
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,8 +14,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class UR_Form_Field_Checkbox extends UR_Form_Field {
 
+	/**
+	 * Instance Variable.
+	 *
+	 * @var [mixed]
+	 */
 	private static $_instance;
 
+	/**
+	 * Get Instance of class.
+	 */
 	public static function get_instance() {
 		// If the single instance hasn't been set, set it now.
 		if ( is_null( self::$_instance ) ) {
@@ -27,6 +33,9 @@ class UR_Form_Field_Checkbox extends UR_Form_Field {
 		return self::$_instance;
 	}
 
+	/**
+	 * Constructor.
+	 */
 	public function __construct() {
 
 		$this->id                       = 'user_registration_checkbox';
@@ -48,31 +57,34 @@ class UR_Form_Field_Checkbox extends UR_Form_Field {
 	}
 
 	/**
-	 * @return string
+	 * Get Registered admin fields.
 	 */
 	public function get_registered_admin_fields() {
 
-		return '<li id="' . esc_attr( $this->id ) . '_list " class="ur-registered-item draggable" data-field-id="' .esc_attr( $this->id ) . '"><span class="' . esc_attr( $this->registered_fields_config['icon'] ). '"></span>' . esc_html( $this->registered_fields_config['label'] ) . '</li>';
+		return '<li id="' . esc_attr( $this->id ) . '_list " class="ur-registered-item draggable" data-field-id="' . esc_attr( $this->id ) . '"><span class="' . esc_attr( $this->registered_fields_config['icon'] ) . '"></span>' . esc_html( $this->registered_fields_config['label'] ) . '</li>';
 	}
 
 	/**
-	 * @param $single_form_field
-	 * @param $form_data
-	 * @param $filter_hook
-	 * @param $form_id
+	 * Validate field.
+	 *
+	 * @param [object] $single_form_field Field Data.
+	 * @param [object] $form_data Form Data.
+	 * @param [string] $filter_hook Hook.
+	 * @param [int]    $form_id Form id.
 	 */
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
-		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array(); //phpcs:ignore;
 		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
 		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {
-					return esc_html__( $field_label . ' is required.', 'user-registration' );
+					/* translators: %1$s - Field Label */
+					return sprintf( __( '%1$s is required.', 'user-registration' ), $field_label );
 				}
 			);
 		}

--- a/includes/form/class-ur-form-field-country.php
+++ b/includes/form/class-ur-form-field-country.php
@@ -3,8 +3,6 @@
  * UR_Form_Field_Country.
  *
  * @package  UserRegistration/Form
- * @category Admin
- * @author   WPEverest
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,8 +14,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class UR_Form_Field_Country extends UR_Form_Field {
 
+	/**
+	 * Instance Variable.
+	 *
+	 * @var [mixed]
+	 */
 	private static $_instance;
 
+	/**
+	 * Get Instance of class.
+	 */
 	public static function get_instance() {
 		// If the single instance hasn't been set, set it now.
 		if ( is_null( self::$_instance ) ) {
@@ -27,6 +33,9 @@ class UR_Form_Field_Country extends UR_Form_Field {
 		return self::$_instance;
 	}
 
+	/**
+	 * Get Country List.
+	 */
 	public function get_country() {
 
 		return apply_filters(
@@ -287,6 +296,9 @@ class UR_Form_Field_Country extends UR_Form_Field {
 
 	/**
 	 * Get selected countries list of a Country field.
+	 *
+	 * @param [int]    $form_id Form id.
+	 * @param [string] $field_name Field Name.
 	 */
 	public function get_selected_countries( $form_id, $field_name ) {
 		$countries = $this->get_country();
@@ -296,7 +308,7 @@ class UR_Form_Field_Country extends UR_Form_Field {
 		$form_data = UR()->form->get_form( $form_id, array( 'content_only' => true ) );
 		$fields = self::get_form_field_data( $form_data );
 
-		// Get selected_countries data of the field
+		// Get selected_countries data of the field.
 		foreach ( $fields as $field ) {
 			if ( 'country' === $field->field_key && $field_name === $field->general_setting->field_name ) {
 				$advance_setting = $field->advance_setting;
@@ -307,7 +319,7 @@ class UR_Form_Field_Country extends UR_Form_Field {
 			}
 		}
 
-		// Filter countries with selected_countries data
+		// Filter countries with selected_countries data.
 		if ( is_array( $selected_countries ) ) {
 			foreach ( $countries as $iso => $country_name ) {
 				if ( in_array( $iso, $selected_countries, true ) ) {
@@ -339,6 +351,9 @@ class UR_Form_Field_Country extends UR_Form_Field {
 		return ( $form_field_data_array );
 	}
 
+	/**
+	 * Constructor.
+	 */
 	public function __construct() {
 
 		$this->id                       = 'user_registration_country';
@@ -354,23 +369,35 @@ class UR_Form_Field_Country extends UR_Form_Field {
 		);
 	}
 
+	/**
+	 * Get Registered admin fields.
+	 */
 	public function get_registered_admin_fields() {
 
 		return '<li id="' . esc_attr( $this->id ) . '_list " class="ur-registered-item draggable" data-field-id="' . esc_attr( $this->id ) . '"><span class="' . esc_attr( $this->registered_fields_config['icon'] ) . '"></span>' . esc_html( $this->registered_fields_config['label'] ) . '</li>';
 	}
 
+	/**
+	 * Validate field.
+	 *
+	 * @param [object] $single_form_field Field Data.
+	 * @param [object] $form_data Form Data.
+	 * @param [string] $filter_hook Hook.
+	 * @param [int]    $form_id Form id.
+	 */
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
-		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array(); //phpcs:ignore;
 		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
 		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {
-					return esc_html__( $field_label . ' is required.', 'user-registration' );
+					/* translators: %1$s - Field Label */
+					return sprintf( __( '%1$s is required.', 'user-registration' ), $field_label );
 				}
 			);
 		}

--- a/includes/form/class-ur-form-field-country.php
+++ b/includes/form/class-ur-form-field-country.php
@@ -360,12 +360,13 @@ class UR_Form_Field_Country extends UR_Form_Field {
 	}
 
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
-		$is_condition_enabled = isset( $single_form_field->advance_setting->enable_conditional_logic ) ? $single_form_field->advance_setting->enable_conditional_logic : '0';
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
-		if ( $is_condition_enabled !== '1' && 'yes' == $required && empty( $value ) ) {
+		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {

--- a/includes/form/class-ur-form-field-date.php
+++ b/includes/form/class-ur-form-field-date.php
@@ -51,13 +51,14 @@ class UR_Form_Field_Date extends UR_Form_Field {
 
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
 
-		$is_condition_enabled = isset( $single_form_field->advance_setting->enable_conditional_logic ) ? $single_form_field->advance_setting->enable_conditional_logic : '0';
 		$is_enable_date_range = isset( $single_form_field->advance_setting->enable_date_range ) ? $single_form_field->advance_setting->enable_date_range : '';
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
-		if ( $is_condition_enabled !== '1' && 'yes' == $required && empty( $value ) ) {
+		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {

--- a/includes/form/class-ur-form-field-date.php
+++ b/includes/form/class-ur-form-field-date.php
@@ -5,8 +5,6 @@
  * @class    UR_Form_Field_Date
  * @since    1.0.5
  * @package  UserRegistration/Form
- * @category Admin
- * @author   WPEverest
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -18,8 +16,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class UR_Form_Field_Date extends UR_Form_Field {
 
+	/**
+	 * Instance Variable.
+	 *
+	 * @var [mixed]
+	 */
 	private static $_instance;
 
+	/**
+	 * Get Instance of class.
+	 */
 	public static function get_instance() {
 		// If the single instance hasn't been set, set it now.
 		if ( is_null( self::$_instance ) ) {
@@ -29,6 +35,9 @@ class UR_Form_Field_Date extends UR_Form_Field {
 		return self::$_instance;
 	}
 
+	/**
+	 * Constructor.
+	 */
 	public function __construct() {
 
 		$this->id                       = 'user_registration_date';
@@ -44,25 +53,37 @@ class UR_Form_Field_Date extends UR_Form_Field {
 		);
 	}
 
+	/**
+	 * Get Registered admin fields.
+	 */
 	public function get_registered_admin_fields() {
 
-		return '<li id="' . esc_attr( $this->id ) . '_list " class="ur-registered-item draggable" data-field-id="' .esc_attr( $this->id ) . '"><span class="' . esc_attr( $this->registered_fields_config['icon'] ). '"></span>' . esc_html( $this->registered_fields_config['label'] ) . '</li>';
+		return '<li id="' . esc_attr( $this->id ) . '_list " class="ur-registered-item draggable" data-field-id="' . esc_attr( $this->id ) . '"><span class="' . esc_attr( $this->registered_fields_config['icon'] ) . '"></span>' . esc_html( $this->registered_fields_config['label'] ) . '</li>';
 	}
 
+	/**
+	 * Validate field.
+	 *
+	 * @param [object] $single_form_field Field Data.
+	 * @param [object] $form_data Form Data.
+	 * @param [string] $filter_hook Hook.
+	 * @param [int]    $form_id Form id.
+	 */
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
 
 		$is_enable_date_range = isset( $single_form_field->advance_setting->enable_date_range ) ? $single_form_field->advance_setting->enable_date_range : '';
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
-		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array(); //phpcs:ignore;
 		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
 		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {
-					return esc_html__( $field_label . ' is required.', 'user-registration' );
+					/* translators: %1$s - Field Label */
+					return sprintf( __( '%1$s is required.', 'user-registration' ), $field_label );
 				}
 			);
 		}
@@ -71,13 +92,13 @@ class UR_Form_Field_Date extends UR_Form_Field {
 	/**
 	 * Checks for valid date
 	 *
-	 * @param string $date_string
+	 * @param string $date_string Date.
 	 */
 	private function is_valid_date( $date_string ) {
 
 		$date = date_parse( $date_string );
 
-		if ( $date['error_count'] == 0 && checkdate( $date['month'], $date['day'], $date['year'] ) ) {
+		if ( 0 == $date['error_count'] && checkdate( $date['month'], $date['day'], $date['year'] ) ) {
 			return true;
 		}
 

--- a/includes/form/class-ur-form-field-description.php
+++ b/includes/form/class-ur-form-field-description.php
@@ -49,12 +49,13 @@ class UR_Form_Field_Description extends UR_Form_Field {
 	}
 
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
-		$is_condition_enabled = isset( $single_form_field->advance_setting->enable_conditional_logic ) ? $single_form_field->advance_setting->enable_conditional_logic : '0';
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
-		if ( $is_condition_enabled !== '1' && 'yes' == $required && empty( $value ) ) {
+		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {

--- a/includes/form/class-ur-form-field-description.php
+++ b/includes/form/class-ur-form-field-description.php
@@ -3,8 +3,6 @@
  * UR_Form_Field_Description.
  *
  * @package  UserRegistration/Form
- * @category Admin
- * @author   WPEverest
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,8 +14,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class UR_Form_Field_Description extends UR_Form_Field {
 
+	/**
+	 * Instance Variable.
+	 *
+	 * @var [mixed]
+	 */
 	private static $_instance;
 
+	/**
+	 * Get Instance of class.
+	 */
 	public static function get_instance() {
 		// If the single instance hasn't been set, set it now.
 		if ( is_null( self::$_instance ) ) {
@@ -27,7 +33,9 @@ class UR_Form_Field_Description extends UR_Form_Field {
 		return self::$_instance;
 	}
 
-
+	/**
+	 * Constructor.
+	 */
 	public function __construct() {
 
 		$this->id                       = 'user_registration_description';
@@ -43,23 +51,35 @@ class UR_Form_Field_Description extends UR_Form_Field {
 		);
 	}
 
+	/**
+	 * Get Registered admin fields.
+	 */
 	public function get_registered_admin_fields() {
 
-		return '<li id="' . esc_attr( $this->id ) . '_list " class="ur-registered-item draggable" data-field-id="' .esc_attr( $this->id ) . '"><span class="' . esc_attr( $this->registered_fields_config['icon'] ). '"></span>' . esc_html( $this->registered_fields_config['label'] ) . '</li>';
+		return '<li id="' . esc_attr( $this->id ) . '_list " class="ur-registered-item draggable" data-field-id="' . esc_attr( $this->id ) . '"><span class="' . esc_attr( $this->registered_fields_config['icon'] ) . '"></span>' . esc_html( $this->registered_fields_config['label'] ) . '</li>';
 	}
 
+	/**
+	 * Validate field.
+	 *
+	 * @param [object] $single_form_field Field Data.
+	 * @param [object] $form_data Form Data.
+	 * @param [string] $filter_hook Hook.
+	 * @param [int]    $form_id Form id.
+	 */
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
-		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
-		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
-		$value                = isset( $form_data->value ) ? $form_data->value : '';
-		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$required         = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
+		$field_label      = isset( $form_data->label ) ? $form_data->label : '';
+		$value            = isset( $form_data->value ) ? $form_data->value : '';
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array(); //phpcs:ignore;
 		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
 		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {
-					return esc_html__( $field_label . ' is required.', 'user-registration' );
+					/* translators: %1$s - Field Label */
+					return sprintf( __( '%1$s is required.', 'user-registration' ), $field_label );
 				}
 			);
 		}

--- a/includes/form/class-ur-form-field-display-name.php
+++ b/includes/form/class-ur-form-field-display-name.php
@@ -3,8 +3,6 @@
  * UR_Form_Field_Display_Name.
  *
  * @package  UserRegistration/Form
- * @category Admin
- * @author   WPEverest
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,8 +14,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class UR_Form_Field_Display_Name extends UR_Form_Field {
 
+	/**
+	 * Instance Variable.
+	 *
+	 * @var [mixed]
+	 */
 	private static $_instance;
 
+	/**
+	 * Get Instance of class.
+	 */
 	public static function get_instance() {
 		// If the single instance hasn't been set, set it now.
 		if ( is_null( self::$_instance ) ) {
@@ -27,6 +33,9 @@ class UR_Form_Field_Display_Name extends UR_Form_Field {
 		return self::$_instance;
 	}
 
+	/**
+	 * Constructor.
+	 */
 	public function __construct() {
 
 		$this->id                       = 'user_registration_display_name';
@@ -42,23 +51,35 @@ class UR_Form_Field_Display_Name extends UR_Form_Field {
 		);
 	}
 
+	/**
+	 * Get Registered admin fields.
+	 */
 	public function get_registered_admin_fields() {
 
-		return '<li id="' . esc_attr( $this->id ) . '_list " class="ur-registered-item draggable" data-field-id="' .esc_attr( $this->id ) . '"><span class="' . esc_attr( $this->registered_fields_config['icon'] ). '"></span>' . esc_html( $this->registered_fields_config['label'] ) . '</li>';
+		return '<li id="' . esc_attr( $this->id ) . '_list " class="ur-registered-item draggable" data-field-id="' . esc_attr( $this->id ) . '"><span class="' . esc_attr( $this->registered_fields_config['icon'] ) . '"></span>' . esc_html( $this->registered_fields_config['label'] ) . '</li>';
 	}
 
+	/**
+	 * Validate field.
+	 *
+	 * @param [object] $single_form_field Field Data.
+	 * @param [object] $form_data Form Data.
+	 * @param [string] $filter_hook Hook.
+	 * @param [int]    $form_id Form id.
+	 */
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
-		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array(); //phpcs:ignore;
 		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
 		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {
-					return __( $field_label . ' is required.', 'user-registration' );
+					/* translators: %1$s - Field Label */
+					return sprintf( __( '%1$s is required.', 'user-registration' ), $field_label );
 				}
 			);
 		}

--- a/includes/form/class-ur-form-field-display-name.php
+++ b/includes/form/class-ur-form-field-display-name.php
@@ -48,12 +48,13 @@ class UR_Form_Field_Display_Name extends UR_Form_Field {
 	}
 
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
-		$is_condition_enabled = isset( $single_form_field->advance_setting->enable_conditional_logic ) ? $single_form_field->advance_setting->enable_conditional_logic : '0';
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
-		if ( $is_condition_enabled !== '1' && 'yes' == $required && empty( $value ) ) {
+		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {

--- a/includes/form/class-ur-form-field-email.php
+++ b/includes/form/class-ur-form-field-email.php
@@ -48,12 +48,13 @@ class UR_Form_Field_Email extends UR_Form_Field {
 	}
 
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
-		$is_condition_enabled = isset( $single_form_field->advance_setting->enable_conditional_logic ) ? $single_form_field->advance_setting->enable_conditional_logic : '0';
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
-		if ( $is_condition_enabled !== '1' && 'yes' == $required && empty( $value ) ) {
+		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {

--- a/includes/form/class-ur-form-field-email.php
+++ b/includes/form/class-ur-form-field-email.php
@@ -3,8 +3,6 @@
  * UR_Form_Field_Email.
  *
  * @package  UserRegistration/Form
- * @category Admin
- * @author   WPEverest
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,8 +14,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class UR_Form_Field_Email extends UR_Form_Field {
 
+	/**
+	 * Instance Variable.
+	 *
+	 * @var [mixed]
+	 */
 	private static $_instance;
 
+	/**
+	 * Get Instance of class.
+	 */
 	public static function get_instance() {
 		// If the single instance hasn't been set, set it now.
 		if ( is_null( self::$_instance ) ) {
@@ -27,6 +33,9 @@ class UR_Form_Field_Email extends UR_Form_Field {
 		return self::$_instance;
 	}
 
+	/**
+	 * Constructor.
+	 */
 	public function __construct() {
 
 		$this->id                       = 'user_registration_email';
@@ -42,23 +51,35 @@ class UR_Form_Field_Email extends UR_Form_Field {
 		);
 	}
 
+	/**
+	 * Get Registered admin fields.
+	 */
 	public function get_registered_admin_fields() {
 
-		return '<li id="' . esc_attr( $this->id ) . '_list " class="ur-registered-item draggable" data-field-id="' .esc_attr( $this->id ) . '"><span class="' . esc_attr( $this->registered_fields_config['icon'] ). '"></span>' . esc_html( $this->registered_fields_config['label'] ) . '</li>';
+		return '<li id="' . esc_attr( $this->id ) . '_list " class="ur-registered-item draggable" data-field-id="' . esc_attr( $this->id ) . '"><span class="' . esc_attr( $this->registered_fields_config['icon'] ) . '"></span>' . esc_html( $this->registered_fields_config['label'] ) . '</li>';
 	}
 
+	/**
+	 * Validate field.
+	 *
+	 * @param [object] $single_form_field Field Data.
+	 * @param [object] $form_data Form Data.
+	 * @param [string] $filter_hook Hook.
+	 * @param [int]    $form_id Form id.
+	 */
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
-		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array(); //phpcs:ignore;
 		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
 		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {
-					return __( $field_label . ' is required.', 'user-registration' );
+					/* translators: %1$s - Field Label */
+					return sprintf( __( '%1$s is required.', 'user-registration' ), $field_label );
 				}
 			);
 		}
@@ -67,7 +88,8 @@ class UR_Form_Field_Email extends UR_Form_Field {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {
-					return __( $field_label . ' must be a valid email address.', 'user-registration' );
+					/* translators: %1$s - Field Label */
+					return sprintf( __( '%1$s must be a valid email address.', 'user-registration' ), $field_label );
 				}
 			);
 		}

--- a/includes/form/class-ur-form-field-first-name.php
+++ b/includes/form/class-ur-form-field-first-name.php
@@ -3,8 +3,6 @@
  * UR_Form_Field_First_Name.
  *
  * @package  UserRegistration/Form
- * @category Admin
- * @author   WPEverest
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,8 +14,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class UR_Form_Field_First_Name extends UR_Form_Field {
 
+	/**
+	 * Instance Variable.
+	 *
+	 * @var [mixed]
+	 */
 	private static $_instance;
 
+	/**
+	 * Get Instance of class.
+	 */
 	public static function get_instance() {
 		// If the single instance hasn't been set, set it now.
 		if ( is_null( self::$_instance ) ) {
@@ -27,6 +33,9 @@ class UR_Form_Field_First_Name extends UR_Form_Field {
 		return self::$_instance;
 	}
 
+	/**
+	 * Constructor.
+	 */
 	public function __construct() {
 
 		$this->id                       = 'user_registration_first_name';
@@ -42,23 +51,35 @@ class UR_Form_Field_First_Name extends UR_Form_Field {
 		);
 	}
 
+	/**
+	 * Get Registered admin fields.
+	 */
 	public function get_registered_admin_fields() {
 
-		return '<li id="' . esc_attr( $this->id ) . '_list " class="ur-registered-item draggable" data-field-id="' .esc_attr( $this->id ) . '"><span class="' . esc_attr( $this->registered_fields_config['icon'] ). '"></span>' . esc_html( $this->registered_fields_config['label'] ) . '</li>';
+		return '<li id="' . esc_attr( $this->id ) . '_list " class="ur-registered-item draggable" data-field-id="' . esc_attr( $this->id ) . '"><span class="' . esc_attr( $this->registered_fields_config['icon'] ) . '"></span>' . esc_html( $this->registered_fields_config['label'] ) . '</li>';
 	}
 
+	/**
+	 * Validate field.
+	 *
+	 * @param [object] $single_form_field Field Data.
+	 * @param [object] $form_data Form Data.
+	 * @param [string] $filter_hook Hook.
+	 * @param [int]    $form_id Form id.
+	 */
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
-		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array(); //phpcs:ignore;
 		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
 		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {
-					return __( $field_label . ' is required.', 'user-registration' );
+					/* translators: %1$s - Field Label */
+					return sprintf( __( '%1$s is required.', 'user-registration' ), $field_label );
 				}
 			);
 		}

--- a/includes/form/class-ur-form-field-first-name.php
+++ b/includes/form/class-ur-form-field-first-name.php
@@ -48,12 +48,13 @@ class UR_Form_Field_First_Name extends UR_Form_Field {
 	}
 
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
-		$is_condition_enabled = isset( $single_form_field->advance_setting->enable_conditional_logic ) ? $single_form_field->advance_setting->enable_conditional_logic : '0';
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
-		if ( $is_condition_enabled !== '1' && 'yes' == $required && empty( $value ) ) {
+		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {

--- a/includes/form/class-ur-form-field-last-name.php
+++ b/includes/form/class-ur-form-field-last-name.php
@@ -3,8 +3,6 @@
  * UR_Form_Field_Last_Name.
  *
  * @package  UserRegistration/Form
- * @category Admin
- * @author   WPEverest
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,8 +14,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class UR_Form_Field_Last_Name extends UR_Form_Field {
 
+	/**
+	 * Instance Variable.
+	 *
+	 * @var [mixed]
+	 */
 	private static $_instance;
 
+	/**
+	 * Get Instance of class.
+	 */
 	public static function get_instance() {
 		// If the single instance hasn't been set, set it now.
 		if ( is_null( self::$_instance ) ) {
@@ -27,6 +33,9 @@ class UR_Form_Field_Last_Name extends UR_Form_Field {
 		return self::$_instance;
 	}
 
+	/**
+	 * Constructor.
+	 */
 	public function __construct() {
 
 		$this->id                       = 'user_registration_last_name';
@@ -42,23 +51,35 @@ class UR_Form_Field_Last_Name extends UR_Form_Field {
 		);
 	}
 
+	/**
+	 * Get Registered admin fields.
+	 */
 	public function get_registered_admin_fields() {
 
-		return '<li id="' . esc_attr( $this->id ) . '_list " class="ur-registered-item draggable" data-field-id="' .esc_attr( $this->id ) . '"><span class="' . esc_attr( $this->registered_fields_config['icon'] ). '"></span>' . esc_html( $this->registered_fields_config['label'] ) . '</li>';
+		return '<li id="' . esc_attr( $this->id ) . '_list " class="ur-registered-item draggable" data-field-id="' . esc_attr( $this->id ) . '"><span class="' . esc_attr( $this->registered_fields_config['icon'] ) . '"></span>' . esc_html( $this->registered_fields_config['label'] ) . '</li>';
 	}
 
+	/**
+	 * Validate field.
+	 *
+	 * @param [object] $single_form_field Field Data.
+	 * @param [object] $form_data Form Data.
+	 * @param [string] $filter_hook Hook.
+	 * @param [int]    $form_id Form id.
+	 */
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
-		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array(); //phpcs:ignore;
 		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
 		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {
-					return __( $field_label . ' is required.', 'user-registration' );
+					/* translators: %1$s - Field Label */
+					return sprintf( __( '%1$s is required.', 'user-registration' ), $field_label );
 				}
 			);
 		}

--- a/includes/form/class-ur-form-field-last-name.php
+++ b/includes/form/class-ur-form-field-last-name.php
@@ -48,12 +48,13 @@ class UR_Form_Field_Last_Name extends UR_Form_Field {
 	}
 
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
-		$is_condition_enabled = isset( $single_form_field->advance_setting->enable_conditional_logic ) ? $single_form_field->advance_setting->enable_conditional_logic : '0';
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
-		if ( $is_condition_enabled !== '1' && 'yes' == $required && empty( $value ) ) {
+		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {

--- a/includes/form/class-ur-form-field-nickname.php
+++ b/includes/form/class-ur-form-field-nickname.php
@@ -50,12 +50,13 @@ class UR_Form_Field_Nickname extends UR_Form_Field {
 
 
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
-		$is_condition_enabled = isset( $single_form_field->advance_setting->enable_conditional_logic ) ? $single_form_field->advance_setting->enable_conditional_logic : '0';
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
-		if ( $is_condition_enabled !== '1' && 'yes' == $required && empty( $value ) ) {
+		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {

--- a/includes/form/class-ur-form-field-nickname.php
+++ b/includes/form/class-ur-form-field-nickname.php
@@ -3,8 +3,6 @@
  * UR_Form_Field_Nickname.
  *
  * @package  UserRegistration/Form
- * @category Admin
- * @author   WPEverest
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,8 +14,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class UR_Form_Field_Nickname extends UR_Form_Field {
 
+	/**
+	 * Instance Variable.
+	 *
+	 * @var [mixed]
+	 */
 	private static $_instance;
 
+	/**
+	 * Get Instance of class.
+	 */
 	public static function get_instance() {
 		// If the single instance hasn't been set, set it now.
 		if ( is_null( self::$_instance ) ) {
@@ -27,6 +33,9 @@ class UR_Form_Field_Nickname extends UR_Form_Field {
 		return self::$_instance;
 	}
 
+	/**
+	 * Constructor.
+	 */
 	public function __construct() {
 
 		$this->id                       = 'user_registration_nickname';
@@ -42,25 +51,35 @@ class UR_Form_Field_Nickname extends UR_Form_Field {
 		);
 	}
 
-
+	/**
+	 * Get Registered admin fields.
+	 */
 	public function get_registered_admin_fields() {
 
-		return '<li id="' . esc_attr( $this->id ) . '_list " class="ur-registered-item draggable" data-field-id="' .esc_attr( $this->id ) . '"><span class="' . esc_attr( $this->registered_fields_config['icon'] ). '"></span>' . esc_html( $this->registered_fields_config['label'] ) . '</li>';
+		return '<li id="' . esc_attr( $this->id ) . '_list " class="ur-registered-item draggable" data-field-id="' . esc_attr( $this->id ) . '"><span class="' . esc_attr( $this->registered_fields_config['icon'] ) . '"></span>' . esc_html( $this->registered_fields_config['label'] ) . '</li>';
 	}
 
-
+	/**
+	 * Validate field.
+	 *
+	 * @param [object] $single_form_field Field Data.
+	 * @param [object] $form_data Form Data.
+	 * @param [string] $filter_hook Hook.
+	 * @param [int]    $form_id Form id.
+	 */
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
-		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array(); //phpcs:ignore;
 		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
 		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {
-					return __( $field_label . ' is required.', 'user-registration' );
+					/* translators: %1$s - Field Label */
+					return sprintf( __( '%1$s is required.', 'user-registration' ), $field_label );
 				}
 			);
 		}

--- a/includes/form/class-ur-form-field-number.php
+++ b/includes/form/class-ur-form-field-number.php
@@ -5,8 +5,6 @@
  * @class    UR_Form_Field_Number
  * @since    1.0.5
  * @package  UserRegistration/Form
- * @category Admin
- * @author   WPEverest
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -18,8 +16,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class UR_Form_Field_Number extends UR_Form_Field {
 
+	/**
+	 * Instance Variable.
+	 *
+	 * @var [mixed]
+	 */
 	private static $_instance;
 
+	/**
+	 * Get Instance of class.
+	 */
 	public static function get_instance() {
 		// If the single instance hasn't been set, set it now.
 		if ( is_null( self::$_instance ) ) {
@@ -29,6 +35,9 @@ class UR_Form_Field_Number extends UR_Form_Field {
 		return self::$_instance;
 	}
 
+	/**
+	 * Constructor.
+	 */
 	public function __construct() {
 
 		$this->id                       = 'user_registration_number';
@@ -44,23 +53,35 @@ class UR_Form_Field_Number extends UR_Form_Field {
 		);
 	}
 
+	/**
+	 * Get Registered admin fields.
+	 */
 	public function get_registered_admin_fields() {
 
-		return '<li id="' . esc_attr( $this->id ) . '_list " class="ur-registered-item draggable" data-field-id="' .esc_attr( $this->id ) . '"><span class="' . esc_attr( $this->registered_fields_config['icon'] ). '"></span>' . esc_html( $this->registered_fields_config['label'] ) . '</li>';
+		return '<li id="' . esc_attr( $this->id ) . '_list " class="ur-registered-item draggable" data-field-id="' . esc_attr( $this->id ) . '"><span class="' . esc_attr( $this->registered_fields_config['icon'] ) . '"></span>' . esc_html( $this->registered_fields_config['label'] ) . '</li>';
 	}
 
+	/**
+	 * Validate field.
+	 *
+	 * @param [object] $single_form_field Field Data.
+	 * @param [object] $form_data Form Data.
+	 * @param [string] $filter_hook Hook.
+	 * @param [int]    $form_id Form id.
+	 */
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
-		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array(); //phpcs:ignore;
 		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
 		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {
-					return __( $field_label . ' is required.', 'user-registration' );
+					/* translators: %1$s - Field Label */
+					return sprintf( __( '%1$s is required.', 'user-registration' ), $field_label );
 				}
 			);
 		}
@@ -69,7 +90,8 @@ class UR_Form_Field_Number extends UR_Form_Field {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {
-					return __( $field_label . ' must be numeric value.', 'user-registration' );
+					/* translators: %1$s - Field Label */
+					return sprintf( __( '%1$s must be numeric value.', 'user-registration' ), $field_label );
 				}
 			);
 		}

--- a/includes/form/class-ur-form-field-number.php
+++ b/includes/form/class-ur-form-field-number.php
@@ -50,12 +50,13 @@ class UR_Form_Field_Number extends UR_Form_Field {
 	}
 
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
-		$is_condition_enabled = isset( $single_form_field->advance_setting->enable_conditional_logic ) ? $single_form_field->advance_setting->enable_conditional_logic : '0';
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
-		if ( $is_condition_enabled !== '1' && 'yes' == $required && empty( $value ) ) {
+		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {

--- a/includes/form/class-ur-form-field-password.php
+++ b/includes/form/class-ur-form-field-password.php
@@ -3,8 +3,6 @@
  * UR_Form_Field_Password.
  *
  * @package  UserRegistration/Form
- * @category Admin
- * @author   WPEverest
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,8 +14,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class UR_Form_Field_Password extends UR_Form_Field {
 
+	/**
+	 * Instance Variable.
+	 *
+	 * @var [mixed]
+	 */
 	private static $_instance;
 
+	/**
+	 * Get Instance of class.
+	 */
 	public static function get_instance() {
 		// If the single instance hasn't been set, set it now.
 		if ( is_null( self::$_instance ) ) {
@@ -27,6 +33,9 @@ class UR_Form_Field_Password extends UR_Form_Field {
 		return self::$_instance;
 	}
 
+	/**
+	 * Constructor.
+	 */
 	public function __construct() {
 
 		$this->id                       = 'user_registration_password';
@@ -42,25 +51,35 @@ class UR_Form_Field_Password extends UR_Form_Field {
 		);
 	}
 
-
+	/**
+	 * Get Registered admin fields.
+	 */
 	public function get_registered_admin_fields() {
 
-		return '<li id="' . esc_attr( $this->id ) . '_list " class="ur-registered-item draggable" data-field-id="' .esc_attr( $this->id ) . '"><span class="' . esc_attr( $this->registered_fields_config['icon'] ). '"></span>' . esc_html( $this->registered_fields_config['label'] ) . '</li>';
+		return '<li id="' . esc_attr( $this->id ) . '_list " class="ur-registered-item draggable" data-field-id="' . esc_attr( $this->id ) . '"><span class="' . esc_attr( $this->registered_fields_config['icon'] ) . '"></span>' . esc_html( $this->registered_fields_config['label'] ) . '</li>';
 	}
 
-
+	/**
+	 * Validate field.
+	 *
+	 * @param [object] $single_form_field Field Data.
+	 * @param [object] $form_data Form Data.
+	 * @param [string] $filter_hook Hook.
+	 * @param [int]    $form_id Form id.
+	 */
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
-		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array(); //phpcs:ignore;
 		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
 		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {
-					return __( $field_label . ' is required.', 'user-registration' );
+					/* translators: %1$s - Field Label */
+					return sprintf( __( '%1$s is required.', 'user-registration' ), $field_label );
 				}
 			);
 		}

--- a/includes/form/class-ur-form-field-password.php
+++ b/includes/form/class-ur-form-field-password.php
@@ -50,12 +50,13 @@ class UR_Form_Field_Password extends UR_Form_Field {
 
 
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
-		$is_condition_enabled = isset( $single_form_field->advance_setting->enable_conditional_logic ) ? $single_form_field->advance_setting->enable_conditional_logic : '0';
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
-		if ( $is_condition_enabled !== '1' && 'yes' == $required && empty( $value ) ) {
+		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {

--- a/includes/form/class-ur-form-field-privacy-policy.php
+++ b/includes/form/class-ur-form-field-privacy-policy.php
@@ -58,12 +58,13 @@ class UR_Form_Field_Privacy_Policy extends UR_Form_Field {
 	 * @param $form_id
 	 */
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
-		$is_condition_enabled = isset( $single_form_field->advance_setting->enable_conditional_logic ) ? $single_form_field->advance_setting->enable_conditional_logic : '0';
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
-		if ( $is_condition_enabled !== '1' && 'yes' == $required && empty( $value ) ) {
+		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {

--- a/includes/form/class-ur-form-field-privacy-policy.php
+++ b/includes/form/class-ur-form-field-privacy-policy.php
@@ -3,8 +3,6 @@
  * UR_Form_Field_Privacy_Policy.
  *
  * @package  UserRegistration/Form
- * @category Admin
- * @author   WPEverest
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,8 +14,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class UR_Form_Field_Privacy_Policy extends UR_Form_Field {
 
+	/**
+	 * Instance Variable.
+	 *
+	 * @var [mixed]
+	 */
 	private static $_instance;
 
+	/**
+	 * Get Instance of class.
+	 */
 	public static function get_instance() {
 		// If the single instance hasn't been set, set it now.
 		if ( is_null( self::$_instance ) ) {
@@ -27,6 +33,9 @@ class UR_Form_Field_Privacy_Policy extends UR_Form_Field {
 		return self::$_instance;
 	}
 
+	/**
+	 * Constructor.
+	 */
 	public function __construct() {
 
 		$this->id                       = 'user_registration_privacy_policy';
@@ -43,32 +52,35 @@ class UR_Form_Field_Privacy_Policy extends UR_Form_Field {
 	}
 
 	/**
-	 * @return string
+	 * Get Registered admin fields.
 	 */
 	public function get_registered_admin_fields() {
 
-		return '<li id="' . esc_attr( $this->id ) . '_list " class="ur-registered-item draggable" data-field-id="' .esc_attr( $this->id ) . '"><span class="' . esc_attr( $this->registered_fields_config['icon'] ). '"></span>' . esc_html( $this->registered_fields_config['label'] ) . '</li>';
+		return '<li id="' . esc_attr( $this->id ) . '_list " class="ur-registered-item draggable" data-field-id="' . esc_attr( $this->id ) . '"><span class="' . esc_attr( $this->registered_fields_config['icon'] ) . '"></span>' . esc_html( $this->registered_fields_config['label'] ) . '</li>';
 	}
 
 
 	/**
-	 * @param $single_form_field
-	 * @param $form_data
-	 * @param $filter_hook
-	 * @param $form_id
+	 * Validate field.
+	 *
+	 * @param [object] $single_form_field Field Data.
+	 * @param [object] $form_data Form Data.
+	 * @param [string] $filter_hook Hook.
+	 * @param [int]    $form_id Form id.
 	 */
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
-		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array(); //phpcs:ignore;
 		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
 		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {
-					return __( $field_label . ' is required.', 'user-registration' );
+					/* translators: %1$s - Field Label */
+					return sprintf( __( '%1$s is required.', 'user-registration' ), $field_label );
 				}
 			);
 		}

--- a/includes/form/class-ur-form-field-radio.php
+++ b/includes/form/class-ur-form-field-radio.php
@@ -3,8 +3,6 @@
  * UR_Form_Field_Radio.
  *
  * @package  UserRegistration/Form
- * @category Admin
- * @author   WPEverest
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,8 +14,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class UR_Form_Field_Radio extends UR_Form_Field {
 
+	/**
+	 * Instance Variable.
+	 *
+	 * @var [mixed]
+	 */
 	private static $_instance;
 
+	/**
+	 * Get Instance of class.
+	 */
 	public static function get_instance() {
 		// If the single instance hasn't been set, set it now.
 		if ( is_null( self::$_instance ) ) {
@@ -28,7 +34,7 @@ class UR_Form_Field_Radio extends UR_Form_Field {
 	}
 
 	/**
-	 * Hook in tabs.
+	 * Constructor.
 	 */
 	public function __construct() {
 
@@ -50,25 +56,35 @@ class UR_Form_Field_Radio extends UR_Form_Field {
 		);
 	}
 
-
+	/**
+	 * Get Registered admin fields.
+	 */
 	public function get_registered_admin_fields() {
 
 		return '<li id="' . $this->id . '_list " class="ur-registered-item draggable" data-field-id="' . $this->id . '"><span class="' . $this->registered_fields_config['icon'] . '"></span>' . $this->registered_fields_config['label'] . '</li>';
 	}
 
-
+	/**
+	 * Validate field.
+	 *
+	 * @param [object] $single_form_field Field Data.
+	 * @param [object] $form_data Form Data.
+	 * @param [string] $filter_hook Hook.
+	 * @param [int]    $form_id Form id.
+	 */
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
-		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array(); //phpcs:ignore;
 		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
 		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {
-					return __( $field_label . ' is required.', 'user-registration' );
+					/* translators: %1$s - Field Label */
+					return sprintf( __( '%1$s is required.', 'user-registration' ), $field_label );
 				}
 			);
 		}

--- a/includes/form/class-ur-form-field-radio.php
+++ b/includes/form/class-ur-form-field-radio.php
@@ -58,12 +58,13 @@ class UR_Form_Field_Radio extends UR_Form_Field {
 
 
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
-		$is_condition_enabled = isset( $single_form_field->advance_setting->enable_conditional_logic ) ? $single_form_field->advance_setting->enable_conditional_logic : '0';
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
-		if ( $is_condition_enabled !== '1' && 'yes' == $required && empty( $value ) ) {
+		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {

--- a/includes/form/class-ur-form-field-select.php
+++ b/includes/form/class-ur-form-field-select.php
@@ -53,12 +53,13 @@ class UR_Form_Field_Select extends UR_Form_Field {
 	}
 
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
-		$is_condition_enabled = isset( $single_form_field->advance_setting->enable_conditional_logic ) ? $single_form_field->advance_setting->enable_conditional_logic : '0';
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
-		if ( $is_condition_enabled !== '1' && 'yes' == $required && empty( $value ) ) {
+		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {

--- a/includes/form/class-ur-form-field-select.php
+++ b/includes/form/class-ur-form-field-select.php
@@ -3,8 +3,6 @@
  * UR_Form_Field_Selec.
  *
  * @package  UserRegistration/Form
- * @category Admin
- * @author   WPEverest
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,8 +14,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class UR_Form_Field_Select extends UR_Form_Field {
 
+	/**
+	 * Instance Variable.
+	 *
+	 * @var [mixed]
+	 */
 	private static $_instance;
 
+	/**
+	 * Get Instance of class.
+	 */
 	public static function get_instance() {
 		// If the single instance hasn't been set, set it now.
 		if ( is_null( self::$_instance ) ) {
@@ -27,6 +33,9 @@ class UR_Form_Field_Select extends UR_Form_Field {
 		return self::$_instance;
 	}
 
+	/**
+	 * Constructor.
+	 */
 	public function __construct() {
 
 		$this->id                       = 'user_registration_select';
@@ -47,23 +56,35 @@ class UR_Form_Field_Select extends UR_Form_Field {
 		);
 	}
 
+	/**
+	 * Get Registered admin fields.
+	 */
 	public function get_registered_admin_fields() {
 
 		return '<li id="' . $this->id . '_list " class="ur-registered-item draggable" data-field-id="' . $this->id . '"><span class="' . $this->registered_fields_config['icon'] . '"></span>' . $this->registered_fields_config['label'] . '</li>';
 	}
 
+	/**
+	 * Validate field.
+	 *
+	 * @param [object] $single_form_field Field Data.
+	 * @param [object] $form_data Form Data.
+	 * @param [string] $filter_hook Hook.
+	 * @param [int]    $form_id Form id.
+	 */
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
-		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array(); //phpcs:ignore;
 		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
 		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {
-					return __( $field_label . ' is required.', 'user-registration' );
+					/* translators: %1$s - Field Label */
+					return sprintf( __( '%1$s is required.', 'user-registration' ), $field_label );
 				}
 			);
 		}

--- a/includes/form/class-ur-form-field-text.php
+++ b/includes/form/class-ur-form-field-text.php
@@ -3,8 +3,6 @@
  * UR_Form_Field_Text.
  *
  * @package  UserRegistration/Form
- * @category Admin
- * @author   WPEverest
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,8 +14,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class UR_Form_Field_Text extends UR_Form_Field {
 
+	/**
+	 * Instance Variable.
+	 *
+	 * @var [mixed]
+	 */
 	private static $_instance;
 
+	/**
+	 * Get Instance of class.
+	 */
 	public static function get_instance() {
 		// If the single instance hasn't been set, set it now.
 		if ( is_null( self::$_instance ) ) {
@@ -27,6 +33,9 @@ class UR_Form_Field_Text extends UR_Form_Field {
 		return self::$_instance;
 	}
 
+	/**
+	 * Constructor.
+	 */
 	public function __construct() {
 
 		$this->id                       = 'user_registration_text';
@@ -42,25 +51,36 @@ class UR_Form_Field_Text extends UR_Form_Field {
 		);
 	}
 
+	/**
+	 * Get Registered admin fields.
+	 */
 	public function get_registered_admin_fields() {
 
 		return '<li id="' . $this->id . '_list " class="ur-registered-item draggable" data-field-id="' . $this->id . '"><span class="' . $this->registered_fields_config['icon'] . '"></span>' . $this->registered_fields_config['label'] . '</li>';
 	}
 
+	/**
+	 * Validate field.
+	 *
+	 * @param [object] $single_form_field Field Data.
+	 * @param [object] $form_data Form Data.
+	 * @param [string] $filter_hook Hook.
+	 * @param [int]    $form_id Form id.
+	 */
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
-
 
 		$required    = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label = isset( $form_data->label ) ? $form_data->label : '';
 		$value       = isset( $form_data->value ) ? $form_data->value : '';
-		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array(); //phpcs:ignore;
 		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
 		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {
-					return __( $field_label . ' is required.', 'user-registration' );
+					/* translators: %1$s - Field Label */
+					return sprintf( __( '%1$s is required.', 'user-registration' ), $field_label );
 				}
 			);
 		}

--- a/includes/form/class-ur-form-field-text.php
+++ b/includes/form/class-ur-form-field-text.php
@@ -49,13 +49,14 @@ class UR_Form_Field_Text extends UR_Form_Field {
 
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
 
-		$is_condition_enabled = isset( $single_form_field->advance_setting->enable_conditional_logic ) ? $single_form_field->advance_setting->enable_conditional_logic : '0';
 
 		$required    = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label = isset( $form_data->label ) ? $form_data->label : '';
 		$value       = isset( $form_data->value ) ? $form_data->value : '';
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
-		if ( $is_condition_enabled !== '1' && 'yes' == $required && empty( $value ) ) {
+		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {

--- a/includes/form/class-ur-form-field-textarea.php
+++ b/includes/form/class-ur-form-field-textarea.php
@@ -50,12 +50,13 @@ class UR_Form_Field_Textarea extends UR_Form_Field {
 
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
 
-		$is_condition_enabled = isset( $single_form_field->advance_setting->enable_conditional_logic ) ? $single_form_field->advance_setting->enable_conditional_logic : '0';
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
-		if ( $is_condition_enabled !== '1' && 'yes' == $required && empty( $value ) ) {
+		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {

--- a/includes/form/class-ur-form-field-textarea.php
+++ b/includes/form/class-ur-form-field-textarea.php
@@ -3,8 +3,6 @@
  * UR_Form_Field_Textarea.
  *
  * @package  UserRegistration/Form
- * @category Admin
- * @author   WPEverest
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,8 +14,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class UR_Form_Field_Textarea extends UR_Form_Field {
 
+	/**
+	 * Instance Variable.
+	 *
+	 * @var [mixed]
+	 */
 	private static $_instance;
 
+	/**
+	 * Get Instance of class.
+	 */
 	public static function get_instance() {
 		// If the single instance hasn't been set, set it now.
 		if ( is_null( self::$_instance ) ) {
@@ -27,6 +33,9 @@ class UR_Form_Field_Textarea extends UR_Form_Field {
 		return self::$_instance;
 	}
 
+	/**
+	 * Constructor.
+	 */
 	public function __construct() {
 
 		$this->id                       = 'user_registration_textarea';
@@ -42,25 +51,36 @@ class UR_Form_Field_Textarea extends UR_Form_Field {
 		);
 	}
 
+	/**
+	 * Get Registered admin fields.
+	 */
 	public function get_registered_admin_fields() {
 
 		return '<li id="' . $this->id . '_list " class="ur-registered-item draggable" data-field-id="' . $this->id . '"><span class="' . $this->registered_fields_config['icon'] . '"></span>' . $this->registered_fields_config['label'] . '</li>';
 	}
 
-
+	/**
+	 * Validate field.
+	 *
+	 * @param [object] $single_form_field Field Data.
+	 * @param [object] $form_data Form Data.
+	 * @param [string] $filter_hook Hook.
+	 * @param [int]    $form_id Form id.
+	 */
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
 
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
-		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array(); //phpcs:ignore;
 		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
 		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {
-					return __( $field_label . ' is required.', 'user-registration' );
+					/* translators: %1$s - Field Label */
+					return sprintf( __( '%1$s is required.', 'user-registration' ), $field_label );
 				}
 			);
 		}

--- a/includes/form/class-ur-form-field-user-confirm-email.php
+++ b/includes/form/class-ur-form-field-user-confirm-email.php
@@ -3,8 +3,6 @@
  * UR_Form_Field_User_Confirm_Email.
  *
  * @package  UserRegistration/Form
- * @category Admin
- * @author   WPEverest
  * @since 1.6.0
  */
 
@@ -63,6 +61,14 @@ class UR_Form_Field_User_Confirm_Email extends UR_Form_Field {
 		return '<li id="' . $this->id . '_list "  class="ur-registered-item draggable" data-field-id="' . $this->id . '"><span class="' . $this->registered_fields_config['icon'] . '"></span>' . $this->registered_fields_config['label'] . '</li>';
 	}
 
+	/**
+	 * Validate field.
+	 *
+	 * @param [object] $single_form_field Field Data.
+	 * @param [object] $form_data Form Data.
+	 * @param [string] $filter_hook Hook.
+	 * @param [int]    $form_id Form id.
+	 */
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {}
 }
 

--- a/includes/form/class-ur-form-field-user-confirm-password.php
+++ b/includes/form/class-ur-form-field-user-confirm-password.php
@@ -3,8 +3,6 @@
  * UR_Form_Field_User_Confirm_Password.
  *
  * @package  UserRegistration/Form
- * @category Admin
- * @author   WPEverest
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,8 +14,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class UR_Form_Field_User_Confirm_Password extends UR_Form_Field {
 
+	/**
+	 * Instance Variable.
+	 *
+	 * @var [mixed]
+	 */
 	private static $_instance;
 
+	/**
+	 * Get Instance of class.
+	 */
 	public static function get_instance() {
 		// If the single instance hasn't been set, set it now.
 		if ( is_null( self::$_instance ) ) {
@@ -27,6 +33,9 @@ class UR_Form_Field_User_Confirm_Password extends UR_Form_Field {
 		return self::$_instance;
 	}
 
+	/**
+	 * Constructor.
+	 */
 	public function __construct() {
 
 		$this->id                       = 'user_registration_user_confirm_password';
@@ -41,11 +50,22 @@ class UR_Form_Field_User_Confirm_Password extends UR_Form_Field {
 		);
 	}
 
+	/**
+	 * Html to display in builder fields list.
+	 */
 	public function get_registered_admin_fields() {
 
 		return '<li id="' . $this->id . '_list "  class="ur-registered-item draggable" data-field-id="' . $this->id . '"><span class="' . $this->registered_fields_config['icon'] . '"></span>' . $this->registered_fields_config['label'] . '</li>';
 	}
 
+	/**
+	 * Validate field.
+	 *
+	 * @param [object] $single_form_field Field Data.
+	 * @param [object] $form_data Form Data.
+	 * @param [string] $filter_hook Hook.
+	 * @param [int]    $form_id Form id.
+	 */
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {}
 }
 

--- a/includes/form/class-ur-form-field-user-email.php
+++ b/includes/form/class-ur-form-field-user-email.php
@@ -3,8 +3,6 @@
  * UR_Form_Field_User_Email.
  *
  * @package  UserRegistration/Form
- * @category Admin
- * @author   WPEverest
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,8 +14,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class UR_Form_Field_User_Email extends UR_Form_Field {
 
+	/**
+	 * Instance Variable.
+	 *
+	 * @var [mixed]
+	 */
 	private static $_instance;
 
+	/**
+	 * Get Instance of class.
+	 */
 	public static function get_instance() {
 		// If the single instance hasn't been set, set it now.
 		if ( is_null( self::$_instance ) ) {
@@ -27,6 +33,9 @@ class UR_Form_Field_User_Email extends UR_Form_Field {
 		return self::$_instance;
 	}
 
+	/**
+	 * Constructor.
+	 */
 	public function __construct() {
 
 		$this->id                       = 'user_registration_user_email';
@@ -41,12 +50,22 @@ class UR_Form_Field_User_Email extends UR_Form_Field {
 		);
 	}
 
+	/**
+	 * Html to display in builder fields list.
+	 */
 	public function get_registered_admin_fields() {
 
 		return '<li id="' . $this->id . '_list " class="ur-registered-item draggable" data-field-id="' . $this->id . '"><span class="' . $this->registered_fields_config['icon'] . '"></span>' . $this->registered_fields_config['label'] . '</li>';
 	}
 
-
+	/**
+	 * Validate field.
+	 *
+	 * @param [object] $single_form_field Field Data.
+	 * @param [object] $form_data Form Data.
+	 * @param [string] $filter_hook Hook.
+	 * @param [int]    $form_id Form id.
+	 */
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
 
 		$email  = isset( $form_data->value ) ? $form_data->value : '';

--- a/includes/form/class-ur-form-field-user-login.php
+++ b/includes/form/class-ur-form-field-user-login.php
@@ -3,8 +3,6 @@
  * UR_Form_Field_User_Login.
  *
  * @package  UserRegistration/Form
- * @category Admin
- * @author   WPEverest
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,8 +14,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class UR_Form_Field_User_Login extends UR_Form_Field {
 
+	/**
+	 * Instance Variable.
+	 *
+	 * @var [mixed]
+	 */
 	private static $_instance;
 
+	/**
+	 * Get Instance of class.
+	 */
 	public static function get_instance() {
 		// If the single instance hasn't been set, set it now.
 		if ( is_null( self::$_instance ) ) {
@@ -27,6 +33,9 @@ class UR_Form_Field_User_Login extends UR_Form_Field {
 		return self::$_instance;
 	}
 
+	/**
+	 * Constructor.
+	 */
 	public function __construct() {
 
 		$this->id                       = 'user_registration_user_login';
@@ -41,12 +50,22 @@ class UR_Form_Field_User_Login extends UR_Form_Field {
 		);
 	}
 
+	/**
+	 * Html to display in builder fields list.
+	 */
 	public function get_registered_admin_fields() {
 
 		return '<li id="' . $this->id . '_list " class="ur-registered-item draggable" data-field-id="' . $this->id . '"><span class="' . $this->registered_fields_config['icon'] . '"></span>' . $this->registered_fields_config['label'] . '</li>';
 	}
 
-
+	/**
+	 * Validate field.
+	 *
+	 * @param [object] $single_form_field Field Data.
+	 * @param [object] $form_data Form Data.
+	 * @param [string] $filter_hook Hook.
+	 * @param [int]    $form_id Form id.
+	 */
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
 		$username = isset( $form_data->value ) ? $form_data->value : '';
 

--- a/includes/form/class-ur-form-field-user-pass.php
+++ b/includes/form/class-ur-form-field-user-pass.php
@@ -3,8 +3,6 @@
  * UR_Form_Field_User_Pass
  *
  * @package  UserRegistration/Form
- * @category Admin
- * @author   WPEverest
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,8 +14,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class UR_Form_Field_User_Pass extends UR_Form_Field {
 
+	/**
+	 * Instance Variable.
+	 *
+	 * @var [mixed]
+	 */
 	private static $_instance;
 
+	/**
+	 * Get Instance of class.
+	 */
 	public static function get_instance() {
 		// If the single instance hasn't been set, set it now.
 		if ( is_null( self::$_instance ) ) {
@@ -27,6 +33,9 @@ class UR_Form_Field_User_Pass extends UR_Form_Field {
 		return self::$_instance;
 	}
 
+	/**
+	 * Constructor.
+	 */
 	public function __construct() {
 
 		$this->id                       = 'user_registration_user_pass';
@@ -41,11 +50,22 @@ class UR_Form_Field_User_Pass extends UR_Form_Field {
 		);
 	}
 
+	/**
+	 * Html to display in builder fields list.
+	 */
 	public function get_registered_admin_fields() {
 
 		return '<li id="' . $this->id . '_list " class="ur-registered-item draggable" data-field-id="' . $this->id . '"><span class="' . $this->registered_fields_config['icon'] . '"></span>' . $this->registered_fields_config['label'] . '</li>';
 	}
 
+	/**
+	 * Validate field.
+	 *
+	 * @param [object] $single_form_field Field Data.
+	 * @param [object] $form_data Form Data.
+	 * @param [string] $filter_hook Hook.
+	 * @param [int]    $form_id Form id.
+	 */
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
 
 		$password = isset( $form_data->value ) ? $form_data->value : '';
@@ -60,6 +80,11 @@ class UR_Form_Field_User_Pass extends UR_Form_Field {
 		}
 	}
 
+	/**
+	 * Check Password Length
+	 *
+	 * @param [string] $password Password.
+	 */
 	private static function check_password_length( $password ) {
 
 		$strength = 0;

--- a/includes/form/class-ur-form-field-user-url.php
+++ b/includes/form/class-ur-form-field-user-url.php
@@ -50,12 +50,14 @@ class UR_Form_Field_User_Url extends UR_Form_Field {
 
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
 
-		$is_condition_enabled = isset( $single_form_field->advance_setting->enable_conditional_logic ) ? $single_form_field->advance_setting->enable_conditional_logic : '0';
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
 
-		if ( $is_condition_enabled !== '1' && 'yes' == $required && empty( $value ) ) {
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
+
+		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {

--- a/includes/form/class-ur-form-field-user-url.php
+++ b/includes/form/class-ur-form-field-user-url.php
@@ -3,8 +3,6 @@
  * UR_Form_Field_User_Url
  *
  * @package  UserRegistration/Form
- * @category Admin
- * @author   WPEverest
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,8 +14,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class UR_Form_Field_User_Url extends UR_Form_Field {
 
+	/**
+	 * Instance Variable.
+	 *
+	 * @var [mixed]
+	 */
 	private static $_instance;
 
+	/**
+	 * Get Instance of class.
+	 */
 	public static function get_instance() {
 		// If the single instance hasn't been set, set it now.
 		if ( is_null( self::$_instance ) ) {
@@ -27,6 +33,9 @@ class UR_Form_Field_User_Url extends UR_Form_Field {
 		return self::$_instance;
 	}
 
+	/**
+	 * Constructor.
+	 */
 	public function __construct() {
 
 		$this->id                       = 'user_registration_user_url';
@@ -41,27 +50,37 @@ class UR_Form_Field_User_Url extends UR_Form_Field {
 		);
 	}
 
-
+	/**
+	 * Html to display in builder fields list.
+	 */
 	public function get_registered_admin_fields() {
 
 		return '<li id="' . $this->id . '_list " class="ur-registered-item draggable" data-field-id="' . $this->id . '"><span class="' . $this->registered_fields_config['icon'] . '"></span>' . $this->registered_fields_config['label'] . '</li>';
 	}
 
-
+	/**
+	 * Validate field.
+	 *
+	 * @param [object] $single_form_field Field Data.
+	 * @param [object] $form_data Form Data.
+	 * @param [string] $filter_hook Hook.
+	 * @param [int]    $form_id Form id.
+	 */
 	public function validation( $single_form_field, $form_data, $filter_hook, $form_id ) {
 
 		$required             = isset( $single_form_field->general_setting->required ) ? $single_form_field->general_setting->required : 'no';
 		$field_label          = isset( $form_data->label ) ? $form_data->label : '';
 		$value                = isset( $form_data->value ) ? $form_data->value : '';
 
-		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array();
+		$urcl_hide_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( stripslashes( $_POST['urcl_hide_fields'] ), true ) : array(); //phpcs:ignore;
 		$field_name       = isset( $single_form_field->general_setting->field_name ) ? $single_form_field->general_setting->field_name : '';
 
 		if ( ! in_array( $field_name, $urcl_hide_fields, true ) && 'yes' == $required && empty( $value ) ) {
 			add_filter(
 				$filter_hook,
 				function ( $msg ) use ( $field_label ) {
-					return __( $field_label . ' is required.', 'user-registration' );
+					/* translators: %1$s - Field Label */
+					return sprintf( __( '%1$s is required.', 'user-registration' ), $field_label );
 				}
 			);
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Previously, When we apply conditional logic to any required field and in frontend if we bypass the  client side required validation from browser console. then it was submitting the form instead server side validation. This issue has been fixed in this PR.

### How to test the changes in this Pull Request:

1. Create a form with required field and conditional logic enabled.
2. Goto frontend Form Show that required field and goto inspect element and remove the **required="required"**.
3. Submit the form without entering any value in that field. It should validate from server side.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

>  Fix - Required field not working when conditional logic enabled.