### PR TITLE
Tweak - Multiple form import export at a time

### DIFF
--- a/includes/admin/class-ur-admin-import-export-forms.php
+++ b/includes/admin/class-ur-admin-import-export-forms.php
@@ -75,13 +75,17 @@ class UR_Admin_Import_Export_Forms {
 				),
 				'form_post_meta' => (array) $form_post_meta,
 			);
-			$form_name   = strtolower( str_replace( ' ', '-', get_the_title( $form_id ) ) );
-			$file_name   = $form_name . '-' . current_time( 'Y-m-d_H:i:s' ) . '.json';
 
 			if ( ob_get_contents() ) {
 				ob_clean();
 			}
 			$export_all_forms[] = $export_data;
+		}
+		if ( count( $form_ids ) > 1 ) {
+			$file_name = 'user-registration-forms-' . current_time( 'Y-m-d-H:i:s' ) . '.json';
+		} else {
+			$form_name = strtolower( str_replace( ' ', '-', get_the_title( $form_ids[0] ) ) );
+			$file_name = $form_name . '-' . current_time( 'Y-m-d_H:i:s' ) . '.json';
 		}
 		$forms['forms'] = $export_all_forms;
 		// Force download.

--- a/includes/admin/class-ur-admin-import-export-forms.php
+++ b/includes/admin/class-ur-admin-import-export-forms.php
@@ -139,12 +139,18 @@ class UR_Admin_Import_Export_Forms {
 			if ( 'json' === $ext ) {
 				$post_ids = array();
 				// read json file.
-				$form_datas = json_decode( file_get_contents( $_FILES['jsonfile']['tmp_name'] ) ); // @codingStandardsIgnoreLine
+				$form_datas_obj = json_decode( file_get_contents( $_FILES['jsonfile']['tmp_name'] ) ); // @codingStandardsIgnoreLine
 				// check for non empty json file.
-				if ( ! empty( $form_datas ) ) {
-
+				if ( ! empty( $form_datas_obj ) ) {
 					// check for non empty post data array.
-					if ( ! empty( $form_datas->forms ) ) {
+					if ( ! empty( $form_datas_obj->forms ) || ! empty( $form_datas_obj->form_post ) ) {
+						if ( ! empty( $form_datas_obj->form_post ) ) {
+							// For the importing old form.
+							$arr['forms'] = array( $form_datas_obj );
+							$form_datas   = (object) $arr;
+						} else {
+							$form_datas = $form_datas_obj;
+						}
 						// If Form Title already exist concat it with imported tag.
 						foreach ( $form_datas->forms as $key => $form_data ) {
 							$args  = array( 'post_type' => 'user_registration' );

--- a/includes/admin/views/html-admin-page-import-export-forms.php
+++ b/includes/admin/views/html-admin-page-import-export-forms.php
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						</p>
 
 						<p>
-							<select name="formid" class="ur-input forms-list">
+							<select name="formid[]" class="ur-input forms-list ur-select2-multiple" multiple>
 								<?php
 								foreach ( $all_forms as $form_id => $form ) {
 									echo '<option value ="' . esc_attr( $form_id ) . '">' . esc_html( $form ) . '</option>';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Previously, while exporting or importing form, we were able to import or export only one form at a time. Now this PR enhance the Import/Export functionality, we can choose one or multiple form at a time and can export these form. Also we can import one or multiple form at time.

### How to test the changes in this Pull Request:

1. First go to setting > Import/Export Forms tab
2. Try to select multiple forms and Click on Export
3. After Exporting the selected form, Try to import these form file > click on import and see imported form in All Forms

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Tweak - Multiple form import export at a time
