### PR TITLE
Tweak - Check captcha keys while setting up captcha for form

### DIFF
--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -945,9 +945,16 @@
 					$message.addClass("entered");
 				}, 50);
 
-				setTimeout(function () {
-					URFormBuilder.removeMessage($message);
-				}, 3000);
+				if ($(".ur-error").find(".ur-captcha-error").length == 1) {
+					$(".ur-error").css("width", "490px");
+					setTimeout(function () {
+						URFormBuilder.removeMessage($message);
+					}, 5000);
+				} else {
+					setTimeout(function () {
+						URFormBuilder.removeMessage($message);
+					}, 3000);
+				}
 			},
 			/**
 			 * Remove the validation message when calles.
@@ -1598,11 +1605,11 @@
 									}
 								});
 
-								var locked = ul_node.find('.ur-locked-field');
-								$.each(locked, function() {
+								var locked = ul_node.find(".ur-locked-field");
+								$.each(locked, function () {
 									$this = $(this);
 									$this.draggable("disable");
-								})
+								});
 							},
 							/**
 							 * Populate the dropped node when a field is dragged from field container to form builder area.
@@ -3981,45 +3988,65 @@
 		});
 
 		$(document).on("click", function () {
-			if($(document).find('.ur-smart-tags-list').is(':visible')) {
-
-				$('.ur-smart-tags-list').hide();
+			if ($(document).find(".ur-smart-tags-list").is(":visible")) {
+				$(".ur-smart-tags-list").hide();
 			}
 		});
 
-		$('.ur-smart-tags-list').hide();
+		$(".ur-smart-tags-list").hide();
 
-		$(document.body).on('click', '.ur-smart-tags-list-button', function (e) {
-			e.stopPropagation();
-			$('.ur-smart-tags-list').hide();
-			$( this ).parent().find('.ur-smart-tags-list').toggle('show');
-		});
+		$(document.body).on(
+			"click",
+			".ur-smart-tags-list-button",
+			function (e) {
+				e.stopPropagation();
+				$(".ur-smart-tags-list").hide();
+				$(this).parent().find(".ur-smart-tags-list").toggle("show");
+			}
+		);
 
-		$(document.body).on('click', '.ur-select-smart-tag', function(event) {
+		$(document.body).on("click", ".ur-select-smart-tag", function (event) {
 			event.preventDefault();
 			var smart_tag;
-			input_value =$(this).parent().parent().parent().find('input').val();
-			smart_tag = $(this).data('key');
+			input_value = $(this)
+				.parent()
+				.parent()
+				.parent()
+				.find("input")
+				.val();
+			smart_tag = $(this).data("key");
 			input_value += smart_tag;
 			update_input(input_value);
 
-			$(this).parent().parent().parent().find('input').val(input_value);
-			$(document.body).find('.ur-smart-tags-list').hide();
+			$(this).parent().parent().parent().find("input").val(input_value);
+			$(document.body).find(".ur-smart-tags-list").hide();
 		});
 
-		$(document.body).on('change', '.ur_advance_setting.ur-settings-default-value', function(){
-			input_value = $(this).val();
-			update_input(input_value);
-		})
+		$(document.body).on(
+			"change",
+			".ur_advance_setting.ur-settings-default-value",
+			function () {
+				input_value = $(this).val();
+				update_input(input_value);
+			}
+		);
 		/**
 		 * For update the default value.
 		 */
