### PR TITLE
UR-426 Fix - Wrong fields order in multipart forms compatibility

### DIFF
--- a/includes/admin/class-ur-admin-assets.php
+++ b/includes/admin/class-ur-admin-assets.php
@@ -305,6 +305,7 @@ class UR_Admin_Assets {
 					'ajax_url'            => admin_url( 'admin-ajax.php' ),
 					'ur_import_form_save' => wp_create_nonce( 'ur_import_form_save_nonce' ),
 					'no_file_selected'    => esc_html__( 'No file selected.', 'user-registration' ),
+					'ur_get_form_fields'  => wp_create_nonce( 'ur_get_form_fields' ),
 				)
 			);
 			wp_localize_script( 'user-registration-form-builder', 'user_registration_form_builder_data', $params );

--- a/includes/admin/class-ur-admin-export-users.php
+++ b/includes/admin/class-ur-admin-export-users.php
@@ -220,6 +220,9 @@ class UR_Admin_Export_Users {
 							}
 						}
 						$user_extra_row[ $user_extra_data_key ] = $file_link;
+					} else if ( isset( $field_data['field_key'] ) && ( 'checkbox' === $field_data['field_key'] || 'multi_select2' === $field_data['field_key'] ) ) {
+						$values = ( is_array(  $user_extra_data ) && ! empty(  $user_extra_data ) ) ? implode( ',', $user_extra_data ) : $user_extra_data;
+						$user_extra_row[ $user_extra_data_key ] = $values;
 					}
 				}
 			}

--- a/includes/admin/class-ur-admin-export-users.php
+++ b/includes/admin/class-ur-admin-export-users.php
@@ -61,7 +61,7 @@ class UR_Admin_Export_Users {
 			$all_fields = (array) json_decode( $all_fields );
 			$all_fields = array_keys( $all_fields );
 
-			$checked_fields = isset( $_POST['csv-export-custom-fields'] ) ? ur_clean( $_POST['csv-export-custom-fields'] ) : array();
+			$checked_fields = isset( $_POST['csv-export-custom-fields'] ) ? ur_clean( $_POST['csv-export-custom-fields'] ) : array(); //phpcs:ignore
 			$unchecked_fields = array_diff( $all_fields, $checked_fields );
 		} else {
 			$unchecked_fields = array();
@@ -220,8 +220,8 @@ class UR_Admin_Export_Users {
 							}
 						}
 						$user_extra_row[ $user_extra_data_key ] = $file_link;
-					} else if ( isset( $field_data['field_key'] ) && ( 'checkbox' === $field_data['field_key'] || 'multi_select2' === $field_data['field_key'] ) ) {
-						$values = ( is_array(  $user_extra_data ) && ! empty(  $user_extra_data ) ) ? implode( ',', $user_extra_data ) : $user_extra_data;
+					} elseif ( isset( $field_data['field_key'] ) && ( 'checkbox' === $field_data['field_key'] || 'multi_select2' === $field_data['field_key'] ) ) {
+						$values = ( is_array( $user_extra_data ) && ! empty( $user_extra_data ) ) ? implode( ',', $user_extra_data ) : $user_extra_data; //phpcs:ignore
 						$user_extra_row[ $user_extra_data_key ] = $values;
 					}
 				}

