### PR TITLE
Fix - Form export issue when the form name has a special character.

### DIFF
--- a/includes/admin/class-ur-admin-import-export-forms.php
+++ b/includes/admin/class-ur-admin-import-export-forms.php
@@ -86,9 +86,8 @@ class UR_Admin_Import_Export_Forms {
 		header( 'Content-Type: application/force-download' );
 
 		// Disposition / Encoding on response body.
-		header( "Content-Disposition: attachment;filename={$file_name}" );
+		header( "Content-Disposition: attachment;filename=\"{$file_name}\";charset=utf-8" );
 		header( 'Content-type: application/json' );
-
 		echo wp_json_encode( $export_data );
 		exit();
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Previously, When the form name has a special character and when we try to export the form. the form is not exporting in JSON format. This PR fixes this issue

### How to test the changes in this Pull Request:

1. Create a form name with a special character like(&#).
2. Go to Settings>Import/Export.
3. Export the form and verify it is working or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Form export issue when the form name has a special character.