-		function update_input(input_value){
-			active_field = $('.ur-item-active');
-			target_input_field = $(active_field).find('.user-registration-field-option-group.ur-advance-setting-block');
-			ur_toggle_content = target_input_field.find('.ur-advance-setting.ur-advance-default_value');
-			target_input = $(ur_toggle_content).find('input[data-id=text_advance_setting_default_value]');
-			target_textarea = $(ur_toggle_content).find('input[data-id=textarea_advance_setting_default_value]');
+		function update_input(input_value) {
+			active_field = $(".ur-item-active");
+			target_input_field = $(active_field).find(
+				".user-registration-field-option-group.ur-advance-setting-block"
+			);
+			ur_toggle_content = target_input_field.find(
+				".ur-advance-setting.ur-advance-default_value"
+			);
+			target_input = $(ur_toggle_content).find(
+				"input[data-id=text_advance_setting_default_value]"
+			);
+			target_textarea = $(ur_toggle_content).find(
+				"input[data-id=textarea_advance_setting_default_value]"
+			);
 
 			target_input.val(input_value);
 			target_textarea.val(input_value);

--- a/includes/admin/settings/class-ur-settings-general.php
+++ b/includes/admin/settings/class-ur-settings-general.php
@@ -660,6 +660,14 @@ if ( ! class_exists( 'UR_Settings_General' ) ) :
 				$settings = $this->get_frontend_messages_settings();
 			} elseif ( 'login-options' === $current_section ) {
 				$settings = $this->get_login_options_settings();
+				$captcha_enabled = get_option( 'user_registration_login_options_enable_recaptcha' );
+
+				if ( ur_string_to_bool( $captcha_enabled ) && ! ur_check_captch_keys() ) {
+					echo '<div id="ur-captcha-error" class="notice notice-warning is-dismissible"><p><strong>' . sprintf(
+						/* translators: %s - Integration tab url */
+						__( 'Seems like you haven\'t added the reCAPTCHA Keys. <a href="%s" >Add Now.</a>', 'user-registration' ),
+						esc_url( admin_url( 'admin.php?page=user-registration-settings&tab=integration' ) ) ) .'</strong></p></div>';
+				}
 			} else {
 				$settings = array();
 			}

--- a/includes/admin/settings/class-ur-settings-general.php
+++ b/includes/admin/settings/class-ur-settings-general.php
@@ -659,14 +659,16 @@ if ( ! class_exists( 'UR_Settings_General' ) ) :
 			} elseif ( 'frontend-messages' === $current_section ) {
 				$settings = $this->get_frontend_messages_settings();
 			} elseif ( 'login-options' === $current_section ) {
-				$settings = $this->get_login_options_settings();
+				$settings        = $this->get_login_options_settings();
 				$captcha_enabled = get_option( 'user_registration_login_options_enable_recaptcha' );
 
 				if ( ur_string_to_bool( $captcha_enabled ) && ! ur_check_captch_keys() ) {
 					echo '<div id="ur-captcha-error" class="notice notice-warning is-dismissible"><p><strong>' . sprintf(
 						/* translators: %s - Integration tab url */
-						__( 'Seems like you haven\'t added the reCAPTCHA Keys. <a href="%s" target="_blank">Add Now.</a>', 'user-registration' ),
-						esc_url( admin_url( 'admin.php?page=user-registration-settings&tab=integration' ) ) ) .'</strong></p></div>';
+						'%s<a href="%s" target="_blank">Add Now.</a>',
+						esc_html__( "Seems like you haven't added the CAPTCHA Keys. ", 'user-registration' ),
+						esc_url( admin_url( 'admin.php?page=user-registration-settings&tab=integration' ) )
+					) . '</strong></p></div>';
 				}
 			} else {
 				$settings = array();

--- a/includes/admin/settings/class-ur-settings-general.php
+++ b/includes/admin/settings/class-ur-settings-general.php
@@ -665,7 +665,7 @@ if ( ! class_exists( 'UR_Settings_General' ) ) :
 				if ( ur_string_to_bool( $captcha_enabled ) && ! ur_check_captch_keys() ) {
 					echo '<div id="ur-captcha-error" class="notice notice-warning is-dismissible"><p><strong>' . sprintf(
 						/* translators: %s - Integration tab url */
-						__( 'Seems like you haven\'t added the reCAPTCHA Keys. <a href="%s" >Add Now.</a>', 'user-registration' ),
+						__( 'Seems like you haven\'t added the reCAPTCHA Keys. <a href="%s" target="_blank">Add Now.</a>', 'user-registration' ),
 						esc_url( admin_url( 'admin.php?page=user-registration-settings&tab=integration' ) ) ) .'</strong></p></div>';
 				}
 			} else {

--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -869,8 +869,8 @@ class UR_AJAX {
 						throw  new Exception(
 							sprintf(
 							/* translators: %s - Integration tab url */
-								'%s<a href="%s" target="_blank">Add Now</a>',
-								esc_html__( "Seems like you haven't added the CAPTCHA Keys.", 'user-registration' ),
+							esc_html__( "Seems like you are trying to enable the captcha feature, but the captcha keys are empty. Please click %s to add them and save your form.", 'user-registration' ),
+							'<a href="%s" class="ur-captcha-error" target="_blank">here</a>',
 							esc_url( admin_url( 'admin.php?page=user-registration-settings&tab=integration' ) ) ) ); //phpcs:ignore
 					}
 				}

--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -869,7 +869,7 @@ class UR_AJAX {
 						throw  new Exception(
 							sprintf(
 							/* translators: %s - Integration tab url */
-							__( 'Seems like you haven\'t added the reCAPTCHA Keys. <a href="%s" >Add Now.</a>', 'user-registration' ),
+							__( 'Seems like you haven\'t added the reCAPTCHA Keys. <a href="%s" target="_blank">Add Now.</a>', 'user-registration' ),
 							esc_url( admin_url( 'admin.php?page=user-registration-settings&tab=integration' ) ) ) ); //phpcs:ignore
 					}
 				}

