### PR TITLE
Fix - Add new form and click on scratch and enter any name and cancel

### DIFF
--- a/assets/js/admin/ur-setup.js
+++ b/assets/js/admin/ur-setup.js
@@ -1092,6 +1092,7 @@ jQuery(function ($) {
 					return false;
 				},
 			}).then(function (result) {
+				if(result.isConfirmed) {
 				if ($(".user-registration-template-continue").length > 0) {
 					var $formName = $("#user-registration-setup-name");
 
@@ -1128,7 +1129,8 @@ jQuery(function ($) {
 						});
 					});
 				}
-			});
+			}
+		});
 		},
 		input_keypress: function (e) {
 			var button = e.keyCode || e.which;


### PR DESCRIPTION

### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Previously, When you add a new form and click on scratch and enter any name and cancel the process then the state has been created. This PR fixes this issue.

### How to test the changes in this Pull Request:

1. Goto add form.
2. Click on scratch and enter any name
3. Then cancel the pop and verify form is created or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?


### Changelog entry

> Fix - Add new form and click on scratch and enter any name and cancel the process the form will be created..
