### PR TITLE
Fix - Validation error when range is used as payment field

### DIFF
--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -294,7 +294,7 @@ class UR_AJAX {
 				$field['type'] = 'text';
 			}
 			// Unset hidden field value.
-			if ( 'hidden' === $field['type'] && 'hidden' === $field['field_key'] || 'range' === $field['type'] && ur_string_to_bool( $field['enable_payment_slider'] ) ) {
+			if ( 'hidden' === $field['type'] && 'hidden' === $field['field_key'] || ( 'range' === $field['type'] && ur_string_to_bool( $field['enable_payment_slider'] ) ) ) {
 				$key = array_search( $field, $profile, true );
 				if ( false !== ( $key ) ) {
 					unset( $profile[ $key ] );

--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -294,7 +294,7 @@ class UR_AJAX {
 				$field['type'] = 'text';
 			}
 			// Unset hidden field value.
-			if ( 'hidden' === $field['type'] && 'hidden' === $field['field_key'] ) {
+			if ( 'hidden' === $field['type'] && 'hidden' === $field['field_key'] || 'range' === $field['type'] && ur_string_to_bool( $field['enable_payment_slider'] ) ) {
 				$key = array_search( $field, $profile, true );
 				if ( false !== ( $key ) ) {
 					unset( $profile[ $key ] );

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -811,6 +811,7 @@ if ( ! function_exists( 'user_registration_form_data' ) ) {
 					$custom_attributes      = isset( $field->general_setting->custom_attributes ) ? $field->general_setting->custom_attributes : array();
 					$enable_validate_unique = isset( $field->advance_setting->validate_unique ) ? $field->advance_setting->validate_unique : false;
 					$validate_message       = isset( $field->advance_setting->validation_message ) ? $field->advance_setting->validation_message : esc_html__( 'This field value need to be unique.', 'user-registration' );
+					$enable_payment_slider  = isset( $field->advance_setting->enable_payment_slider ) ? $field->advance_setting->enable_payment_slider : false;
 
 					if ( empty( $field_label ) ) {
 						$field_label_array = explode( '_', $field_name );
@@ -912,6 +913,10 @@ if ( ! function_exists( 'user_registration_form_data' ) ) {
 						if ( isset( $field->advance_setting->validate_unique ) ) {
 							$fields[ 'user_registration_' . $field_name ]['validate_unique']  = $enable_validate_unique;
 							$fields[ 'user_registration_' . $field_name ]['validate_message'] = $validate_message;
+						}
+
+						if ( isset( $field->advance_setting->enable_payment_slider ) ) {
+							$fields[ 'user_registration_' . $field_name ]['enable_payment_slider']  = $enable_payment_slider;
 						}
 
 						if ( isset( $fields[ 'user_registration_' . $field_name ] ) && count( $extra_params ) > 0 ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously, When the range field is used as a payment field and Ajax submission is enabled on the profile update then validation error is thrown. This PR will fix this issue.

### How to test the changes in this Pull Request:

1. Make the range field as payment field and make sure Ajax submission is enabled on the profile update.
2. Verify whether it is working as expected or not while saving profile details.

 ### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Validation error when range is used as payment field.
