### PR TITLE
UR-536 Fix - Reset and incorrect password message appears at same time

### DIFF
--- a/assets/js/frontend/ur-login.js
+++ b/assets/js/frontend/ur-login.js
@@ -78,6 +78,11 @@ jQuery(function ($) {
 
 								$this
 									.closest("#user-registration")
+									.find(".user-registration-message")
+									.remove();
+
+								$this
+									.closest("#user-registration")
 									.prepend(
 										'<ul class="user-registration-error">' +
 											res.data.message +

--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -661,6 +661,7 @@ class UR_Form_Handler {
 					$ur_login_or_account_page = ur_get_page_permalink( 'login' );
 				}
 
+				set_transient( 'ur_password_resetted_flag', true, 60 );
 				wp_redirect( add_query_arg( 'password-reset', 'true', $ur_login_or_account_page ) );
 				exit;
 			}

--- a/includes/shortcodes/class-ur-shortcode-login.php
+++ b/includes/shortcodes/class-ur-shortcode-login.php
@@ -40,8 +40,10 @@ class UR_Shortcode_Login {
 
 		if ( ! is_user_logged_in() ) {
 			// After password reset, add confirmation message.
-			if ( ! empty( $_GET['password-reset'] ) ) {
+			$is_password_resetted = get_transient( 'ur_password_resetted_flag' );
+			if ( ! empty( $is_password_resetted ) ) {
 				ur_add_notice( __( 'Your password has been reset successfully.', 'user-registration' ) );
+				delete_transient( 'ur_password_resetted_flag' );
 			}
 			if ( isset( $wp->query_vars['ur-lost-password'] ) ) {
 				UR_Shortcode_My_Account::lost_password();

--- a/includes/shortcodes/class-ur-shortcode-my-account.php
+++ b/includes/shortcodes/class-ur-shortcode-my-account.php
@@ -72,8 +72,10 @@ class UR_Shortcode_My_Account {
 			}
 
 			// After password reset, add confirmation message.
-			if ( ! empty( $_GET['password-reset'] ) ) {
+			$is_password_resetted = get_transient( 'ur_password_resetted_flag' );
+			if ( ! empty( $is_password_resetted ) ) {
 				ur_add_notice( __( 'Your password has been reset successfully.', 'user-registration' ) );
+				delete_transient( 'ur_password_resetted_flag' );
 			}
 
 			$render_default = apply_filters( 'user_registration_my_account_render_default', true, $atts );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously, When Password is reset and  you try to login then if password you entered is incorrect then both password reset message and incorrect password message visible at same time. This PR will this issue.

### How to test the changes in this Pull Request:

1. First Go to Login Form and perform lost your password.
2. then After you reset your password and try to login with incorrect password.
3. then verify whether this issue has been fixed or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

>Fix - Reset and incorrect password message appears at same time.
