### PR TITLE
Enhancement - List of smart tags in email content

### DIFF
--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -3974,6 +3974,50 @@
 			}
 		});
 
+		$(document).on("click", function () {
+			if($(document).find('.ur-smart-tags-list').is(':visible')) {
+
+				$('.ur-smart-tags-list').hide();
+			}
+		});
+
+		$('.ur-smart-tags-list').hide();
+
+		$(document.body).on('click', '.ur-smart-tags-list-button', function (e) {
+			e.stopPropagation();
+			$('.ur-smart-tags-list').hide();
+			$( this ).parent().find('.ur-smart-tags-list').toggle('show');
+		});
+
+		$(document.body).on('click', '.ur-select-smart-tag', function(event) {
+			event.preventDefault();
+			var smart_tag;
+			input_value =$(this).parent().parent().parent().find('input').val();
+			smart_tag = $(this).data('key');
+			input_value += smart_tag;
+			update_input();
+
+			$(this).parent().parent().parent().find('input').val(input_value);
+			$(document.body).find('.ur-smart-tags-list').hide();
+		});
+
+		$(document.body).on('change', '.ur_advance_setting.ur-settings-default-value', function(){
+			input_value = $(this).val();
+			update_input();
+		})
+		/**
+		 * For update the default value.
+		 */
+		function update_input(){
+			active_field = $('.ur-item-active');
+			target_input_field = $(active_field).find('.user-registration-field-option-group.ur-advance-setting-block');
+			ur_toggle_content = target_input_field.find('.ur-advance-setting.ur-advance-default_value');
+			target_input = $(ur_toggle_content).find('input[data-id=text_advance_setting_default_value]');
+			target_textarea = $(ur_toggle_content).find('input[data-id=textarea_advance_setting_default_value]');
+
+			target_input.val(input_value);
+			target_textarea.val(input_value);
+		}
 		/**
 		 * This block of code is for the "Selected Countries" option of "Country" field
 		 *

--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -3995,7 +3995,7 @@
 			input_value =$(this).parent().parent().parent().find('input').val();
 			smart_tag = $(this).data('key');
 			input_value += smart_tag;
-			update_input();
+			update_input(input_value);
 
 			$(this).parent().parent().parent().find('input').val(input_value);
 			$(document.body).find('.ur-smart-tags-list').hide();
@@ -4003,12 +4003,12 @@
 
 		$(document.body).on('change', '.ur_advance_setting.ur-settings-default-value', function(){
 			input_value = $(this).val();
-			update_input();
+			update_input(input_value);
 		})
 		/**
 		 * For update the default value.
 		 */
-		function update_input(){
+		function update_input(input_value){
 			active_field = $('.ur-item-active');
 			target_input_field = $(active_field).find('.user-registration-field-option-group.ur-advance-setting-block');
 			ur_toggle_content = target_input_field.find('.ur-advance-setting.ur-advance-default_value');

--- a/assets/js/admin/form-modal.js
+++ b/assets/js/admin/form-modal.js
@@ -30,7 +30,7 @@
 		});
 
 		//Insert Smart Tag into TinyMCE
