### PR TITLE
UR-408 Fix - Delete forms while uninstall plugin

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -43,11 +43,21 @@ if ( defined( 'UR_REMOVE_ALL_DATA' ) && true === UR_REMOVE_ALL_DATA || 'yes' ===
 	// Delete form id and confirm key.
 	$wpdb->query( "DELETE FROM $wpdb->usermeta WHERE meta_key IN ( 'ur_form_id', 'ur_confirm_email', 'ur_confirm_email_token' ) " );
 
-	$all_forms = ur_get_all_user_registration_form();
+	$args = array(
+		'order'       => 'ASC',
+		'numberposts' => -1,
+		'status'      => 'publish',
+		'post_type'     => 'user_registration',
+		'orderby'       => 'ID',
+		'order'         => 'DESC',
+		'no_found_rows' => true,
+		'nopaging'      => true,
+	);
+	$all_forms = get_posts( $args );
 
-	foreach ( $all_forms as $form_id => $form_name ) {
-		wp_delete_post( $form_id );
-		$wpdb->delete( $wpdb->postmeta, array( 'post_id' => $form_id ) );
+	foreach ( $all_forms as $post ) {
+		$result = wp_delete_post( $post->ID );
+		$del_meta = $wpdb->delete( $wpdb->postmeta, array( 'post_id' => $post->ID ) );
 	}
 
 	// Clear any cached data that has been removed.

--- a/uninstall.php
+++ b/uninstall.php
@@ -43,6 +43,13 @@ if ( defined( 'UR_REMOVE_ALL_DATA' ) && true === UR_REMOVE_ALL_DATA || 'yes' ===
 	// Delete form id and confirm key.
 	$wpdb->query( "DELETE FROM $wpdb->usermeta WHERE meta_key IN ( 'ur_form_id', 'ur_confirm_email', 'ur_confirm_email_token' ) " );
 
+	$all_forms = ur_get_all_user_registration_form();
+
+	foreach ( $all_forms as $form_id => $form_name ) {
+		wp_delete_post( $form_id );
+		$wpdb->delete( $wpdb->postmeta, array( 'post_id' => $form_id ) );
+	}
+
 	// Clear any cached data that has been removed.
 	wp_cache_flush();
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -4,8 +4,6 @@
  *
  * Uninstalls the plugin and associated data.
  *
- * @author   WPEverest
- * @category Core
  * @package  UserRegistration/Uninstaller
  * @version  1.0.0
  */
@@ -55,9 +53,9 @@ if ( defined( 'UR_REMOVE_ALL_DATA' ) && true === UR_REMOVE_ALL_DATA || 'yes' ===
 	);
 	$all_forms = get_posts( $args );
 
-	foreach ( $all_forms as $post ) {
-		$result = wp_delete_post( $post->ID );
-		$del_meta = $wpdb->delete( $wpdb->postmeta, array( 'post_id' => $post->ID ) );
+	foreach ( $all_forms as $form ) {
+		$result = wp_delete_post( $form->ID );
+		$del_meta = $wpdb->delete( $wpdb->postmeta, array( 'post_id' => $form->ID ) );
 	}
 
 	// Clear any cached data that has been removed.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Previously when uninstall option enabled and plugin deleted then it only deleted the global settings and unassigned the user but it was not deleting the forms from post table.

### How to test the changes in this Pull Request:

1. Enable uninstall option from Misc Tab of Settings.
2. Goto Plugin Section and deactivate and delete the user registration plugin.
3. Again Install the user registration plugin and check whether all settings and forms are deleted or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Delete forms while uninstall plugin.
