### PR TITLE
UR-665 Enhancement - Enable disable email from email list table global email setting

### DIFF
--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -498,16 +498,19 @@ jQuery(function ($) {
 	// Email Status
 	$(".user-registration-email-status-toggle").on("change", function (e) {
 		e.preventDefault();
-		var status = $('#awaiting_admin_approval_email').val();
+		var status = $(this).find('input[type="checkbox"]:checked').val();
+		var id = $(this).find('input[type="checkbox"]').attr('id');
 		$.ajax({
 			url: user_registration_email_setting_status.ajax_url,
+			type: "POST",
 			data: {
-				type: "POST",
 				action: "user_registration_email_setting_status",
 				status: status,
+				id : id,
+				security : user_registration_email_setting_status.user_registration_email_setting_status_nonce,
 			},
 			success: function (response) {
-					console.log('hello');
+					console.log(response);
 			},
 		});
 	});

--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -494,6 +494,23 @@ jQuery(function ($) {
 			},
 		});
 	});
+
+	// Email Status
+	$(".user-registration-email-status-toggle").on("change", function (e) {
+		e.preventDefault();
+		var status = $('#awaiting_admin_approval_email').val();
+		$.ajax({
+			url: user_registration_email_setting_status.ajax_url,
+			data: {
+				type: "POST",
+				action: "user_registration_email_setting_status",
+				status: status,
+			},
+			success: function (response) {
+					console.log('hello');
+			},
+		});
+	});
 });
 
 (function ($, user_registration_admin_data) {

--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -510,7 +510,7 @@ jQuery(function ($) {
 				security : user_registration_email_setting_status.user_registration_email_setting_status_nonce,
 			},
 			success: function (response) {
-					console.log(response);
+
 			},
 		});
 	});

--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -429,4 +429,21 @@
 				$(this).closest("label").addClass("selected");
 			});
 		});
+
+		$('.user-registration-email-status-toggle').on("change", function(e) {
+			email_status();
+
+		});
+		function email_status(val){
+			val = $('#awaiting_admin_approval_email').val();
+			$.ajax({
+				url:user_registration_settings_params.ajax_url,
+				method:'post',
+				data:{action: 'email_setting_status', 'id':'awaiting_admin_approval_email' ,'value':val },
+				success: function(res) {
+					 console.log(res);
+				}
+
+			})
+		}
 })(jQuery);

--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -429,21 +429,4 @@
 				$(this).closest("label").addClass("selected");
 			});
 		});
-
-		$('.user-registration-email-status-toggle').on("change", function(e) {
-			email_status();
-
-		});
-		function email_status(val){
-			val = $('#awaiting_admin_approval_email').val();
-			$.ajax({
-				url:user_registration_settings_params.ajax_url,
-				method:'post',
-				data:{action: 'email_setting_status', 'id':'awaiting_admin_approval_email' ,'value':val },
-				success: function(res) {
-					 console.log(res);
-				}
-
-			})
-		}
 })(jQuery);

--- a/includes/admin/class-ur-admin-assets.php
+++ b/includes/admin/class-ur-admin-assets.php
@@ -364,6 +364,7 @@ class UR_Admin_Assets {
 				'user_registration_email_setting_status',
 				array(
 					'ajax_url' => admin_url( 'admin-ajax.php' ),
+					'user_registration_email_setting_status_nonce' => wp_create_nonce( 'email_setting_status_nonce' ),
 				)
 			);
 		}

--- a/includes/admin/class-ur-admin-assets.php
+++ b/includes/admin/class-ur-admin-assets.php
@@ -357,6 +357,17 @@ class UR_Admin_Assets {
 			);
 		}
 
+		$current_tab = ! empty( $_REQUEST['tab'] ) ? sanitize_title( wp_unslash( $_REQUEST['tab'] ) ) : ''; //phpcs:ignore WordPress.Security.NonceVerification
+		if ( 'user-registration_page_user-registration-settings' === $screen_id && 'email' === $current_tab ) {
+			wp_localize_script(
+				'user-registration-admin',
+				'user_registration_email_setting_status',
+				array(
+					'ajax_url' => admin_url( 'admin-ajax.php' ),
+				)
+			);
+		}
+
 		wp_register_script( 'ur-live-user-notice', UR()->plugin_url() . '/assets/js/admin/live-user-notice' . $suffix . '.js', array( 'jquery', 'heartbeat' ), UR_VERSION, false );
 		wp_enqueue_script( 'ur-live-user-notice' );
 	}

--- a/includes/admin/settings/class-ur-settings-email.php
+++ b/includes/admin/settings/class-ur-settings-email.php
@@ -208,7 +208,7 @@ if ( ! class_exists( 'UR_Settings_Email' ) ) :
 				$settings .= '<td class="ur-email-settings-table">';
 				$label     = 'email_confirmation' === $email->id ? '<div class="ur-toggle-section"><span class="user-registration-toggle-form" ><input type="checkbox" name="email_status[' . $email->id . ']" value="yes"  checked disabled/><span class="slider round"></span></span></div>' : '<div class="ur-toggle-section"><span class="user-registration-toggle-form user-registration-email-status-toggle" ><input class="user-registration-email-input" type="hidden" name="email_status[' . $email->id . ']" value="no" /><input type="checkbox" name="email_status[' . $email->id . ']" id="' . $email->id . '"' . ( $status ? "checked='checked'" : '' ) . '"/><span class="slider round"></span></span></div>';
 				$settings .= '<label style="' . ( $status ? 'color:green;font-weight:500;' : 'color:red;font-weight:500;' ) . '">';
