### PR TITLE
UR-547 Fix - User export issue when form name has special characters

### DIFF
--- a/includes/admin/class-ur-admin-export-users.php
+++ b/includes/admin/class-ur-admin-export-users.php
@@ -61,7 +61,7 @@ class UR_Admin_Export_Users {
 			$all_fields = (array) json_decode( $all_fields );
 			$all_fields = array_keys( $all_fields );
 
-			$checked_fields = isset( $_POST['csv-export-custom-fields'] ) ? ur_clean( $_POST['csv-export-custom-fields'] ) : array();
+			$checked_fields = isset( $_POST['csv-export-custom-fields'] ) ? ur_clean( $_POST['csv-export-custom-fields'] ) : array(); //phpcs:ignore
 			$unchecked_fields = array_diff( $all_fields, $checked_fields );
 		} else {
 			$unchecked_fields = array();
@@ -96,7 +96,7 @@ class UR_Admin_Export_Users {
 		header( 'Content-Type: application/download' );
 
 		// Disposition / Encoding on response body.
-		header( "Content-Disposition: attachment;filename={$file_name}" );
+		header( "Content-Disposition: attachment;filename=\"{$file_name}\";charset=utf-8" );
 		header( 'Content-Transfer-Encoding: binary' );
 
 		$handle = fopen( 'php://output', 'w' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously, When the form name has special character and when you try to export users then it will give error this page isn't working. This PR will this issue.

### How to test the changes in this Pull Request:

1. Create a form name with all possible special characters in it.
2. then Go to Settings > Import/Export.
3. then try to exports users of this form name and verify whether it is working or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - User export issue when form name has special characters.
