### PR TITLE
Fix - Required validation when entering 0 in number field

### DIFF
--- a/includes/validation/class-ur-validation.php
+++ b/includes/validation/class-ur-validation.php
@@ -27,7 +27,11 @@ class UR_Validation {
 	 * @return boolean or WP_Error.
 	 */
 	public static function required( $value ) {
-		if ( ! isset( $value ) ) {
+		if ( empty( $value ) ) {
+			if ( is_numeric( $value ) || '0' === $value ) {
+				return true;
+			}
+
 			return new WP_Error(
 				'user_registration_validation_empty_field',
 				__( 'Please enter a valid value', 'user-registration' )

--- a/includes/validation/class-ur-validation.php
+++ b/includes/validation/class-ur-validation.php
@@ -27,7 +27,7 @@ class UR_Validation {
 	 * @return boolean or WP_Error.
 	 */
 	public static function required( $value ) {
-		if ( empty( $value ) ) {
+		if ( ! isset( $value ) ) {
 			return new WP_Error(
 				'user_registration_validation_empty_field',
 				__( 'Please enter a valid value', 'user-registration' )


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When we submit the form by entering 0 in the number field. Then it gives the error Number field is required. This PR this issue.

### How to test the changes in this Pull Request:

1. Drag a number field in the form
2. Try to submit the form by entering 0 in the number field.
3. Verify whether the number field required error message is showing or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Fix - Required validation when entering 0 in number field.
