### PR TITLE
Tweak - Field option should be clickable even when no any field is selected.

### DIFF
--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -262,7 +262,6 @@ jQuery(function ($) {
 			// Empty fields panels.
 			$(".ur-builder-wrapper-content").hide();
 			$(".ur-builder-wrapper-footer").hide();
-
 			// Show only the form settings in fields panel.
 			$(".ur-selected-inputs").find("form#ur-field-settings").show();
 		}
@@ -278,7 +277,6 @@ jQuery(function ($) {
 			// Show field panels.
 			$(".ur-builder-wrapper-content").show();
 			$(".ur-builder-wrapper-footer").show();
-
 			// Hide the form settings in fields panel.
 			$(".ur-selected-inputs").find("form#ur-field-settings").hide();
 		}

--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -16,12 +16,22 @@
 
 				//Initialize Form Builder.
 				URFormBuilder.init_form_builder();
+				//
+				$(document).on(
+					"click",
+					'ul.ur-tab-lists li[aria-controls="ur-tab-field-options"]',
+					function () {
 
+					firstItem = $('.ur-selected-item:first');
+						console.log(firstItem);
+					URFormBuilder.handle_selected_item(firstItem);
+					// $(firstItem).trigger('click');
+					// console.log('3');
+				});
 				// Handle the field settings when a field is selected in the form builder.
 				$(document).on("click", ".ur-selected-item", function () {
 					URFormBuilder.handle_selected_item($(this));
 				});
-
 				// Run keyboard shortcuts action in form builder area only.
 				if (user_registration_form_builder_data.is_form_builder) {
 					$(window).on("keydown", function (event) {
@@ -2286,14 +2296,6 @@
 									.find("a")
 									.eq(0)
 									.trigger("click", ["triggered_click"]);
-								$(".ur-tabs")
-									.find(
-										'[aria-controls="ur-tab-field-options"]'
-									)
-									.addClass("ur-no-pointer");
-								$(".ur-selected-item").removeClass(
-									"ur-item-active"
-								);
 							},
 						};
 						builder.init();
@@ -2607,7 +2609,7 @@
 				form.append(general_setting);
 				form.append(advance_setting);
 				$("#ur-tab-field-options").append(form);
-				//$('#ur-tab-field-options').append(advance_setting);
+				$('#ur-tab-field-options').append(advance_setting);
 				$("#ur-tab-field-options")
 					.find(".ur-advance-setting-block")
 					.show();

--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -16,17 +16,20 @@
 
 				//Initialize Form Builder.
 				URFormBuilder.init_form_builder();
-				//
+				//Field option tab
 				$(document).on(
 					"click",
 					'ul.ur-tab-lists li[aria-controls="ur-tab-field-options"]',
 					function () {
-
-					firstItem = $('.ur-selected-item:first');
-						console.log(firstItem);
-					URFormBuilder.handle_selected_item(firstItem);
-					// $(firstItem).trigger('click');
-					// console.log('3');
+						// Hide the form settings in fields panel.
+						$(".ur-selected-inputs").find("form#ur-field-settings").hide();
+						//Show field panels
+						$(".ur-builder-wrapper-content").show();
+						$(".ur-builder-wrapper-footer").show();
+						if($('.ur-selected-item.ur-item-active').length == 0) {
+							//Selecting first ur selected item
+							URFormBuilder.handle_selected_item($('.ur-selected-item:first'));
+						}
 				});
 				// Handle the field settings when a field is selected in the form builder.
 				$(document).on("click", ".ur-selected-item", function () {
@@ -2420,9 +2423,6 @@
 			 * Handles all the operations performed on a selected field.
 			 */
 			handle_selected_item: function (selected_item) {
-				$(".ur-registered-inputs")
-					.find("ul li.ur-no-pointer")
-					.removeClass("ur-no-pointer");
 				$(".ur-selected-item").removeClass("ur-item-active");
 				$(selected_item).addClass("ur-item-active");
 				URFormBuilder.render_advance_setting($(selected_item));

--- a/includes/admin/class-ur-admin-form-templates.php
+++ b/includes/admin/class-ur-admin-form-templates.php
@@ -47,7 +47,7 @@ class UR_Admin_Form_Templates {
 				$content_json  = wp_remote_retrieve_body( $content );
 				$template_data = json_decode( $content_json );
 			} catch ( Exception $e ) {
-
+				$e->getMessage();
 			}
 
 			// Removing directory so the templates can be reinitialized.
@@ -77,6 +77,9 @@ class UR_Admin_Form_Templates {
 		return isset( $template_data->templates ) ? apply_filters( 'user_registration_template_section_data', $template_data->templates ) : self::get_default_template();
 	}
 
+	/**
+	 * Load the template view.
+	 */
 	public static function load_template_view() {
 		$templates       = array();
 		$current_section = isset( $_GET['section'] ) ? sanitize_text_field( wp_unslash( $_GET['section'] ) ) : '_all'; // phpcs:ignore WordPress.Security.NonceVerification

--- a/includes/admin/views/html-admin-page-form-templates.php
+++ b/includes/admin/views/html-admin-page-form-templates.php
@@ -1,5 +1,5 @@
 <?php
-/**ur-tab-field-options
+/**
  * Admin View: Form Templates Selector
  *
  * @package UserRegistration/Admin/FormTemplates

--- a/includes/admin/views/html-admin-page-form-templates.php
+++ b/includes/admin/views/html-admin-page-form-templates.php
@@ -1,5 +1,5 @@
 <?php
-/**
+/**ur-tab-field-options
  * Admin View: Form Templates Selector
  *
  * @package UserRegistration/Admin/FormTemplates
@@ -86,7 +86,7 @@ $license_plan = ur_get_license_plan();
 						$upgrade_class = 'ur-template-select';
 
 					}
-					$fallback_image = untrailingslashit(plugin_dir_url(UR_PLUGIN_FILE)) . '/assets/images/templates/placeholder.png';
+					$fallback_image = untrailingslashit( plugin_dir_url( UR_PLUGIN_FILE ) ) . '/assets/images/templates/placeholder.png';
 
 					/* translators: %s: Template title */
 					$template_name = sprintf( esc_attr_x( '%s template', 'Template name', 'user-registration' ), esc_attr( $template->title ) );

--- a/includes/admin/views/html-admin-page-forms.php
+++ b/includes/admin/views/html-admin-page-forms.php
@@ -57,7 +57,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 									<li><a href="#ur-tab-registered-fields"
 										class="nav-tab active"><?php esc_html_e( 'Fields', 'user-registration' ); ?></a>
 									</li>
-									<li class="ur-no-pointer"><a href="#ur-tab-field-options" class="nav-tab"><?php esc_html_e( 'Field Options', 'user-registration' ); ?></a>
+									<li><a href="#ur-tab-field-options" class="nav-tab"><?php esc_html_e( 'Field Options', 'user-registration' ); ?></a>
 									</li>
 
 									<?php
@@ -90,7 +90,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 										<?php do_action( 'user_registration_extra_fields' ); ?>
 									</div>
 									<div id="ur-tab-field-options" class="ur-tab-content">
-
 									</div>
 									<div id="ur-tab-field-settings" class="ur-tab-content">
 

--- a/includes/functions-ur-page.php
+++ b/includes/functions-ur-page.php
@@ -76,7 +76,7 @@ function ur_get_page_id( $page ) {
 			$translations = pll_get_post_translations( $page );
 			$page         = isset( $translations[ pll_current_language() ] ) ? $translations[ pll_current_language() ] : $page;
 		}
-	} elseif (  $page > 0 && has_filter( 'wpml_current_language' ) ) {
+	} elseif ( $page > 0 && has_filter( 'wpml_current_language' ) ) {
 		$page = ur_get_wpml_page_language( $page );
 	}
 
@@ -93,9 +93,9 @@ function ur_get_wpml_page_language( $page_id ) {
 	$current_language = apply_filters( 'wpml_current_language', 'en' );
 	$element_prepared = $wpdb->prepare(
 		"SELECT element_id FROM {$wpdb->prefix}icl_translations WHERE trid=%d AND element_type=%s AND language_code=%s",
-		array( $page_id, "post_page", $current_language )
+		array( $page_id, 'post_page', $current_language )
 	);
-	$element_id = $wpdb->get_var( $element_prepared );
+	$element_id       = $wpdb->get_var( $element_prepared ); //phpcs:ignore.
 	return $element_id > 0 ? $element_id : $page_id;
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?


### Changes proposed in this Pull Request:

Previously, while clicking on the field option in form builder it was not clickable if  no any field is selected. Now it is clickable even when no field is selected.

### How to test the changes in this Pull Request:

1.Go to all forms then 
2.Edit any form
3.Click on Field option tab

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Field option is clickable even when no any field is selected
