### PR TITLE
UR-442 Feature - Restrict copy paste on confirm email and confirm password field

### DIFF
--- a/assets/js/frontend/user-registration.js
+++ b/assets/js/frontend/user-registration.js
@@ -1656,4 +1656,11 @@ function ur_includes(arr, item) {
 			}
 		}
 	});
+	// Restrict copy,cut,paste on confirm email and password field.
+	$("#user_confirm_email,#user_confirm_password").bind(
+		"cut copy paste",
+		function (e) {
+			e.preventDefault();
+		}
+	);
 })(jQuery);

--- a/assets/js/frontend/user-registration.js
+++ b/assets/js/frontend/user-registration.js
@@ -1657,7 +1657,7 @@ function ur_includes(arr, item) {
 		}
 	});
 	// Restrict copy,cut,paste on confirm email and password field.
-	$("#user_confirm_email,#user_confirm_password").bind(
+	$("#user_confirm_email,#user_confirm_password").on(
 		"cut copy paste",
 		function (e) {
 			e.preventDefault();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously, User can do copy, cut and paste on confirm email and confirm password field. This PR will fix this issue.

### How to test the changes in this Pull Request:

1. Drag and drop confirm email and confirm password and update the form.
2. then verify whether copy, cut and paste is restricted or not on these fields.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Feature - Restrict copy paste on confirm email and confirm password field.
