### PR TITLE
Fix - Email content override not working.

### DIFF
--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -264,6 +264,10 @@
 					URFormBuilder.show_message(validation_response.message);
 					return;
 				}
+				if ( typeof tinyMCE !== 'undefined' ) {
+					tinyMCE.triggerSave();
+				}
+
 
 				var form_data = URFormBuilder.get_form_data();
 				var form_row_ids = URFormBuilder.get_form_row_ids();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Previously, When the email content is changed in the builder setting with the email templates addon. The content is not updated.

### How to test the changes in this Pull Request:

1. Create a form with an email template addon.
2.  Go to Form Setting > Email templates.
3. Try to change the content and verify the content are updating or not

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Email content override not working.
