### PR TITLE
UR-496 Enhance - Trigger Successful Registration email after email confirmation done by user.

### DIFF
--- a/includes/class-ur-email-confirmation.php
+++ b/includes/class-ur-email-confirmation.php
@@ -243,6 +243,14 @@ class UR_Email_Confirmation {
 					update_user_meta( $user_id, 'ur_confirm_email', 1 );
 					delete_user_meta( $user_id, 'ur_confirm_email_token' );
 
+					$user    = get_user_by( 'id', $user_id );
+					$attachments = apply_filters( 'user_registration_email_attachment_resending_token', array() );
+					$name_value  = ur_get_user_extra_fields( $user_id );
+						// Get selected email template id for specific form.
+					$template_id = ur_get_single_post_meta( $form_id, 'user_registration_select_email_template' );
+
+					UR_Emailer::send_mail_to_user( $user->user_email, $user->user_login, $user_id, '', $name_value, $attachments, $template_id );
+
 					if ( 'admin_approval_after_email_confirmation' === $login_option ) {
 						add_filter( 'login_message', array( $this, 'custom_email_confirmed_admin_await_message' ) );
 						add_filter( 'user_registration_login_form_before_notice', array( $this, 'custom_email_confirmed_admin_await_message' ) );

--- a/includes/class-ur-emailer.php
+++ b/includes/class-ur-emailer.php
@@ -656,8 +656,8 @@ class UR_Emailer {
 		}
 
 		foreach ( $values as $key => $value ) {
-			$value   = ur_format_field_values( $key, $value );
-			if( ! is_array( $value ) ) {
+			$value = ur_format_field_values( $key, $value );
+			if ( ! is_array( $value ) ) {
 				$content = str_replace( '{{' . $key . '}}', $value, $content );
 			}
 		}

--- a/includes/class-ur-emailer.php
+++ b/includes/class-ur-emailer.php
@@ -309,7 +309,7 @@ class UR_Emailer {
 			if ( 'yes' === get_option( 'user_registration_enable_registration_denied_email', 'yes' ) ) {
 				self::user_registration_process_and_send_email( $email, $subject, $message, self::ur_get_header(), $attachment, $template_id );
 			}
-		} elseif ( 'default' === $login_option || 'auto_login' === $login_option ) {
+		} elseif ( 'default' === $login_option || 'auto_login' === $login_option || ur_string_to_bool( $email_status ) ) {
 			$subject = get_option( 'user_registration_successfully_registered_email_subject', __( 'Congratulations! Registration Complete on {{blog_info}}', 'user-registration' ) );
 			$settings = new UR_Settings_Successfully_Registered_Email();
 			$message = $settings->ur_get_successfully_registered_email();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Previously, Success Registered Email sent only when manual login or auto-login login option selected but in this release after email confirmation done by user then Successful Registered Email Sent to User.

### How to test the changes in this Pull Request:

1. Create a Form with Email Confirmation login option and then register the user.
2. You will receive an email confirmation link in email then click on that link.
3. Once confirmation process passed then user will received successful registered email.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhance - Trigger Successful Registration email after email confirmation done by user.
