### PR TITLE
UR-555 Fix - Gutenberg compatibility issue with my account

### DIFF
--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -2798,8 +2798,8 @@ if ( ! function_exists( 'ur_find_my_account_in_blocks' ) ) {
 									return $matched;
 								}
 							} elseif ( 'core/group' === $inner_block['blockName'] || 'core/column' === $inner_block['blockName'] || 'core/columns' === $inner_block['blockName'] ) {
-								$matched = ur_find_my_account_in_page( $inner_block['innerBlocks'], $myaccount_page, $matched );
 
+								$matched = ur_find_my_account_in_page( $shortcode['innerBlocks'], $myaccount_page, $matched );
 								if ( 0 < absint( $matched ) ) {
 									return $matched;
 								}
@@ -2831,13 +2831,8 @@ if ( ! function_exists( 'ur_find_my_account_in_blocks' ) ) {
 								if ( 0 < absint( $matched ) ) {
 									return $matched;
 								}
-							} elseif ( 'core/group' === $inner_block['blockName'] ) {
-								$matched = ur_find_my_account_in_page( $inner_block['innerBlocks'], $myaccount_page, $matched );
+							} elseif ( 'core/group' === $inner_block['blockName'] || 'core/column' === $inner_block['blockName'] || 'core/columns' === $inner_block['blockName'] ) {
 
-								if ( 0 < absint( $matched ) ) {
-									return $matched;
-								}
-							} elseif ( 'core/column' === $inner_block['blockName'] || 'core/columns' === $inner_block['blockName'] ) {
 								$matched = ur_find_my_account_in_page( $inner_block['innerBlocks'], $myaccount_page, $matched );
 
 								if ( 0 < absint( $matched ) ) {

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -2762,7 +2762,7 @@ if ( ! function_exists( 'ur_find_my_account_in_blocks' ) ) {
 	 *
 	 * @param array $shortcodes Shortcode.
 	 * @param mixed $myaccount_page My Account Page.
-	 * @param int $matched Default 0.
+	 * @param int   $matched Default 0.
 	 * @return int If matched then 1 else 0.
 	 * @since  2.2.7
 	 */
@@ -2795,13 +2795,53 @@ if ( ! function_exists( 'ur_find_my_account_in_blocks' ) ) {
 								if ( 0 < absint( $matched ) ) {
 									return $matched;
 								}
-							} elseif ( 'core/group' === $inner_block['blockName'] ) {
-								$matched = ur_find_my_account_in_page(  $shortcode['innerBlocks'], $myaccount_page, $matched );
+							} elseif ( 'core/group' === $inner_block['blockName'] || 'core/column' === $inner_block['blockName'] || 'core/columns' === $inner_block['blockName'] ) {
+								$matched = ur_find_my_account_in_page( $inner_block['innerBlocks'], $myaccount_page, $matched );
 
 								if ( 0 < absint( $matched ) ) {
 									return $matched;
 								}
-							}  elseif ( 'core/block' === $inner_block['blockName'] ) {
+							} elseif ( 'core/block' === $inner_block['blockName'] ) {
+								if ( isset( $inner_block['attrs']['ref'] ) && ! empty( $inner_block['attrs']['ref'] ) ) {
+									$resuable_block_page = get_post( $inner_block['attrs']['ref'] );
+									if ( ! empty( $resuable_block_page ) ) {
+										$resuable_block = parse_blocks( $resuable_block_page->post_content );
+										$matched = ur_find_my_account_in_page( $resuable_block, $resuable_block_page, $matched );
+										if ( 0 < absint( $matched ) ) {
+											return $matched;
+										}
+									}
+								}
+							}
+						}
+					}
+				} elseif ( 'core/columns' === $shortcode['blockName'] ) {
+					if ( isset( $shortcode['innerBlocks'] ) && ! empty( $shortcode['innerBlocks'] ) ) {
+						foreach ( $shortcode['innerBlocks'] as $inner_block ) {
+							if ( 'user-registration/form-selector' === $inner_block['blockName'] && isset( $inner_block['attrs']['shortcode'] ) ) {
+								$matched = 1;
+								return $matched;
+							} elseif ( ( 'core/shortcode' === $inner_block['blockName'] || 'core/paragraph' === $inner_block['blockName'] ) && isset( $inner_block['innerHTML'] ) ) {
+								$matched = preg_match( '/\[user_registration_my_account(\s\S+){0,3}\]|\[user_registration_login(\s\S+){0,3}\]/', $inner_block['innerHTML'] );
+								if ( 1 > absint( $matched ) ) {
+									$matched = preg_match( '/\[woocommerce_my_account(\s\S+){0,3}\]/', $shortcode['innerHTML'] );
+								}
+								if ( 0 < absint( $matched ) ) {
+									return $matched;
+								}
+							} elseif ( 'core/group' === $inner_block['blockName'] ) {
+								$matched = ur_find_my_account_in_page( $inner_block['innerBlocks'], $myaccount_page, $matched );
+
+								if ( 0 < absint( $matched ) ) {
+									return $matched;
+								}
+							} elseif ( 'core/column' === $inner_block['blockName'] || 'core/columns' === $inner_block['blockName'] ) {
+								$matched = ur_find_my_account_in_page( $inner_block['innerBlocks'], $myaccount_page, $matched );
+
+								if ( 0 < absint( $matched ) ) {
+									return $matched;
+								}
+							} elseif ( 'core/block' === $inner_block['blockName'] ) {
 								if ( isset( $inner_block['attrs']['ref'] ) && ! empty( $inner_block['attrs']['ref'] ) ) {
 									$resuable_block_page = get_post( $inner_block['attrs']['ref'] );
 									if ( ! empty( $resuable_block_page ) ) {
@@ -2828,7 +2868,6 @@ if ( ! function_exists( 'ur_find_my_account_in_blocks' ) ) {
 						}
 					}
 				}
-
 			} else {
 				$matched = preg_match( '/\[user_registration_my_account(\s\S+){0,3}\]|\[user_registration_login(\s\S+){0,3}\]/', $myaccount_page->post_content );
 				if ( 1 > absint( $matched ) ) {

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -2748,6 +2748,7 @@ if ( ! function_exists( 'user_registration_install_pages_notice' ) ) {
 
 		if ( 0 === $matched ) {
 			$message = 'Please select My Account page in the <strong>User Registration -> Settings -> General -> My Account section </strong> ( <a href="' . admin_url() . '/admin.php?page=user-registration-settings#user_registration_myaccount_page_id" style="text-decoration:none;">My Account Page</a> )';
+			/* translators: %s - My account Selection Notice. */
 			$message = sprintf( __( '%1$s', 'user-registration' ), wp_kses_post( $message ) );
 			UR_Admin_Notices::add_custom_notice( 'select_my_account', $message );
 		} else {

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -2747,9 +2747,9 @@ if ( ! function_exists( 'user_registration_install_pages_notice' ) ) {
 		}
 
 		if ( 0 === $matched ) {
-			$message = 'Please select My Account page in the <strong>User Registration -> Settings -> General -> My Account section </strong> ( <a href="' . admin_url() . '/admin.php?page=user-registration-settings#user_registration_myaccount_page_id" style="text-decoration:none;">My Account Page</a> )';
-			/* translators: %s - My account Selection Notice. */
-			$message = sprintf( __( '%1$s', 'user-registration' ), wp_kses_post( $message ) );
+			$my_account_setting_link = admin_url() . 'admin.php?page=user-registration-settings#user_registration_myaccount_page_id';
+			/* translators: %s - My account Link. */
+			$message = sprintf( __( 'Please select My Account page in the <strong>User Registration -> Settings -> General -> My Account section </strong> ( <a href="%s" style="text-decoration:none;">My Account Page</a> )', 'user-registration' ), $my_account_setting_link );
 			UR_Admin_Notices::add_custom_notice( 'select_my_account', $message );
 		} else {
 			UR_Admin_Notices::remove_notice( 'select_my_account' );

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -2433,7 +2433,7 @@ if ( ! function_exists( 'ur_install_extensions' ) ) {
 	function ur_install_extensions( $name, $slug ) {
 		try {
 
-			$plugin = 'user-registration-pro' === $slug ? plugin_basename( sanitize_text_field( wp_unslash( $slug . '/user-registration.php' ) ) ) :  plugin_basename( sanitize_text_field( wp_unslash( $slug . '/' . $slug . '.php' ) ) );
+			$plugin = 'user-registration-pro' === $slug ? plugin_basename( sanitize_text_field( wp_unslash( $slug . '/user-registration.php' ) ) ) : plugin_basename( sanitize_text_field( wp_unslash( $slug . '/' . $slug . '.php' ) ) );
 			$status = array(
 				'install' => 'plugin',
 				'slug'    => sanitize_key( wp_unslash( $slug ) ),
@@ -2742,7 +2742,7 @@ if ( ! function_exists( 'user_registration_install_pages_notice' ) ) {
 
 		if ( ! empty( $myaccount_page ) ) {
 			$shortcodes = parse_blocks( $myaccount_page->post_content );
-			$matched = ur_find_my_account_in_page( $shortcodes, $myaccount_page , $matched );
+			$matched = ur_find_my_account_in_page( $shortcodes, $myaccount_page, $matched );
 
 		}
 
@@ -2760,12 +2760,13 @@ if ( ! function_exists( 'ur_find_my_account_in_blocks' ) ) {
 	/**
 	 * Find My Account Shortcode.
 	 *
+	 * @param array $shortcodes Shortcode.
 	 * @param mixed $myaccount_page My Account Page.
 	 * @param int $matched Default 0.
 	 * @return int If matched then 1 else 0.
 	 * @since  2.2.7
 	 */
-	function ur_find_my_account_in_page(  $shortcodes, $myaccount_page , $matched ) {
+	function ur_find_my_account_in_page( $shortcodes, $myaccount_page, $matched ) {
 
 		foreach ( $shortcodes as $shortcode ) {
 			if ( ! empty( $shortcode['blockName'] ) ) {
@@ -2780,7 +2781,7 @@ if ( ! function_exists( 'ur_find_my_account_in_blocks' ) ) {
 					if ( 0 < absint( $matched ) ) {
 						return $matched;
 					}
-				} elseif ( 'core/group' ===  $shortcode['blockName'] ) {
+				} elseif ( 'core/group' === $shortcode['blockName'] ) {
 					if ( isset( $shortcode['innerBlocks'] ) && ! empty( $shortcode['innerBlocks'] ) ) {
 						foreach ( $shortcode['innerBlocks'] as $inner_block ) {
 							if ( 'user-registration/form-selector' === $inner_block['blockName'] && isset( $inner_block['attrs']['shortcode'] ) ) {
@@ -2794,13 +2795,13 @@ if ( ! function_exists( 'ur_find_my_account_in_blocks' ) ) {
 								if ( 0 < absint( $matched ) ) {
 									return $matched;
 								}
-							} elseif ( 'core/group' ===  $inner_block['blockName'] ) {
+							} elseif ( 'core/group' === $inner_block['blockName'] ) {
 								$matched = ur_find_my_account_in_page(  $shortcode['innerBlocks'], $myaccount_page, $matched );
 
 								if ( 0 < absint( $matched ) ) {
 									return $matched;
 								}
-							}  elseif ( 'core/block' ===  $inner_block['blockName'] ) {
+							}  elseif ( 'core/block' === $inner_block['blockName'] ) {
 								if ( isset( $inner_block['attrs']['ref'] ) && ! empty( $inner_block['attrs']['ref'] ) ) {
 									$resuable_block_page = get_post( $inner_block['attrs']['ref'] );
 									if ( ! empty( $resuable_block_page ) ) {
@@ -2814,7 +2815,7 @@ if ( ! function_exists( 'ur_find_my_account_in_blocks' ) ) {
 							}
 						}
 					}
-				} elseif ( 'core/block' ===  $shortcode['blockName'] ) {
+				} elseif ( 'core/block' === $shortcode['blockName'] ) {
 
 					if ( isset( $shortcode['attrs']['ref'] ) && ! empty( $shortcode['attrs']['ref'] ) ) {
 						$resuable_block_page = get_post( $shortcode['attrs']['ref'] );

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -2748,6 +2748,7 @@ if ( ! function_exists( 'user_registration_install_pages_notice' ) ) {
 
 		if ( 0 === $matched ) {
 			$message = 'Please select My Account page in the <strong>User Registration -> Settings -> General -> My Account section </strong> ( <a href="' . admin_url() . '/admin.php?page=user-registration-settings#user_registration_myaccount_page_id" style="text-decoration:none;">My Account Page</a> )';
+			$message = sprintf( __( '%1$s', 'user-registration' ), wp_kses_post( $message ) );
 			UR_Admin_Notices::add_custom_notice( 'select_my_account', $message );
 		} else {
 			UR_Admin_Notices::remove_notice( 'select_my_account' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Previously My Account Page selection notice appears when my account shortcode not exits in selected page, but even though shortcode is exits in the page inside the Gutenberg nested group, columns and reusable block the my account page selection notice was still showing. This issue fixed in the PR.


### How to test the changes in this Pull Request:

1. Create My Account Page with our shortcode in combination of nested group, columns and reuasble blocks.
2. Select that page as My Account Page.
3. Check whether My Account selection notice appears or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Gutenberg compatibility issue with my account.
