### PR TITLE
Enhancement - Lock disable field if integration not setup

### DIFF
--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -43,7 +43,31 @@ jQuery(function ($) {
 			$(".ur-fields-not-found").show();
 		}
 	});
-
+	
+	//Bind UI Actions for locked fields
+	$(document).on('click', '.ur-locked-field', function(e){
+		e.preventDefault();
+		var icon = '<i class="dashicons dashicons-lock"></i>';
+		var field_data = $(this).data('field-data');
+		var title =
+			icon +
+			'<span class="user-registration-swal2-modal__title">' +
+			field_data.title +
+			"</span>";
+		Swal.fire({
+			title: title,
+			html:field_data.message,
+			showCloseButton: true,
+			customClass:
+			  "user-registration-swal2-modal user-registration-swal2-modal--center",
+			confirmButtonText: field_data.button_title,
+		  }).then(function (result) {
+			if (result.value) {
+				var url = field_data.link;
+				window.open(url, "_blank");
+			}
+		});
+	})
 	// Bind UI Actions for upgradable fields
 	$(document).on("mousedown", ".ur-upgradable-field", function (e) {
 		e.preventDefault();

--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -43,9 +43,9 @@ jQuery(function ($) {
 			$(".ur-fields-not-found").show();
 		}
 	});
-	
+
 	//Bind UI Actions for locked fields
-	$(document).on('click', '.ur-locked-field', function(e){
+	$(document).on('mousedown', '.ur-locked-field', function(e){
 		e.preventDefault();
 		var icon = '<i class="dashicons dashicons-lock"></i>';
 		var field_data = $(this).data('field-data');

--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -1597,6 +1597,12 @@
 										}
 									}
 								});
+
+								var locked = ul_node.find('.ur-locked-field');
+								$.each(locked, function() {
+									$this = $(this);
+									$this.draggable("disable");
+								})
 							},
 							/**
 							 * Populate the dropped node when a field is dragged from field container to form builder area.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a lock for those fields whose setup is not set upped correctly.

### How to test the changes in this Pull Request:

1. Edit or Add a form.
2. Do not set up for field stripe, learn dash, and invite code. And check on click on the field -> modal is coming or not.
3. And also check after setup the field's required setup.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?


### Changelog entry

> Enhancement - Lock disable field if integration not setup.
