### PR TITLE
Tweak - Incorrect default date displayed in date field while editing the user

### DIFF
--- a/includes/admin/class-ur-admin-profile.php
+++ b/includes/admin/class-ur-admin-profile.php
@@ -115,6 +115,9 @@ if ( ! class_exists( 'UR_Admin_Profile', false ) ) :
 							if ( 'data-date-format' === $name ) {
 								$date_format = $value;
 							}
+							if ( 'data-default-date' === $name ) {
+								continue;
+							}
 							if ( 'data-mode' === $name ) {
 								$date_mode = $value;
 							}
@@ -255,7 +258,7 @@ if ( ! class_exists( 'UR_Admin_Profile', false ) ) :
 														$value      = date_i18n( $date_format, strtotime( trim( $date_range[0] ) ) ) . ' to ' . date_i18n( $date_format, strtotime( trim( $date_range[1] ) ) );
 													}
 													?>
-									<input type="text" 
+									<input type="text"
 										   value="<?php echo esc_attr( $actual_value ); ?>"
 										   class="ur-flatpickr-field regular-text"
 										   data-id = '<?php echo esc_attr( $key ); ?>'


### PR DESCRIPTION

### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Previously, when click on the date field of extra information of the user in the edit user page, it shows chosen date but when we click on it, it checkout to the default date value field. It is applicable only to those date fields that have default values as YES in the registration form. This PR fixes this issue.

### How to test the changes in this Pull Request:

1. Create a registration form with a date field -> set its value to default value as YES from the advanced setting.
2. Try to register one user-> fill in all fields -> change the date field value to another date then submit.
3. Go to users -> edit user-> click on date field -> check if it changed to a default value or not.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?


### Changelog entry

> Tweak - Incorrect default date displayed in date field while editing the user
