### PR TITLE
Feature - PHP Deprecation notice

### DIFF
--- a/includes/admin/class-ur-admin.php
+++ b/includes/admin/class-ur-admin.php
@@ -268,7 +268,7 @@ class UR_Admin {
 	 * Add PHP Deprecation notice.
 	 */
 	public function php_deprecation_notice() {
-		$php_version  = phpversion();
+		$php_version  = explode( '-', PHP_VERSION )[0];
 		$base_version = '7.2';
 
 		if ( version_compare( $php_version, $base_version, '<' ) ) {

--- a/includes/admin/class-ur-admin.php
+++ b/includes/admin/class-ur-admin.php
@@ -28,6 +28,7 @@ class UR_Admin {
 		add_action( 'admin_notices', array( $this, 'review_notice' ) );
 		add_action( 'admin_notices', array( $this, 'survey_notice' ) );
 		add_action( 'admin_notices', array( $this, 'allow_usage_notice' ) );
+		add_action( 'admin_notices', array( $this, 'php_deprecation_notice' ) );
 		add_action( 'admin_footer', 'ur_print_js', 25 );
 		add_filter( 'heartbeat_received', array( $this, 'new_user_live_notice' ), 10, 2 );
 		add_filter( 'admin_body_class', array( $this, 'user_registration_add_body_classes' ) );
@@ -261,6 +262,30 @@ class UR_Admin {
 			return false;
 		}
 	}
+
+
+	/**
+	 * Add PHP Deprecation notice.
+	 */
+	public function php_deprecation_notice() {
+		$php_version  = phpversion();
+		$base_version = '7.2';
+
+		if ( version_compare( $php_version, $base_version, '<' ) ) {
+			$last_prompt_date = get_option( 'user_registration_php_deprecated_notice_last_prompt_date', '' );
+
+			if ( empty( $last_prompt_date ) || strtotime( $last_prompt_date ) < strtotime( '-1 day' ) ) {
+				$prompt_limit = 3;
+				$prompt_count = get_option( 'user_registration_php_deprecated_notice_prompt_count', 0 );
+
+				if ( $prompt_count < $prompt_limit ) {
+					include dirname( __FILE__ ) . '/views/html-notice-php-deprecation.php';
+				}
+			}
+		}
+	}
+
+
 
 	/**
 	 * Survey notice on header.

--- a/includes/admin/views/html-notice-php-deprecation.php
+++ b/includes/admin/views/html-notice-php-deprecation.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Admin View: Notice - PHP Deprecation
+ *
+ * @package  UserRegistration
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+?>
+
+<div class="notice notice-warning is-dismissible" id="user-registration-php-deprecation-notice">
+	<p>
+		<strong><?php esc_html_e( 'Warning!', 'user-registration' ); ?></strong>
+		<?php _e( "Your website is running on an outdated version of PHP ( $php_version ) that will not be supported by <strong>User Registration</strong> plugin in future updates.", 'user-registration' ); //phpcs:ignore ?>
+		</br>
+		<?php
+		echo esc_html__( //phpcs:ignore
+			sprintf( //phpcs:ignore
+				'Please update to latest PHP version ( >= %s ) to ensure compatibility and security.',
+				$base_version
+			),
+			'user-registration'
+		);
+		?>
+		<a href="#"><?php esc_html_e( 'Learn More', 'user-registration' ); ?> </a>
+	</p>
+</div>
+
+<script>
+
+	jQuery( function( $ ) {
+		$(document).ready( function() {
+			var notice_container = $('#user-registration-php-deprecation-notice');
+			notice_container.find( '.notice-dismiss' ).on( 'click', function(e) {
+				e.preventDefault();
+				var data = {
+					action: "user_registration_php_notice_dismiss",
+				};
+
+				$.post(ur_notice_params.ajax_url, data, function (response) {
+					// Success. Do nothing. Silence is golden.
+				});
+			});
+
+		});
+	});
+</script>

--- a/includes/admin/views/html-notice-php-deprecation.php
+++ b/includes/admin/views/html-notice-php-deprecation.php
@@ -14,18 +14,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 <div class="notice notice-warning is-dismissible" id="user-registration-php-deprecation-notice">
 	<p>
 		<strong><?php esc_html_e( 'Warning!', 'user-registration' ); ?></strong>
-		<?php _e( "Your website is running on an outdated version of PHP ( $php_version ) that will not be supported by <strong>User Registration</strong> plugin in future updates.", 'user-registration' ); //phpcs:ignore ?>
+		<?php _e( "Your website is running on an outdated version of PHP ( v$php_version ) that might not be supported by <strong>User Registration</strong> plugin in future updates.", 'user-registration' ); //phpcs:ignore ?>
 		</br>
 		<?php
 		echo esc_html__( //phpcs:ignore
 			sprintf( //phpcs:ignore
-				'Please update to latest PHP version ( >= %s ) to ensure compatibility and security.',
+				'Please update to atleast PHP v%s to ensure compatibility and security.',
 				$base_version
 			),
 			'user-registration'
 		);
 		?>
-		<a href="#"><?php esc_html_e( 'Learn More', 'user-registration' ); ?> </a>
+		<a href="https://docs.wpeverest.com/user-registration/docs/php-version-lesser-than-7-2-is-not-supported/" target="_blank"><?php esc_html_e( 'Learn More', 'user-registration' ); ?> </a>
 	</p>
 </div>
 

--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -69,6 +69,7 @@ class UR_AJAX {
 			'cancel_email_change'       => false,
 			'email_setting_status'      => false,
 			'locked_form_fields_notice' => false,
+			'php_notice_dismiss'        => false,
 		);
 
 		foreach ( $ajax_events as $ajax_event => $nopriv ) {
@@ -1562,6 +1563,22 @@ class UR_AJAX {
 		$button = ob_get_clean();
 		wp_send_json_success( array( 'action_button' => $button ) );
 
+	}
+
+
+	/**
+	 * Handle PHP Deprecated notice dismiss action.
+	 *
+	 * @return bool
+	 */
+	public static function php_notice_dismiss() {
+		$current_date = gmdate( 'Y-m-d' );
+		$prompt_count = get_option( 'user_registration_php_deprecated_notice_prompt_count', 0 );
+
+		update_option( 'user_registration_php_deprecated_notice_last_prompt_date', $current_date );
+		update_option( 'user_registration_php_deprecated_notice_prompt_count', ++$prompt_count );
+
+		return false;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a php deprecation notice shown in the admin panel if the website is running on PHP below version 7.2.
The notice is dismissible and is shown up to 3 times with the interval of one day.


### How to test the changes in this Pull Request:

1. Verify if the notice is displayed properly, is dismissible, and is displayed only 3 times.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Feature - PHP Deprecation notice