-		$(document).on('click', '.ur-select-smart-tag', function(event) {
+		$(document).on('change', '#select-smart-tags', function(event) {
 			event.preventDefault();
 			var smart_tag;
 			smart_tag = $(this).val();

--- a/assets/js/admin/form-modal.js
+++ b/assets/js/admin/form-modal.js
@@ -9,7 +9,7 @@
 			$( document.body ).removeClass( 'modal-open' );
 		};
 		// Open modal when media button is clicked
-		$(document).on('click', '.ur-insert-form-button', function(event) {			
+		$(document).on('click', '.ur-insert-form-button', function(event) {
 			event.preventDefault();
 			$('#ur-modal-backdrop, #ur-modal-wrap').css('display','block');
 			$( document.body ).addClass( 'modal-open' );
@@ -28,6 +28,17 @@
 			wp.media.editor.insert(shortcode);
 			urModalClose();
 		});
-		
+
+		//Insert Smart Tag into TinyMCE
+		$(document).on('click', '.ur-select-smart-tag', function(event) {
+			event.preventDefault();
+			var smart_tag;
+			smart_tag = $(this).val();
+			wp.media.editor.insert(smart_tag);
+			urModalClose();
+			$("#select-smart-tags").val($("#select-smart-tags option:first").val());
+		});
+
 	});
+
 }(jQuery));

--- a/includes/abstracts/abstract-ur-field-settings.php
+++ b/includes/abstracts/abstract-ur-field-settings.php
@@ -1,27 +1,52 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
-}
-
 /**
  * Abstract UR Field Setting Class
  *
  * @version  1.0.0
  * @package  UserRegistration/Abstracts
- * @category Abstract Class
- * @author   WPEverest
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+/**
+ * UR_Form_Field_Setting Class.
  */
 abstract class UR_Field_Settings {
 
+	/**
+	 * Field id for this object.
+	 *
+	 * @since 1.0.0
+	 * @var int
+	 */
 	public $field_id;
+
+	/**
+	 * Fields html.
+	 *
+	 * @var string
+	 */
 	public $fields_html;
-	public $field_data    = array();
+
+	/**
+	 * Field Data.
+	 *
+	 * @var array
+	 */
+	public $field_data = array();
+
+	/**
+	 * Default Class.
+	 *
+	 * @var string
+	 */
 	public $default_class = 'ur_advance_setting';
 
 	/**
-	 * @param $key
+	 * Get Advance setting data.
 	 *
-	 * @return string
+	 * @param string $key Atrribute of fields.
 	 */
 	public function get_advance_setting_data( $key ) {
 
@@ -33,18 +58,23 @@ abstract class UR_Field_Settings {
 	}
 
 	/**
-	 * @param array $field_data
+	 * Output.
 	 *
-	 * @return mixed
+	 * @param array $field_data field data.
 	 */
 	abstract public function output( $field_data = array() );
 
 
+	/**
+	 * Register fields.
+	 */
 	abstract public function register_fields();
 
 
 	/**
-	 * @param $fields
+	 * Render html.
+	 *
+	 * @param array $fields list of fieds.
 	 */
 	public function render_html( $fields ) {
 
@@ -83,8 +113,8 @@ abstract class UR_Field_Settings {
 					break;
 
 				case 'select':
-					$is_multiple = isset( $field['multiple'] ) && true === $field['multiple'];
-					$this->fields_html .= '<select data-advance-field="' . esc_attr( $field_key ) . '" class="' . esc_attr( $field['class'] ) . '" data-id="' . ( isset( $field['data-id'] ) ? esc_attr( $field['data-id'] ) : '' ) . '" name="' . esc_attr( $field['name'] ) .  esc_attr( $is_multiple ? '[]' : '' ) . '"';
+					$is_multiple        = isset( $field['multiple'] ) && true === $field['multiple'];
+					$this->fields_html .= '<select data-advance-field="' . esc_attr( $field_key ) . '" class="' . esc_attr( $field['class'] ) . '" data-id="' . ( isset( $field['data-id'] ) ? esc_attr( $field['data-id'] ) : '' ) . '" name="' . esc_attr( $field['name'] ) . esc_attr( $is_multiple ? '[]' : '' ) . '"';
 
 					if ( true == $field['required'] ) {
 						$this->fields_html .= ' required ';

--- a/includes/abstracts/abstract-ur-field-settings.php
+++ b/includes/abstracts/abstract-ur-field-settings.php
@@ -52,7 +52,18 @@ abstract class UR_Field_Settings {
 
 		foreach ( $fields as $field_key => $field ) {
 
-			$tooltip_html       = ! empty( $field['tip'] ) ? ur_help_tip( $field['tip'], false, 'ur-portal-tooltip' ) : '';
+			$tooltip_html = ! empty( $field['tip'] ) ? ur_help_tip( $field['tip'], false, 'ur-portal-tooltip' ) : '';
+			$smart_tags   = '';
+			if ( 'default_value' === $field_key ) {
+				$smart_tags_list = UR_Smart_Tags::smart_tags_list();
+				$smart_tags     .= '<a href="#" class="button ur-smart-tags-list-button"><span class="dashicons dashicons-editor-code"></span></a>';
+				$smart_tags     .= '<div class="ur-smart-tags-list" style="display: none">';
+				$smart_tags     .= '<div class="smart-tag-title ur-smart-tag-title">Smart Tags</div><ul class="ur-smart-tags">';
+				foreach ( $smart_tags_list as $key => $value ) {
+					$smart_tags .= "<li class='ur-select-smart-tag' data-key = '" . esc_attr( $key ) . "'> " . esc_html( $value ) . '</li>';
+				}
+				$smart_tags .= '</ul></div>';
+			}
 			$this->fields_html .= '<div class="ur-advance-setting ur-advance-' . esc_attr( $field_key ) . '">';
 			$this->fields_html .= '<label for="' . esc_attr( $field['class'] ) . '">' . ( isset( $field['label'] ) ? esc_attr( $field['label'] ) : '' ) . $tooltip_html . '</label>';
 
@@ -68,6 +79,7 @@ abstract class UR_Field_Settings {
 					}
 
 					$this->fields_html .= ' />';
+					$this->fields_html .= $smart_tags;
 					break;
 
 				case 'select':

--- a/includes/admin/class-ur-admin-form-modal.php
+++ b/includes/admin/class-ur-admin-form-modal.php
@@ -24,6 +24,7 @@ if ( ! class_exists( 'UR_Admin_Form_Modal', false ) ) :
 		public function __construct() {
 
 			add_action( 'media_buttons', array( $this, 'media_button' ), 15 );
+			add_action( 'smart_tags_list', array( $this, 'select_smart_tags' ), 15, 1 );
 		}
 
 		/**
@@ -41,6 +42,7 @@ if ( ! class_exists( 'UR_Admin_Form_Modal', false ) ) :
 
 			// Remove Add User Registration Form button from wp-editor in customize my account settings page.
 			if ( isset( $_GET['tab'] ) && 'user-registration-customize-my-account' === $_GET['tab'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				do_action( 'smart_tags_list', $editor_id );
 				return;
 			}
 
@@ -55,14 +57,7 @@ if ( ! class_exists( 'UR_Admin_Form_Modal', false ) ) :
 				wp_kses_post( $icon ),
 				esc_html__( 'Add Registration Form', 'user-registration' )
 			);
-			$smart_tags_list = UR_Emailer::smart_tags_list();
-			printf( '<select id="select-smart-tags" class="button" style="color:#2271B1; border-color:#2271B1">', esc_attr( $editor_id ) );
-			printf( '<option value="">%s</option>', esc_html__( 'Add Smart Tags', 'user-registration' ) );
-			foreach ( $smart_tags_list as $key => $value ) {
-				printf( "<option class='ur-select-smart-tag' value = '%s'> %s</option>", esc_attr( $key ), esc_html( $value ) );
-			}
-			echo '</select>';
-
+			do_action( 'smart_tags_list', $editor_id );
 			add_action( 'admin_footer', array( $this, 'shortcode_modal' ) );
 		}
 
@@ -113,6 +108,20 @@ if ( ! class_exists( 'UR_Admin_Form_Modal', false ) ) :
 						</form>
 					</div>
 			<?php
+		}
+		/**
+		 * Smart tag list button
+		 *
+		 * @param int $editor_id  editor id.
+		 */
+		public function select_smart_tags( $editor_id ) {
+			$smart_tags_list = UR_Emailer::smart_tags_list();
+			printf( '<select id="select-smart-tags" class="button" style="color:#2271B1; border-color:#2271B1">', esc_attr( $editor_id ) );
+			printf( '<option value="">%s</option>', esc_html__( 'Add Smart Tags', 'user-registration' ) );
+			foreach ( $smart_tags_list as $key => $value ) {
+				printf( "<option class='ur-select-smart-tag' value = '%s'> %s</option>", esc_attr( $key ), esc_html( $value ) );
+			}
+			echo '</select>';
 		}
 	}
 

--- a/includes/admin/class-ur-admin-form-modal.php
+++ b/includes/admin/class-ur-admin-form-modal.php
@@ -24,7 +24,7 @@ if ( ! class_exists( 'UR_Admin_Form_Modal', false ) ) :
 		public function __construct() {
 
 			add_action( 'media_buttons', array( $this, 'media_button' ), 15 );
-			add_action( 'smart_tags_list', array( $this, 'select_smart_tags' ), 15, 1 );
+			add_action( 'ur_smart_tags_list', array( $this, 'select_smart_tags' ), 15, 1 );
 		}
 
 		/**
@@ -42,7 +42,7 @@ if ( ! class_exists( 'UR_Admin_Form_Modal', false ) ) :
 
 			// Remove Add User Registration Form button from wp-editor in customize my account settings page.
 			if ( isset( $_GET['tab'] ) && 'user-registration-customize-my-account' === $_GET['tab'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				do_action( 'smart_tags_list', $editor_id );
+				do_action( 'ur_smart_tags_list', $editor_id );
 				return;
 			}
 
@@ -57,7 +57,7 @@ if ( ! class_exists( 'UR_Admin_Form_Modal', false ) ) :
 				wp_kses_post( $icon ),
 				esc_html__( 'Add Registration Form', 'user-registration' )
 			);
-			do_action( 'smart_tags_list', $editor_id );
+			do_action( 'ur_smart_tags_list', $editor_id );
 			add_action( 'admin_footer', array( $this, 'shortcode_modal' ) );
 		}
 

--- a/includes/admin/class-ur-admin-form-modal.php
+++ b/includes/admin/class-ur-admin-form-modal.php
@@ -115,7 +115,7 @@ if ( ! class_exists( 'UR_Admin_Form_Modal', false ) ) :
 		 * @param int $editor_id  editor id.
 		 */
 		public function select_smart_tags( $editor_id ) {
-			$smart_tags_list = UR_Emailer::smart_tags_list();
+			$smart_tags_list = UR_Smart_Tags::smart_tags_list();
 			printf( '<select id="select-smart-tags" class="button" style="color:#2271B1; border-color:#2271B1">', esc_attr( $editor_id ) );
 			printf( '<option value="">%s</option>', esc_html__( 'Add Smart Tags', 'user-registration' ) );
 			foreach ( $smart_tags_list as $key => $value ) {

--- a/includes/admin/class-ur-admin-form-modal.php
+++ b/includes/admin/class-ur-admin-form-modal.php
@@ -55,6 +55,13 @@ if ( ! class_exists( 'UR_Admin_Form_Modal', false ) ) :
 				wp_kses_post( $icon ),
 				esc_html__( 'Add Registration Form', 'user-registration' )
 			);
+			$smart_tags_list = UR_Emailer::smart_tags_list();
+			printf( '<select id="select-smart-tags" class="button" style="color:#2271B1; border-color:#2271B1">', esc_attr( $editor_id ) );
+			printf( '<option value="">%s</option>', esc_html__( 'Add Smart Tags', 'user-registration' ) );
+			foreach ( $smart_tags_list as $key => $value ) {
+				printf( "<option class='ur-select-smart-tag' value = '%s'> %s</option>", esc_attr( $key ), esc_html( $value ) );
+			}
+			echo '</select>';
 
 			add_action( 'admin_footer', array( $this, 'shortcode_modal' ) );
 		}

--- a/includes/class-ur-emailer.php
+++ b/includes/class-ur-emailer.php
@@ -571,7 +571,27 @@ class UR_Emailer {
 
 		return apply_filters( 'user_registration_process_smart_tag_for_status_change_emails', $name_value, $email );
 	}
-
+	/**
+	 * List of smart tags.
+	 *
+	 * @return array array of smart tags.
+	 */
+	public static function smart_tags_list() {
+		$smart_tags = array(
+			'{{user_id}}'     => __( 'User ID', 'user-registration' ),
+			'{{username}}'    => __( 'User Name', 'user-registration' ),
+			'{{email}}'       => __( 'Email', 'user-registration' ),
+			'{{email_token}}' => __( 'Email Token', 'user-registration' ),
+			'{{blog_info}}'   => __( 'Blog Info', 'user-registration' ),
+			'{{home_url}}'    => __( 'Home URL', 'user-registration' ),
+			'{{ur_login}}'    => __( 'UR Login', 'user-registration' ),
+			'{{key}}'         => __( 'Key', 'user-registration' ),
+			'{{all_fields}}'  => __( 'All Fields', 'user-registration' ),
+			'{{auto_pass}}'   => __( 'Auto Pass', 'user-registration' ),
+			'{{user_roles}}'  => __( 'User Roles', 'user-registration' ),
+		);
+		return $smart_tags;
+	}
 	/**
 	 * Parse Smart tags for emails.
 	 *
@@ -580,20 +600,11 @@ class UR_Emailer {
 	 * @param array  $name_value  Extra values.
 	 */
 	public static function parse_smart_tags( $content = '', $values = array(), $name_value = array() ) {
-		$smart_tags = array(
-			'{{user_id}}',
-			'{{username}}',
-			'{{email}}',
-			'{{email_token}}',
-			'{{blog_info}}',
-			'{{home_url}}',
-			'{{ur_login}}',
-			'{{key}}',
-			'{{all_fields}}',
-			'{{auto_pass}}',
-			'{{user_roles}}',
-		);
 
+		$smart_tags_list = self::smart_tags_list();
+		foreach ( $smart_tags_list as $key => $value ) {
+			$smart_tags[] = $key;
+		}
 		$smart_tags = apply_filters( 'user_registration_smart_tags', $smart_tags );
 
 		$ur_account_page_exists   = ur_get_page_id( 'myaccount' ) > 0;

--- a/includes/class-ur-emailer.php
+++ b/includes/class-ur-emailer.php
@@ -590,7 +590,7 @@ class UR_Emailer {
 			'{{auto_pass}}'   => __( 'Auto Pass', 'user-registration' ),
 			'{{user_roles}}'  => __( 'User Roles', 'user-registration' ),
 		);
-		return $smart_tags;
+		return apply_filters( 'user_registration_smart_tags_list', $smart_tags );
 	}
 	/**
 	 * Parse Smart tags for emails.

--- a/includes/class-ur-emailer.php
+++ b/includes/class-ur-emailer.php
@@ -572,27 +572,6 @@ class UR_Emailer {
 		return apply_filters( 'user_registration_process_smart_tag_for_status_change_emails', $name_value, $email );
 	}
 	/**
-	 * List of smart tags.
-	 *
-	 * @return array array of smart tags.
-	 */
-	public static function smart_tags_list() {
-		$smart_tags = array(
-			'{{user_id}}'     => __( 'User ID', 'user-registration' ),
-			'{{username}}'    => __( 'User Name', 'user-registration' ),
-			'{{email}}'       => __( 'Email', 'user-registration' ),
-			'{{email_token}}' => __( 'Email Token', 'user-registration' ),
-			'{{blog_info}}'   => __( 'Blog Info', 'user-registration' ),
-			'{{home_url}}'    => __( 'Home URL', 'user-registration' ),
-			'{{ur_login}}'    => __( 'UR Login', 'user-registration' ),
-			'{{key}}'         => __( 'Key', 'user-registration' ),
-			'{{all_fields}}'  => __( 'All Fields', 'user-registration' ),
-			'{{auto_pass}}'   => __( 'Auto Pass', 'user-registration' ),
-			'{{user_roles}}'  => __( 'User Roles', 'user-registration' ),
-		);
-		return apply_filters( 'user_registration_smart_tags_list', $smart_tags );
-	}
-	/**
 	 * Parse Smart tags for emails.
 	 *
 	 * @param string $content Contents.
@@ -600,86 +579,7 @@ class UR_Emailer {
 	 * @param array  $name_value  Extra values.
 	 */
 	public static function parse_smart_tags( $content = '', $values = array(), $name_value = array() ) {
-
-		$smart_tags_list = self::smart_tags_list();
-		foreach ( $smart_tags_list as $key => $value ) {
-			$smart_tags[] = $key;
-		}
-		$smart_tags = apply_filters( 'user_registration_smart_tags', $smart_tags );
-
-		$ur_account_page_exists   = ur_get_page_id( 'myaccount' ) > 0;
-		$ur_login_or_account_page = ur_get_page_permalink( 'myaccount' );
-
-		if ( ! $ur_account_page_exists ) {
-			$ur_login_or_account_page = ur_get_page_permalink( 'login' );
-		}
-
-		$ur_login = ( get_home_url() !== $ur_login_or_account_page ) ? $ur_login_or_account_page : wp_login_url();
-		$ur_login = str_replace( get_home_url() . '/', '', $ur_login );
-
-		$default_values = array(
-			'username'       => '',
-			'user_id'        => get_current_user_id(),
-			'email'          => '',
-			'email_token'    => '',
-			'approval_token' => '',
-			'approval_link'  => '',
-			'admin_url'      => admin_url(),
-			'blog_info'      => get_bloginfo(),
-			'home_url'       => get_home_url(),
-			'ur_login'       => $ur_login,
-			'key'            => '',
-			'all_fields'     => '',
-			'auto_pass'      => '',
-		);
-
-		$user_pass = apply_filters( 'user_registration_auto_generated_password', 'user_pass' );
-
-		if ( $user_pass ) {
-			$default_values['auto_pass'] = $user_pass;
-		}
-
-		$default_values = apply_filters( 'user_registration_add_smart_tags', $default_values, $values['email'] );
-
-		$values = wp_parse_args( $values, $default_values );
-
-		if ( ! empty( $values['user_id'] ) ) {
-			$values['user_roles'] = implode( ',', ur_get_user_roles( $values['user_id'] ) );
-		}
-
-		if ( ! empty( $values['email'] ) ) {
-			$user_data = self::user_data_smart_tags( $values['email'] );
-			if ( is_array( $name_value ) && ! empty( $name_value ) ) {
-				$user_data = array_merge( $user_data, $name_value );
-			}
-
-			$values = array_merge( $values, $user_data );
-			array_walk(
-				$values,
-				function( &$value, $key ) {
-					if ( 'user_pass' === $key ) {
-						$value = esc_html__( 'Chosen Password', 'user-registration' );
-					}
-				}
-			);
-
-			$user_smart_tags = array_keys( $user_data );
-			array_walk(
-				$user_smart_tags,
-				function( &$value ) {
-					$value = '{{' . trim( $value, '{}' ) . '}}';
-				}
-			);
-			$smart_tags = array_merge( $smart_tags, $user_smart_tags );
-		}
-
-		foreach ( $values as $key => $value ) {
-			$value = ur_format_field_values( $key, $value );
-			if ( ! is_array( $value ) ) {
-				$content = str_replace( '{{' . $key . '}}', $value, $content );
-			}
-		}
-
+		$content = apply_filters( 'user_registration_process_smart_tags', $content, $values, $name_value );
 		return $content;
 	}
 

--- a/includes/class-ur-shortcodes.php
+++ b/includes/class-ur-shortcodes.php
@@ -246,6 +246,9 @@ class UR_Shortcodes {
 	 */
 	private static function render_form( $form_id ) {
 		$form_data_array = ( $form_id ) ? UR()->form->get_form( $form_id, array( 'content_only' => true ) ) : array();
+		$form_json_data  = wp_json_encode( $form_data_array );
+		$content         = apply_filters( 'user_registration_process_smart_tags', $form_json_data, array(), array() );
+		$form_data_array = json_decode( $content );
 		$form_row_ids    = '';
 
 		if ( ! empty( $form_data_array ) ) {
@@ -280,8 +283,7 @@ class UR_Shortcodes {
 
 		$recaptcha_enabled = ur_get_form_setting_by_key( $form_id, 'user_registration_form_setting_enable_recaptcha_support', 'no' );
 		$recaptcha_node    = ur_get_recaptcha_node( 'register', $recaptcha_enabled );
-
-		$form_data_array = apply_filters( 'user_registration_before_registration_form_template', $form_data_array, $form_id );
+		$form_data_array   = apply_filters( 'user_registration_before_registration_form_template', $form_data_array, $form_id );
 
 		self::$parts = apply_filters( 'user_registration_parts_data', self::$parts, $form_id, $form_data_array );
 

--- a/includes/class-ur-smart-tags.php
+++ b/includes/class-ur-smart-tags.php
@@ -38,7 +38,7 @@ class UR_Smart_Tags {
 			'{{auto_pass}}'   => __( 'Auto Pass', 'user-registration' ),
 			'{{user_roles}}'  => __( 'User Roles', 'user-registration' ),
 		);
-		return apply_filters( 'user_registration_smart_tags_list', $smart_tags );
+		return apply_filters( 'user_registration_smart_tags', $smart_tags );
 	}
 	/**
 	 * Process and parse smart tags.

--- a/includes/class-ur-smart-tags.php
+++ b/includes/class-ur-smart-tags.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Smart tag functionality.
+ *
+ * @package  UserRegistration/Classes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Smart Tag Class.
+ */
+class UR_Smart_Tags {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_filter( 'user_registration_process_smart_tags', array( $this, 'process' ), 10, 3 );
+	}
+
+	/**
+	 * List of smart tags.
+	 *
+	 * @return array array of smart tags.
+	 */
+	public static function smart_tags_list() {
+		$smart_tags = array(
+			'{{user_id}}'     => __( 'User ID', 'user-registration' ),
+			'{{username}}'    => __( 'User Name', 'user-registration' ),
+			'{{email}}'       => __( 'Email', 'user-registration' ),
+			'{{email_token}}' => __( 'Email Token', 'user-registration' ),
+			'{{blog_info}}'   => __( 'Blog Info', 'user-registration' ),
+			'{{home_url}}'    => __( 'Home URL', 'user-registration' ),
+			'{{ur_login}}'    => __( 'UR Login', 'user-registration' ),
+			'{{key}}'         => __( 'Key', 'user-registration' ),
+			'{{all_fields}}'  => __( 'All Fields', 'user-registration' ),
+			'{{auto_pass}}'   => __( 'Auto Pass', 'user-registration' ),
+			'{{user_roles}}'  => __( 'User Roles', 'user-registration' ),
+		);
+		return apply_filters( 'user_registration_smart_tags_list', $smart_tags );
+	}
+	/**
+	 * Process and parse smart tags.
+	 *
+	 * @param string $content Contents.
+	 * @param array  $values Data values.
+	 * @param array  $name_value  Extra values.
+	 */
+	public function process( $content = '', $values = array(), $name_value = array() ) {
+		if ( ! empty( $values['email'] ) ) {
+			$default_values = array();
+			$default_values = apply_filters( 'user_registration_add_smart_tags', $default_values, $values['email'] );
+
+			$values    = wp_parse_args( $values, $default_values );
+			$user_data = UR_Emailer::user_data_smart_tags( $values['email'] );
+			if ( is_array( $name_value ) && ! empty( $name_value ) ) {
+				$user_data = array_merge( $user_data, $name_value );
+			}
+
+			$values = array_merge( $values, $user_data );
+			array_walk(
+				$values,
+				function( &$value, $key ) {
+					if ( 'user_pass' === $key ) {
+						$value = esc_html__( 'Chosen Password', 'user-registration' );
+					}
+				}
+			);
+
+			$user_smart_tags = array_keys( $user_data );
+			array_walk(
+				$user_smart_tags,
+				function( &$value ) {
+					$value = '{{' . trim( $value, '{}' ) . '}}';
+				}
+			);
+			$smart_tags = $user_smart_tags;
+			foreach ( $values as $key => $value ) {
+				$value = ur_format_field_values( $key, $value );
+				if ( ! is_array( $value ) ) {
+					$content = str_replace( '{{' . $key . '}}', $value, $content );
+				}
+			}
+		}
+
+		preg_match_all( '/\{\{(.+?)\}\}/', $content, $other_tags );
+		if ( ! empty( $other_tags[1] ) ) {
+			foreach ( $other_tags[1] as $key => $tag ) {
+				$other_tag = explode( ' ', $tag )[0];
+				switch ( $other_tag ) {
+					case 'user_id':
+						$user_id = ! empty( $values['user_id'] ) ? $values['user_id'] : get_current_user_id();
+						$content = str_replace( '{{' . $other_tag . '}}', $user_id, $content );
+						break;
+					case 'username':
+						if ( is_user_logged_in() ) {
+							$user = wp_get_current_user();
+							$name = sanitize_text_field( $user->user_login );
+						} else {
+							$name = '';
+						}
+						$content = str_replace( '{{' . $other_tag . '}}', $name, $content );
+						break;
+					case 'ur_login':
+						$ur_account_page_exists   = ur_get_page_id( 'myaccount' ) > 0;
+						$ur_login_or_account_page = ur_get_page_permalink( 'myaccount' );
+
+						if ( ! $ur_account_page_exists ) {
+							$ur_login_or_account_page = ur_get_page_permalink( 'login' );
+						}
+
+						$ur_login = ( get_home_url() !== $ur_login_or_account_page ) ? $ur_login_or_account_page : wp_login_url();
+						$ur_login = str_replace( get_home_url() . '/', '', $ur_login );
+						$content  = str_replace( '{{' . $other_tag . '}}', $ur_login, $content );
+						break;
+					case 'auto_pass':
+						$user_pass = apply_filters( 'user_registration_auto_generated_password', 'user_pass' );
+						$content   = str_replace( '{{' . $other_tag . '}}', $user_pass, $content );
+						break;
+					case 'user_roles':
+						if ( ! empty( $values['user_id'] ) ) {
+							$user_id    = $values['user_id'];
+							$user_roles = ur_get_user_roles( $user_id )[0];
+						} elseif ( is_user_logged_in() && empty( $values['user_id'] ) ) {
+							$user_id    = get_current_user_id();
+							$user_roles = ur_get_user_roles( $user_id )[0];
+						} else {
+							$user_roles = '';
+						}
+						$content = str_replace( '{{' . $other_tag . '}}', $user_roles, $content );
+						break;
+					case 'blog_info':
+						$blog_info = get_bloginfo();
+						$content   = str_replace( '{{' . $other_tag . '}}', $blog_info, $content );
+						break;
+					case 'home_url':
+						$home_url = get_home_url();
+						$content  = str_replace( '{{' . $other_tag . '}}', $home_url, $content );
+						break;
+					case 'email':
+						if ( ! empty( $values['email'] ) ) {
+							$email = $values['email'];
+						} elseif ( is_user_logged_in() && empty( $values['email'] ) ) {
+							$user  = wp_get_current_user();
+							$email = sanitize_text_field( $user->user_email );
+						} else {
+							$email = '';
+						}
+						$content = str_replace( '{{' . $other_tag . '}}', $email, $content );
+						break;
+					case 'email_token':
+						if ( ! empty( $values['email_token'] ) ) {
+							$email_token = $values['email_token'];
+						} else {
+							$email_token = '';
+						}
+						$content = str_replace( '{{' . $other_tag . '}}', $email_token, $content );
+						break;
+					case 'key':
+						if ( ! empty( $values['key'] ) ) {
+							$key = $values['key'];
+						} else {
+							$key = '';
+						}
+						$content = str_replace( '{{' . $other_tag . '}}', $key, $content );
+						break;
+					case 'all_fields':
+						if ( ! empty( $values['all_fields'] ) ) {
+							$all_fields = $values['all_fields'];
+						} else {
+							$all_fields = '';
+						}
+						$content = str_replace( '{{' . $other_tag . '}}', $all_fields, $content );
+						break;
+				}
+			}
+		}
+		return $content;
+	}
+}
+
+new UR_Smart_Tags();

--- a/user-registration.php
+++ b/user-registration.php
@@ -188,7 +188,8 @@ if ( ! class_exists( 'UserRegistration' ) ) :
 			include_once UR_ABSPATH . 'includes/functions-ur-core.php';
 			include_once UR_ABSPATH . 'includes/class-ur-install.php';
 			include_once UR_ABSPATH . 'includes/class-ur-post-types.php'; // Registers post types.
-			include_once UR_ABSPATH . 'includes/class-ur-user-approval.php'; // User Approval class.
+			include_once UR_ABSPATH . 'includes/class-ur-user-approval.php';
+			include_once UR_ABSPATH . 'includes/class-ur-smart-tags.php'; // User Approval class.
 			include_once UR_ABSPATH . 'includes/class-ur-emailer.php';
 			include_once UR_ABSPATH . 'includes/class-ur-ajax.php';
 			include_once UR_ABSPATH . 'includes/class-ur-query.php';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is adding a button that gives the list of smart tags in the email content section and also in the customize my account section. With the click of any smart tag, It will be added to the editor.

### How to test the changes in this Pull Request:

1. For Email -> Go to setting -> Email -> Configure  || For Customize my account -> Activate customize my account addon -> Go to Setting -> click Customize My Account tab
2. Then click on the Add Smart Tag button, 
3. It will show the list of smart tags and on the click it will be added to editor.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Enhancement - List of smart tags in email content.