--- a/includes/admin/class-ur-admin-export-users.php
+++ b/includes/admin/class-ur-admin-export-users.php
@@ -59,7 +59,6 @@ class UR_Admin_Export_Users {
 		if ( isset( $_POST['all_fields_dict'] ) ) {
 			$all_fields = sanitize_text_field( wp_unslash( $_POST['all_fields_dict'] ) );
 			$all_fields = (array) json_decode( $all_fields );
-			$all_fields = array_keys( $all_fields );
 
 			$checked_fields = isset( $_POST['csv-export-custom-fields'] ) ? ur_clean( $_POST['csv-export-custom-fields'] ) : array(); //phpcs:ignore
 			$unchecked_fields = array_diff( $all_fields, $checked_fields );

--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -814,6 +814,11 @@ class UR_AJAX {
 			$form_row_ids = sanitize_text_field( $_POST['data']['form_row_ids'] ); //phpcs:ignore
 			$form_id      = sanitize_text_field( $_POST['data']['form_id'] ); //phpcs:ignore
 
+			$post_data_array = apply_filters( 'user_registration_form_data_before_save', array( $post_data, $form_row_ids ) );
+
+			$post_data    = $post_data_array[0];
+			$form_row_ids = $post_data_array[1];
+
 			$post_data = array(
 				'post_type'      => 'user_registration',
 				'post_title'     => sanitize_text_field( $form_name ),
@@ -1362,8 +1367,6 @@ class UR_AJAX {
 
 	/**
 	 * AJAX Get form fields key->label pairs.
-	 *
-	 * @since 2.2.6
 	 */
 	public static function get_form_fields() {
 		$security = isset( $_POST['security'] ) ? sanitize_text_field( wp_unslash( $_POST['security'] ) ) : '';

--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -62,9 +62,10 @@ class UR_AJAX {
 			'dashboard_widget'       => false,
 			'dismiss_notice'         => false,
 			'import_form_action'     => false,
-			'template_licence_check'     => false,
-			'install_extension'     => false,
+			'template_licence_check' => false,
+			'install_extension'      => false,
 			'create_form'            => true,
+			'get_form_fields'        => true,
 		);
 
 		foreach ( $ajax_events as $ajax_event => $nopriv ) {
@@ -1356,6 +1357,35 @@ class UR_AJAX {
 				'error' => esc_html__( 'Something went wrong, please try again later', 'user-registration' ),
 			)
 		);
+	}
+
+
+	/**
+	 * AJAX Get form fields key->label pairs.
+	 *
+	 * @since 2.2.6
+	 */
+	public static function get_form_fields() {
+		$security = isset( $_POST['security'] ) ? sanitize_text_field( wp_unslash( $_POST['security'] ) ) : '';
+
+		if ( ! wp_verify_nonce( $security, 'ur_get_form_fields' ) ) {
+			wp_send_json_error( esc_html( __( 'Nonce error. Please reload the page.', 'user-registration' ) ) );
+		}
+
+		$form_id = isset( $_POST['form_id'] ) ? sanitize_text_field( wp_unslash( $_POST['form_id'] ) ) : 0;
+
+		if ( ! empty( $form_id ) ) {
+			$fields = ur_get_form_fields(
+				$form_id,
+				array(
+					'content_only' => true,
+					'hide_fields'  => true,
+				)
+			);
+			return wp_send_json_success( $fields );
+		}
+
+		return wp_send_json_error();
 	}
 }
 

--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -753,48 +753,6 @@ class UR_Form_Handler {
 		return $forms;
 	}
 
-	/**
-	 * Create and return a dictionary of field_id->field_label for all form fields.
-	 *
-	 * @param [int] $form_id Form Id.
-	 * @param array $args Extra arguments.
-	 * @return array
-	 *
-	 * @since 2.2.3
-	 */
-	public function get_form_fields( $form_id, $args = array() ) {
-		$hide_fields = array(
-			'user_confirm_password',
-			'user_confirm_email',
-		);
-
-		$fields_dict = array();
-
-		if ( is_numeric( $form_id ) ) {
-
-			$form_data = $this->get_form( $form_id, $args );
-
-			foreach ( $form_data as $sec ) {
-				foreach ( $sec as $fields ) {
-					foreach ( $fields as $field ) {
-						$field_id    = $field->general_setting->field_name;
-						$field_label = $field->general_setting->label;
-						if ( ! in_array( $field_id, $hide_fields, true ) ) {
-							$fields_dict[ $field_id ] = $field_label;
-						}
-					}
-				}
-			}
-
-			if ( isset( $args['hide_fields'] ) && true === $args['hide_fields'] ) {
-				foreach ( $hide_fields as $hide_field ) {
-					unset( $fields_dict[ $hide_field ] );
-				}
-			}
-		}
-		return $fields_dict;
-	}
-
 
 	/**
 	 * Create new form.
@@ -812,7 +770,7 @@ class UR_Form_Handler {
 			return false;
 		}
 
-		$args         = apply_filters( 'user_registration_create_form_args', $args, $data );
+		$args = apply_filters( 'user_registration_create_form_args', $args, $data );
 
 		// Prevent content filters from corrupting JSON in post_content.
 		$has_kses = ( false !== has_filter( 'content_save_pre', 'wp_filter_post_kses' ) );

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -2856,3 +2856,37 @@ if ( ! function_exists( 'ur_file_get_contents' ) ) {
 		return;
 	}
 }
+
+
+/**
+ * Return form fields key->label pairs with some fields hidden.
+ * To get all fields, use ur_get_meta_key_label()
+ *
+ * @param [int] $form_id Form Id.
+ * @param array $args Extra arguments.
+ * @since 2.2.6
+ *
+ * @return array
+ */
+function ur_get_form_fields( $form_id, $args = array() ) {
+	if ( isset( $args['hide_fields'] ) && true === $args['hide_fields'] ) {
+		$hide_fields = array(
+			'user_confirm_password',
+			'user_confirm_email',
+			'html',
+			'section_title'
+		);
+	} else {
+		$hide_fields = array();
+	}
+
+	$fields_dict = ur_get_meta_key_label( $form_id );
+
+	foreach ( array_keys( $fields_dict ) as $key ) {
+		if ( in_array( $key, $hide_fields, true ) ) {
+			unset( $field_dict[ $key ] );
+		}
+	}
+
+	return apply_filters( 'user_registration_get_form_fields', $fields_dict, $form_id, $args );
+}

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -2874,7 +2874,7 @@ function ur_get_form_fields( $form_id, $args = array() ) {
 			'user_confirm_password',
 			'user_confirm_email',
 			'html',
-			'section_title'
+			'section_title' //phpcs:ignore
 		);
 	} else {
 		$hide_fields = array();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?


### Changes proposed in this Pull Request:

- This PR contains the compatibility code for https://github.com/wpeverest/user-registration-pro/pull/106.


### How to test the changes in this Pull Request:

1. Switch to this branch when testing https://github.com/wpeverest/user-registration-multi-part/pull/14

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> UR-426 Fix - Wrong fields order in multipart forms compatibility
