### PR TITLE
Fix - Accordion issue in form builder.

### DIFF
--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -2502,6 +2502,7 @@
 
 				$(document.body).trigger("ur_rendered_field_options");
 				$(document.body).trigger("init_tooltips");
+				$( document.body ).trigger( 'init_field_options_toggle' );
 			},
 			/**
 			 * Render the advance setting for selected field.
@@ -3803,12 +3804,20 @@
 			} else {
 				$(this).addClass("closed");
 			}
+			$( this ).parent( '.user-registration-field-option-group' ).toggleClass( 'closed' ).toggleClass( 'open' );
 			var field_list = $(this).find(" ~ .ur-registered-list")[0];
 			$(field_list).slideToggle();
 
 			// For `Field Options` section
-			$(this).siblings(".ur-toggle-content").slideToggle();
+			$(this).siblings(".ur-toggle-content").stop().slideToggle();
 		});
+
+		$( document.body ).on( 'init_field_options_toggle', function() {
+			$( '.user-registration-field-option-group.closed' ).each( function() {
+				$( this ).find( '.ur-toggle-content' ).hide();
+			});
+
+		} ).trigger( 'init_field_options_toggle' );
 
 		/**
 		 * For toggling quick links content.

--- a/includes/abstracts/abstract-ur-form-field.php
+++ b/includes/abstracts/abstract-ur-form-field.php
@@ -658,7 +658,7 @@ abstract class UR_Form_Field {
 
 		if ( ! empty( $advance_settings ) ) {
 			$settings .= "<div class='user-registration-field-option-group ur-advance-setting-block closed'>";
-			$settings .= '<h2 class="ur-toggle-heading">' . __( 'Advanced Settings', 'user-registration' ) . '</h2><hr>';
+			$settings .= '<h2 class="ur-toggle-heading closed">' . __( 'Advanced Settings', 'user-registration' ) . '</h2><hr>';
 			$settings .= '<div class="ur-toggle-content">';
 			$settings .= $advance_settings;
 			$settings .= '</div>';

--- a/includes/abstracts/abstract-ur-form-field.php
+++ b/includes/abstracts/abstract-ur-form-field.php
@@ -514,11 +514,11 @@ abstract class UR_Form_Field {
 					if ( 'multiple_choice' === $strip_prefix ) {
 
 						foreach ( $options as $key => $option ) {
-							$label = is_array( $option ) ? $option['label'] : $option->label;
-							$value = is_array( $option ) ? $option['value'] : $option->value;
-							$currency   = get_option( 'user_registration_payment_currency', 'USD' );
-							$currencies = ur_payment_integration_get_currencies();
-							$currency = $currency . ' ' . $currencies[ $currency ]['symbol'];
+							$label                    = is_array( $option ) ? $option['label'] : $option->label;
+							$value                    = is_array( $option ) ? $option['value'] : $option->value;
+							$currency                 = get_option( 'user_registration_payment_currency', 'USD' );
+							$currencies               = ur_payment_integration_get_currencies();
+							$currency                 = $currency . ' ' . $currencies[ $currency ]['symbol'];
 							$general_setting_wrapper .= '<li>';
 							$general_setting_wrapper .= '<div class="editor-block-mover__control-drag-handle editor-block-mover__control">
 							<svg width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" role="img" aria-hidden="true" focusable="false"><path d="M13,8c0.6,0,1-0.4,1-1s-0.4-1-1-1s-1,0.4-1,1S12.4,8,13,8z M5,6C4.4,6,4,6.4,4,7s0.4,1,1,1s1-0.4,1-1S5.6,6,5,6z M5,10 c-0.6,0-1,0.4-1,1s0.4,1,1,1s1-0.4,1-1S5.6,10,5,10z M13,10c-0.6,0-1,0.4-1,1s0.4,1,1,1s1-0.4,1-1S13.6,10,13,10z M9,6 C8.4,6,8,6.4,8,7s0.4,1,1,1s1-0.4,1-1S9.6,6,9,6z M9,10c-0.6,0-1,0.4-1,1s0.4,1,1,1s1-0.4,1-1S9.6,10,9,10z"></path></svg>
@@ -657,7 +657,7 @@ abstract class UR_Form_Field {
 		$advance_settings = $this->get_field_advance_settings();
 
 		if ( ! empty( $advance_settings ) ) {
-			$settings .= "<div class='ur-advance-setting-block'>";
+			$settings .= "<div class='user-registration-field-option-group ur-advance-setting-block closed'>";
 			$settings .= '<h2 class="ur-toggle-heading">' . __( 'Advanced Settings', 'user-registration' ) . '</h2><hr>';
 			$settings .= '<div class="ur-toggle-content">';
 			$settings .= $advance_settings;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Previously, When the field is dragged and opened all the accordions were kept open. This Pr solves this issue.

### How to test the changes in this Pull Request:

1. Goto the form builder.
2. Drag and drop the field.
3. verify whether only the general setting block is open or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Accordion issue in form builder..
