### PR TITLE
UR-978 Enhance - One time draggable field locked message

### DIFF
--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -51,25 +51,53 @@ jQuery(function ($) {
 		e.preventDefault();
 		var icon =
 			'<i class="dashicons dashicons-lock" style="color:#72aee6; border-color: #72aee6;"></i>';
-		var field_data = $(this).data("field-data");
-		var title =
-			icon +
-			'<span class="user-registration-swal2-modal__title">' +
-			field_data.title +
-			"</span>";
-		Swal.fire({
-			title: title,
-			html: field_data.message,
-			showCloseButton: true,
-			customClass:
-				"user-registration-swal2-modal user-registration-swal2-modal--center user-registration-locked-field",
-			confirmButtonText: field_data.button_title,
-		}).then(function (result) {
-			if (result.value) {
-				var url = field_data.link;
-				window.open(url, "_blank");
-			}
-		});
+
+		if ($(this).hasClass("ur-one-time-draggable-disabled")) {
+			console.log($(this).find("span").text());
+			var title =
+					icon +
+					'<span class="user-registration-swal2-modal__title">' +
+					user_registration_form_builder_data.form_one_time_draggable_fields_locked_title.replace(
+						"%field%",
+						$(this).text()
+					) +
+					"</span>",
+				message =
+					user_registration_form_builder_data.form_one_time_draggable_fields_locked_message.replace(
+						"%field%",
+						$(this).text()
+					);
+
+			Swal.fire({
+				title: title,
+				html: message,
+				showCloseButton: true,
+				customClass:
+					"user-registration-swal2-modal user-registration-swal2-modal--center user-registration-locked-field",
+			}).then(function (result) {
+				// Do Nothing here.
+			});
+		} else {
+			var field_data = $(this).data("field-data");
+			var title =
+				icon +
+				'<span class="user-registration-swal2-modal__title">' +
+				field_data.title +
+				"</span>";
+			Swal.fire({
+				title: title,
+				html: field_data.message,
+				showCloseButton: true,
+				customClass:
+					"user-registration-swal2-modal user-registration-swal2-modal--center user-registration-locked-field",
+				confirmButtonText: field_data.button_title,
+			}).then(function (result) {
+				if (result.value) {
+					var url = field_data.link;
+					window.open(url, "_blank");
+				}
+			});
+		}
 	});
 	// Bind UI Actions for upgradable fields
 	$(document).on("mousedown", ".ur-upgradable-field", function (e) {

--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -53,7 +53,6 @@ jQuery(function ($) {
 			'<i class="dashicons dashicons-lock" style="color:#72aee6; border-color: #72aee6;"></i>';
 
 		if ($(this).hasClass("ur-one-time-draggable-disabled")) {
-			console.log($(this).find("span").text());
 			var title =
 					icon +
 					'<span class="user-registration-swal2-modal__title">' +

--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -1754,8 +1754,18 @@
 											).length > 0
 										) {
 											$this.draggable("disable");
+											$this.addClass("ur-locked-field");
+											$this.addClass(
+												"ur-one-time-draggable-disabled"
+											);
 										} else {
 											$this.draggable("enable");
+											$this.removeClass(
+												"ur-locked-field"
+											);
+											$this.removeClass(
+												"ur-one-time-draggable-disabled"
+											);
 										}
 									}
 								});

--- a/includes/admin/class-ur-admin-assets.php
+++ b/includes/admin/class-ur-admin-assets.php
@@ -310,6 +310,10 @@ class UR_Admin_Assets {
 				'admin_url'                              => admin_url( 'admin.php?page=add-new-registration&edit-registration=' ),
 				'form_required_fields'                   => ur_get_required_fields(),
 				'form_one_time_draggable_fields'         => ur_get_one_time_draggable_fields(),
+				/* translators: %field%: Field Label */
+				'form_one_time_draggable_fields_locked_title' => esc_html__( '%field% field is Locked.', 'user-registration' ),
+				/* translators: %field%: Field Label */
+				'form_one_time_draggable_fields_locked_message' => esc_html__( '%field% field can be used only one time in the form.', 'user-registration' ),
 				'i18n_admin'                             => self::get_i18n_admin_data(),
 				'i18n_shortcut_key_title'                => esc_html__( 'Keyboard Shortcut Keys', 'user-registration' ),
 				'i18n_shortcut_keys'                     => array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously when a user tries to drag already dragged one-time draggable fields that can be used only once in the form then it was only disabled, users were not given any hint that why they are not being able to drag those fields. This PR provides a message when a user tries to drag those fields.

### How to test the changes in this Pull Request:

1. Verify the above mentioned fix.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhance - One time draggable field locked message.
