### PR TITLE
UR-716 Fix - Field Visibility Setting value not saving in safari

### DIFF
--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -22,15 +22,20 @@
 					'ul.ur-tab-lists li[aria-controls="ur-tab-field-options"]',
 					function () {
 						// Hide the form settings in fields panel.
-						$(".ur-selected-inputs").find("form#ur-field-settings").hide();
+						$(".ur-selected-inputs")
+							.find("form#ur-field-settings")
+							.hide();
 						//Show field panels
 						$(".ur-builder-wrapper-content").show();
 						$(".ur-builder-wrapper-footer").show();
-						if($('.ur-selected-item.ur-item-active').length == 0) {
+						if ($(".ur-selected-item.ur-item-active").length == 0) {
 							//Selecting first ur selected item
-							URFormBuilder.handle_selected_item($('.ur-selected-item:first'));
+							URFormBuilder.handle_selected_item(
+								$(".ur-selected-item:first")
+							);
 						}
-				});
+					}
+				);
 				// Handle the field settings when a field is selected in the form builder.
 				$(document).on("click", ".ur-selected-item", function () {
 					URFormBuilder.handle_selected_item($(this));
@@ -195,7 +200,9 @@
 									.hide();
 							}
 						} else {
-							$(bulk_options_html).insertAfter($this.parent()).trigger('init_tooltips');
+							$(bulk_options_html)
+								.insertAfter($this.parent())
+								.trigger("init_tooltips");
 						}
 					}
 				);
@@ -2609,7 +2616,7 @@
 				form.append(general_setting);
 				form.append(advance_setting);
 				$("#ur-tab-field-options").append(form);
-				$('#ur-tab-field-options').append(advance_setting);
+				$("#ur-tab-field-options").append(advance_setting);
 				$("#ur-tab-field-options")
 					.find(".ur-advance-setting-block")
 					.show();
@@ -3638,7 +3645,7 @@
 								.find(
 									'option[value="' + $this_node.val() + '"]'
 								)
-								.attr("selected", "selected");
+								.prop("selected", true);
 						}
 						break;
 					case "textarea":


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously, User registration field visibility addon setting is not saved in the safari browser. This PR will this issue.

### How to test the changes in this Pull Request:

1. Go to the form builder then field option of any field.
2. then try to change the visibility settings of advanced settings and update the form.
3. verify whether it is working properly or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> UR-716 Fix - Field Visibility Setting value not saving in safari.