### PR TITLE
UR-504 Fix - Show Password icon in Password Field

### DIFF
--- a/assets/js/frontend/user-registration.js
+++ b/assets/js/frontend/user-registration.js
@@ -873,7 +873,9 @@
 																response.data
 																	.auto_login
 															) {
-																$(document).trigger(
+																$(
+																	document
+																).trigger(
 																	"user_registration_frontend_before_auto_login"
 																);
 																location.reload();
@@ -1635,6 +1637,11 @@ function ur_includes(arr, item) {
 			$password_field = $(this)
 				.closest(".user-registration-form-row")
 				.find('input[name="password_2"]');
+		}
+		if ($password_field.length === 0) {
+			$password_field = $(this)
+				.closest(".field-password")
+				.find(".input-password");
 		}
 
 		if ($password_field.length > 0) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously, the Show password icon is not working in the Password field. This PR will fix this issue.

### How to test the changes in this Pull Request:

1. Navigate to form builder and drag and drop the password field from the extra fields section.
2. then update the form and also make sure that enable hide/show password is enabled from General tab of User registration settings.
3. then verify whether it is working as expected or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Show Password icon in Password Field.