-				$settings .= esc_html( $label );
+				$settings .=  $label ;
 				$settings .= '</label>';
 				$settings .= '</td>';
 				$settings .= '<td class="ur-email-settings-table">';

--- a/includes/admin/settings/class-ur-settings-email.php
+++ b/includes/admin/settings/class-ur-settings-email.php
@@ -206,7 +206,7 @@ if ( ! class_exists( 'UR_Settings_Email' ) ) :
 				$settings .= ur_help_tip( $email->description );
 				$settings .= '</td>';
 				$settings .= '<td class="ur-email-settings-table">';
-				$label     = $status ? __( 'Active', 'user-registration' ) : __( 'Inactive', 'user-registration' );
+				$label     = 'email_confirmation' === $email->id ? '<div class="ur-toggle-section"><span class="user-registration-toggle-form" ><input type="checkbox" name="email_status[' . $email->id . ']" value="yes"  checked disabled/><span class="slider round"></span></span></div>' : '<div class="ur-toggle-section"><span class="user-registration-toggle-form user-registration-email-status-toggle" ><input class="user-registration-email-input" type="hidden" name="email_status[' . $email->id . ']" value="no" /><input type="checkbox" name="email_status[' . $email->id . ']" id="' . $email->id . '"' . ( $status ? "checked='checked'" : '' ) . '"/><span class="slider round"></span></span></div>';
 				$settings .= '<label style="' . ( $status ? 'color:green;font-weight:500;' : 'color:red;font-weight:500;' ) . '">';
 				$settings .= esc_html( $label );
 				$settings .= '</label>';

--- a/includes/admin/settings/class-ur-settings-email.php
+++ b/includes/admin/settings/class-ur-settings-email.php
@@ -206,9 +206,9 @@ if ( ! class_exists( 'UR_Settings_Email' ) ) :
 				$settings .= ur_help_tip( $email->description );
 				$settings .= '</td>';
 				$settings .= '<td class="ur-email-settings-table">';
-				$label     = 'email_confirmation' === $email->id ? '<div class="ur-toggle-section"><span class="user-registration-toggle-form" ><input type="checkbox" name="email_status[' . $email->id . ']" value="yes"  checked disabled/><span class="slider round"></span></span></div>' : '<div class="ur-toggle-section"><span class="user-registration-toggle-form user-registration-email-status-toggle" ><input class="user-registration-email-input" type="hidden" name="email_status[' . $email->id . ']" value="no" /><input type="checkbox" name="email_status[' . $email->id . ']" id="' . $email->id . '"' . ( $status ? "checked='checked'" : '' ) . '"/><span class="slider round"></span></span></div>';
+				$label     = 'email_confirmation' === $email->id ? '<div class="ur-toggle-section"><span class="user-registration-toggle-form" ><input type="checkbox" name="email_status[' . $email->id . ']" value="yes"  checked disabled/><span class="slider round"></span></span></div>' : '<div class="ur-toggle-section"><span class="user-registration-toggle-form user-registration-email-status-toggle" ><input type="checkbox" name="email_status" id="' . $email->id . '"' . ( $status ? "checked='checked'" : '' ) . '"/><span class="slider round"></span></span></div>';
 				$settings .= '<label style="' . ( $status ? 'color:green;font-weight:500;' : 'color:red;font-weight:500;' ) . '">';
-				$settings .=  $label ;
+				$settings .= $label;
 				$settings .= '</label>';
 				$settings .= '</td>';
 				$settings .= '<td class="ur-email-settings-table">';

--- a/includes/admin/settings/class-ur-settings-email.php
+++ b/includes/admin/settings/class-ur-settings-email.php
@@ -206,7 +206,7 @@ if ( ! class_exists( 'UR_Settings_Email' ) ) :
 				$settings .= ur_help_tip( $email->description );
 				$settings .= '</td>';
 				$settings .= '<td class="ur-email-settings-table">';
