### PR TITLE
UR-946 Fix -Max upload size option accepting  non-numeric, negative, and 0 as values

### DIFF
--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -4473,6 +4473,7 @@
 				update_input(input_value);
 			}
 		);
+
 		/**
 		 * For update the default value.
 		 */
@@ -4505,6 +4506,7 @@
 			target_textarea.val(input_value);
 			target_hidden_input.val(input_value);
 		}
+
 		/**
 		 * This block of code is for the "Selected Countries" option of "Country" field
 		 *
@@ -4604,6 +4606,36 @@
 
 				// Add select all button in dropdown
 				DropdownAdapter = Utils.Decorate(DropdownAdapter, SelectAll);
+			}
+		);
+
+		// Prevent invalid input for Max Upload Size setting and Maximum upload limit input.
+
+		$(document.body).on(
+			"input",
+			'[data-advance-field="max_upload_size"], [data-field="max_files"]',
+			function () {
+				var $this = $(this);
+				var inputValue = $this.val();
+				inputValue = inputValue.replace(/[^0-9]/g, "");
+				$this.val(inputValue);
+			}
+		);
+
+		$(document.body).on(
+			"focusout",
+			'[data-advance-field="max_upload_size"], [data-field="max_files"]',
+			function () {
+				var $this = $(this);
+				var inputValue = $this.val();
+
+				if ("" === inputValue || 0 === parseInt(inputValue)) {
+					inputValue = "";
+				} else {
+					inputValue = parseInt(inputValue); // Remove prefixing zeros(0).
+				}
+
+				$this.val(inputValue);
 			}
 		);
 	});


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously the max upload size option in the profile picture field accepted non-numeric, negative, and 0 as values. This Pr fixes this issue. Also in the file upload there was code to handle this, I have removed that code and added in core to handle both addons.

### How to test the changes in this Pull Request:

1. Check if the max upload size option accepts non-numeric, negative, and 0 as values. 

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix -Max upload size option accepting  non-numeric, negative, and 0 as values
