### PR TITLE
UR-501 Fix - Email verification plain text to link

### DIFF
--- a/includes/admin/settings/emails/class-ur-settings-email-confirmation.php
+++ b/includes/admin/settings/emails/class-ur-settings-email-confirmation.php
@@ -84,7 +84,7 @@ if ( ! class_exists( 'UR_Settings_Email_Confirmation', false ) ) :
 
 You have registered on <a href="{{home_url}}">{{blog_info}}</a>. <br/>
 
-Please click on this verification link {{home_url}}/{{ur_login}}?ur_token={{email_token}} to confirm registration. <br/>
+Please click on this verification link <a href="{{home_url}}/{{ur_login}}?ur_token={{email_token}}">Click here</a> to confirm registration. <br/>
 
 Thank You!',
 						'user-registration'


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously, When User Approval and Login Option is set to Auto Approval After Email Confirmation then Verification link was plain text. This PR will fix this issues.

### How to test the changes in this Pull Request:

1. Navigate to Form builder then form settings.
2. then set User Approval and Login option to Auto Approval After Email Confirmation and update the form.
3.  then make registration and verify whether email verification link is sent as link or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Email verification plain text to link.