-				$label     = 'email_confirmation' === $email->id ? '<div class="ur-toggle-section"><span class="user-registration-toggle-form" ><input type="checkbox" name="email_status[' . $email->id . ']" value="yes"  checked disabled/><span class="slider round"></span></span></div>' : '<div class="ur-toggle-section"><span class="user-registration-toggle-form user-registration-email-status-toggle" ><input type="checkbox" name="email_status" id="' . $email->id . '"' . ( $status ? "checked='checked'" : '' ) . '"/><span class="slider round"></span></span></div>';
+				$label     = 'email_confirmation' === $email->id ? '<div class="ur-toggle-section"><span class="user-registration-toggle-form" ><input type="checkbox" name="email_status[' . esc_attr( $email->id ) . ']" value="yes"  checked disabled/><span class="slider round"></span></span></div>' : '<div class="ur-toggle-section"><span class="user-registration-toggle-form user-registration-email-status-toggle" ><input type="checkbox" name="email_status" id="' . esc_attr( $email->id ) . '"' . ( $status ? "checked='checked'" : '' ) . '"/><span class="slider round"></span></span></div>';
 				$settings .= '<label style="' . ( $status ? 'color:green;font-weight:500;' : 'color:red;font-weight:500;' ) . '">';
 				$settings .= $label;
 				$settings .= '</label>';

--- a/includes/admin/settings/class-ur-settings-email.php
+++ b/includes/admin/settings/class-ur-settings-email.php
@@ -206,7 +206,7 @@ if ( ! class_exists( 'UR_Settings_Email' ) ) :
 				$settings .= ur_help_tip( $email->description );
 				$settings .= '</td>';
 				$settings .= '<td class="ur-email-settings-table">';
-				$label     = 'email_confirmation' === $email->id ? '<div class="ur-toggle-section"><span class="user-registration-toggle-form" ><input type="checkbox" name="email_status[' . esc_attr( $email->id ) . ']" value="yes"  checked disabled/><span class="slider round"></span></span></div>' : '<div class="ur-toggle-section"><span class="user-registration-toggle-form user-registration-email-status-toggle" ><input type="checkbox" name="email_status" id="' . esc_attr( $email->id ) . '"' . ( $status ? "checked='checked'" : '' ) . '"/><span class="slider round"></span></span></div>';
+				$label     = 'email_confirmation' === $email->id ? esc_html__( 'Always Active', 'user-registration' ) : '<div class="ur-toggle-section"><span class="user-registration-toggle-form user-registration-email-status-toggle" ><input type="checkbox" name="email_status" id="' . esc_attr( $email->id ) . '"' . ( $status ? "checked='checked'" : '' ) . '"/><span class="slider round"></span></span></div>';
 				$settings .= '<label style="' . ( $status ? 'color:green;font-weight:500;' : 'color:red;font-weight:500;' ) . '">';
 				$settings .= $label;
 				$settings .= '</label>';

--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -1409,7 +1409,19 @@ class UR_AJAX {
 	 * Email setting status
 	 */
 	public function email_setting_status() {
-		wp_send_json( 'dfsdf' );
+
+		if ( isset( $_POST['security'] ) && wp_verify_nonce( sanitize_key( $_POST['security'] ), 'email_setting_status_nonce' ) ) {
+			$status = isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : null;
+			$id     = isset( $_POST['id'] ) ? sanitize_text_field( wp_unslash( $_POST['id'] ) ) : null;
+			$value  = 'on' === $status ? 'yes' : 'no';
+			$key    = 'user_registration_enable_' . $id;
+			if ( update_option( $key, $value ) ) {
+				wp_send_json( 'Successfully Updated' );
+			} else {
+				wp_send_json( 'Update failed !' );
+			};
+
+		}
 	}
 }
 

--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -65,6 +65,7 @@ class UR_AJAX {
 			'template_licence_check' => false,
 			'install_extension'      => false,
 			'create_form'            => true,
+			'email_setting_status'   => true,
 		);
 
 		foreach ( $ajax_events as $ajax_event => $nopriv ) {
@@ -1403,6 +1404,12 @@ class UR_AJAX {
 				'error' => esc_html__( 'Something went wrong, please try again later', 'user-registration' ),
 			)
 		);
+	}
+	/**
+	 * Email setting status
+	 */
+	public function email_setting_status() {
+		wp_send_json( 'dfsdf' );
 	}
 }
 

--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -1408,7 +1408,7 @@ class UR_AJAX {
 	/**
 	 * Email setting status
 	 */
-	public function email_setting_status() {
+	public static function email_setting_status() {
 
 		if ( isset( $_POST['security'] ) && wp_verify_nonce( sanitize_key( $_POST['security'] ), 'email_setting_status_nonce' ) ) {
 			$status = isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : null;

--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -1416,9 +1416,9 @@ class UR_AJAX {
 			$value  = 'on' === $status ? 'yes' : 'no';
 			$key    = 'user_registration_enable_' . $id;
 			if ( update_option( $key, $value ) ) {
-				wp_send_json( 'Successfully Updated' );
+				wp_send_json_success( 'Successfully Updated' );
 			} else {
-				wp_send_json( 'Update failed !' );
+				wp_send_json_error( 'Update failed !' );
 			};
 
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Previously, In the email notification table, status of email was active and inactive message only. Now this PR is changing the those status by toggle button. These toggle button are functional. We can enable or disable email sent using toggle button. No need go particular configuration to enable or disable the email sent.

Closes # .

### How to test the changes in this Pull Request:

1.First go to Settings > Emails tab
2. Now, email status active/inactive message is replace by toggle button
3.Verify toggle button is also working.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Ur 665 Enhancement - Enable disable email from email list table global email setting