--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -869,9 +869,9 @@ class UR_AJAX {
 						throw  new Exception(
 							sprintf(
 							/* translators: %s - Integration tab url */
-							esc_html__( "Seems like you are trying to enable the captcha feature, but the captcha keys are empty. Please click %s to add them and save your form.", 'user-registration' ),
-							'<a href="%s" class="ur-captcha-error" target="_blank">here</a>',
-							esc_url( admin_url( 'admin.php?page=user-registration-settings&tab=integration' ) ) ) ); //phpcs:ignore
+								esc_html__( 'Seems like you are trying to enable the captcha feature, but the captcha keys are empty. Please click %s to add them and save your form.', 'user-registration' ),
+								'<a href="%s" class="ur-captcha-error" target="_blank">here</a>',
+								esc_url( admin_url( 'admin.php?page=user-registration-settings&tab=integration' ) ) ) ); //phpcs:ignore
 					}
 				}
 			}

--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -862,6 +862,19 @@ class UR_AJAX {
 				throw  new Exception( __( 'Could not save form, ' . join( ', ', $required_fields ) . ' fields are required.! ', 'user-registration' ) ); //phpcs:ignore
 			}
 
+			// check captcha configuration before form save action.
+			if ( isset( $_POST['data']['form_setting_data'] ) ) {
+				foreach ( $_POST['data']['form_setting_data'] as $setting_data ) {
+					if ( 'user_registration_form_setting_enable_recaptcha_support' === $setting_data['name'] && '1' === $setting_data['value'] && ! ur_check_captch_keys() ) {
+						throw  new Exception(
+							sprintf(
+							/* translators: %s - Integration tab url */
+							__( 'Seems like you haven\'t added the reCAPTCHA Keys. <a href="%s" >Add Now.</a>', 'user-registration' ),
+							esc_url( admin_url( 'admin.php?page=user-registration-settings&tab=integration' ) ) ) ); //phpcs:ignore
+					}
+				}
+			}
+
 			$form_name    = sanitize_text_field( $_POST['data']['form_name'] ); //phpcs:ignore
 			$form_row_ids = sanitize_text_field( $_POST['data']['form_row_ids'] ); //phpcs:ignore
 			$form_id      = sanitize_text_field( $_POST['data']['form_id'] ); //phpcs:ignore

--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -864,12 +864,13 @@ class UR_AJAX {
 
 			// check captcha configuration before form save action.
 			if ( isset( $_POST['data']['form_setting_data'] ) ) {
-				foreach ( $_POST['data']['form_setting_data'] as $setting_data ) {
+				foreach ( wp_unslash( $_POST['data']['form_setting_data'] )  as $setting_data ) { //phpcs:ignore
 					if ( 'user_registration_form_setting_enable_recaptcha_support' === $setting_data['name'] && '1' === $setting_data['value'] && ! ur_check_captch_keys() ) {
 						throw  new Exception(
 							sprintf(
 							/* translators: %s - Integration tab url */
-							__( 'Seems like you haven\'t added the reCAPTCHA Keys. <a href="%s" target="_blank">Add Now.</a>', 'user-registration' ),
+								'%s<a href="%s" target="_blank">Add Now</a>',
+								esc_html__( "Seems like you haven't added the CAPTCHA Keys.", 'user-registration' ),
 							esc_url( admin_url( 'admin.php?page=user-registration-settings&tab=integration' ) ) ) ); //phpcs:ignore
 					}
 				}

--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -869,8 +869,8 @@ class UR_AJAX {
 						throw  new Exception(
 							sprintf(
 							/* translators: %s - Integration tab url */
-								esc_html__( 'Seems like you are trying to enable the captcha feature, but the captcha keys are empty. Please click %s to add them and save your form.', 'user-registration' ),
-								'<a href="%s" class="ur-captcha-error" target="_blank">here</a>',
+								'%s <a href="%s" class="ur-captcha-error" target="_blank">here</a> to add them and save your form.',
+								esc_html__( 'Seems like you are trying to enable the captcha feature, but the captcha keys are empty. Please click', 'user-registration' ),
 								esc_url( admin_url( 'admin.php?page=user-registration-settings&tab=integration' ) ) ) ); //phpcs:ignore
 					}
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously, When captcha keys are not setup properly, then it lets to save the form. This PR will not allow to save the form if captcha keys are not setup and captcha is enabled in the form.

### How to test the changes in this Pull Request:

1. setup the captcha form with captcha keys and without keys and verify whether it is working as expected or not. 

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Check captcha keys while setting up the captcha for form.
