### PR TITLE
UR-779 Fix - Single item field error message displaying in wrong place

### DIFF
--- a/assets/js/frontend/user-registration-form-validator.js
+++ b/assets/js/frontend/user-registration-form-validator.js
@@ -220,8 +220,13 @@
 								element.hasClass("ur-quantity")
 							) {
 								error.insertAfter(element.parent());
-							}else if ( "url" === element.attr("type") ) {
-								error.insertAfter( element.parent() );
+							} else if (
+								"text" === element.attr("type") &&
+								element.hasClass("ur-payment-price")
+							) {
+								error.insertAfter(element);
+							} else if ("url" === element.attr("type")) {
+								error.insertAfter(element.parent());
 							} else {
 								error.insertAfter(element.parent().parent());
 							}


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously, when a single is user-defined and make it required then the required message is showing in the wrong place. This PR will fix this issue.

### How to test the changes in this Pull Request:

1. Drag and drop single item payment field and make it user-defined and required to "yes".
2. then verify required is message is showing in the correct place or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Single item field error message displaying in wrong place.
