### PR TITLE
UR-752 Fix - Year not displayed on min max date field option

### DIFF
--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -2820,7 +2820,6 @@
 							.addClass("flatpickr-field")
 							.flatpickr({
 								disableMobile: true,
-								static: true,
 								onChange: function (
 									selectedDates,
 									dateStr,
@@ -2850,7 +2849,6 @@
 							.addClass("flatpickr-field")
 							.flatpickr({
 								disableMobile: true,
-								static: true,
 								onChange: function (
 									selectedDates,
 									dateStr,
@@ -2906,7 +2904,6 @@
 									.addClass("flatpickr-field")
 									.flatpickr({
 										disableMobile: true,
-										static: true,
 										defaultDate: new Date(
 											$(".ur-item-active")
 												.find(".ur-settings-min-date")
@@ -2955,7 +2952,6 @@
 									.addClass("flatpickr-field")
 									.flatpickr({
 										disableMobile: true,
-										static: true,
 										defaultDate: new Date(
 											$(".ur-item-active")
 												.find(".ur-settings-max-date")


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously, When the Min-max option of the Date field is enabled then the Year is not showing in it. This PR Will solve this issue.

### How to test the changes in this Pull Request:

1. Enable the min-max option and check whether a year is showing or not while selecting the min-max date.


### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Year not displayed on min max date field option.
