### PR TITLE
UR-929 Refactor - Create global constant for upload dir path and url

### DIFF
--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -547,7 +547,7 @@ class UR_AJAX {
 				$attachment_id = wp_rand();
 
 				ur_clean_tmp_files();
-				$url = home_url() . '/wp-content/uploads/user_registration_uploads/temp-uploads/' . sanitize_file_name( $file_name );
+				$url = UR_UPLOAD_URL . 'temp-uploads/' . sanitize_file_name( $file_name );
 				wp_send_json_success(
 					array(
 						'attachment_id' => $attachment_id,

--- a/includes/class-ur-install.php
+++ b/includes/class-ur-install.php
@@ -141,7 +141,9 @@ class UR_Install {
 		self::maybe_add_installation_date();
 		self::maybe_run_migrations();
 
-		$path = WP_CONTENT_DIR . '/uploads/user_registration_uploads/profile-pictures';
+		$path = UR_UPLOAD_PATH . 'profile-pictures';
+
+		lg( $path, 'path' );
 
 		if ( ! is_dir( $path ) ) {
 			mkdir( $path, 0777, true );

--- a/includes/class-ur-install.php
+++ b/includes/class-ur-install.php
@@ -143,8 +143,6 @@ class UR_Install {
 
 		$path = UR_UPLOAD_PATH . 'profile-pictures';
 
-		lg( $path, 'path' );
-
 		if ( ! is_dir( $path ) ) {
 			mkdir( $path, 0777, true );
 		}

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -2553,17 +2553,17 @@ if ( ! function_exists( 'ur_install_extensions' ) ) {
 
 			if ( current_user_can( 'activate_plugin', $install_status['file'] ) ) {
 				if ( is_plugin_inactive( $install_status['file'] ) ) {
-					$status['activateUrl'] =
-					esc_url_raw(
-						add_query_arg(
-							array(
-								'action'   => 'activate',
-								'plugin'   => $install_status['file'],
-								'_wpnonce' => wp_create_nonce( 'activate-plugin_' . $install_status['file'] ),
-							),
-							admin_url( 'admin.php?page=user-registration-addons' )
-						)
-					);
+				$status['activateUrl'] =
+				esc_url_raw(
+					add_query_arg(
+						array(
+							'action'   => 'activate',
+							'plugin'   => $install_status['file'],
+							'_wpnonce' => wp_create_nonce( 'activate-plugin_' . $install_status['file'] ),
+						),
+						admin_url( 'admin.php?page=user-registration-addons' )
+					)
+				);
 				} else {
 					$status['deActivateUrl'] =
 					esc_url_raw(
@@ -3108,8 +3108,7 @@ if ( ! function_exists( 'ur_get_tmp_dir' ) ) {
 	 * @return string
 	 */
 	function ur_get_tmp_dir() {
-		$uploads  = wp_upload_dir();
-		$tmp_root = untrailingslashit( $uploads['basedir'] ) . '/user_registration_uploads/temp-uploads';
+		$tmp_root = UR_UPLOAD_PATH . 'temp-uploads';
 
 		if ( ! file_exists( $tmp_root ) || ! wp_is_writable( $tmp_root ) ) {
 			wp_mkdir_p( $tmp_root );
@@ -3156,8 +3155,7 @@ if ( ! function_exists( 'ur_upload_profile_pic' ) ) {
 	 */
 	function ur_upload_profile_pic( $valid_form_data, $user_id ) {
 		$attachment_id = array();
-		$upload_dir    = wp_upload_dir();
-		$upload_path   = $upload_dir['basedir'] . '/user_registration_uploads/profile-pictures'; /*Get path of upload dir of WordPress*/
+		$upload_path   = UR_UPLOAD_PATH . 'profile-pictures'; /*Get path of upload dir of User Registration for profile pictures*/
 
 		// Checks if the upload directory exists and create one if not.
 		if ( ! file_exists( $upload_path ) ) {

--- a/user-registration.php
+++ b/user-registration.php
@@ -115,8 +115,10 @@ if ( ! class_exists( 'UserRegistration' ) ) :
 		 * Define FT Constants.
 		 */
 		private function define_constants() {
-			$upload_dir = wp_upload_dir();
+			$upload_dir = apply_filters( 'user_registration_upload_dir', wp_upload_dir() );
 			$this->define( 'UR_LOG_DIR', $upload_dir['basedir'] . '/ur-logs/' );
+			$this->define( 'UR_UPLOAD_PATH', $upload_dir['basedir'] . '/user_registration_uploads/' );
+			$this->define( 'UR_UPLOAD_URL', $upload_dir['baseurl'] . '/user_registration_uploads/' );
 			$this->define( 'UR_DS', DIRECTORY_SEPARATOR );
 			$this->define( 'UR_PLUGIN_FILE', __FILE__ );
 			$this->define( 'UR_ABSPATH', dirname( __FILE__ ) . UR_DS );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Previously, the upload folder path and URL were hardcoded where required. It caused issues in cases where the user had used a custom upload location instead of /uploads/ folder. So, In this PR, constants **UR_UPLOAD_PATH** and **UR_UPLOAD_URL** are created and replaced in places where the upload path and URLs were hardcoded.


### How to test the changes in this Pull Request:

1. Review the code.
2. Verify that all the upload functionalities are working properly or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> UR-929 Refactor - Create global constant for upload dir path and url
