### PR TITLE
UR-1083 Fix - Make login shortcode compatible with all editors

### DIFF
--- a/includes/frontend/class-ur-frontend.php
+++ b/includes/frontend/class-ur-frontend.php
@@ -194,68 +194,25 @@ class UR_Frontend {
 		$login_page     = get_post( get_option( 'user_registration_login_options_login_redirect_url', 'unset' ) );
 		$myaccount_page = get_post( get_option( 'user_registration_myaccount_page_id' ) );
 		$matched        = 0;
+		$page_id = 0;
 
 		if ( ( isset( $_POST['learndash-login-form'] ) || isset( $_POST['learndash-registration-form'] ) ) ) { //phpcs:ignore
 			return;
 		}
 
 		if ( ! empty( $login_page ) ) {
-			$shortcodes = parse_blocks( $login_page->post_content );
-			foreach ( $shortcodes as $shortcode ) {
-				if ( ! empty( $shortcode['blockName'] ) ) {
-					if ( 'user-registration/form-selector' === $shortcode['blockName'] && isset( $shortcode['attrs']['shortcode'] ) ) {
-						$matched = 1;
-						break;
-					} elseif ( ( 'core/shortcode' === $shortcode['blockName'] || 'core/paragraph' === $shortcode['blockName'] ) && isset( $shortcode['innerHTML'] ) ) {
-						$matched = preg_match( '/\[user_registration_my_account(\s\S+){0,3}\]|\[user_registration_login(\s\S+){0,3}\]/', $shortcode['innerHTML'] );
-						if ( 1 > absint( $matched ) ) {
-							$matched = preg_match( '/\[woocommerce_my_account(\s\S+){0,3}\]/', $shortcode['innerHTML'] );
-						}
-						if ( 0 < absint( $matched ) ) {
-							break;
-						}
-					}
-				} else {
-					$matched = preg_match( '/\[user_registration_my_account(\s\S+){0,3}\]|\[user_registration_login(\s\S+){0,3}\]/', $login_page->post_content );
-					if ( 1 > absint( $matched ) ) {
-						$matched = preg_match( '/\[woocommerce_my_account(\s\S+){0,3}\]/', $login_page->post_content );
-					}
-					if ( 0 < absint( $matched ) ) {
-						break;
-					}
-				}
+			$matched    = ur_find_my_account_in_page( $login_page->ID );
+			if ( $matched > 0 ) {
+				$page_id = $login_page->ID;
 			}
-			$page_id = $login_page->ID;
-		} elseif ( ! empty( $myaccount_page ) ) {
-			$shortcodes = parse_blocks( $myaccount_page->post_content );
-			foreach ( $shortcodes as $shortcode ) {
-				if ( ! empty( $shortcode['blockName'] ) ) {
-					if ( 'user-registration/form-selector' === $shortcode['blockName'] && isset( $shortcode['attrs']['shortcode'] ) ) {
-						$matched = 1;
-						break;
-					} elseif ( ( 'core/shortcode' === $shortcode['blockName'] || 'core/paragraph' === $shortcode['blockName'] ) && isset( $shortcode['innerHTML'] ) ) {
-						$matched = preg_match( '/\[user_registration_my_account(\s\S+){0,3}\]|\[user_registration_login(\s\S+){0,3}\]/', $shortcode['innerHTML'] );
-						if ( 1 > absint( $matched ) ) {
-							$matched = preg_match( '/\[woocommerce_my_account(\s\S+){0,3}\]/', $shortcode['innerHTML'] );
-						}
-						if ( 0 < absint( $matched ) ) {
-							break;
-						}
-					}
-				} else {
-					$matched = preg_match( '/\[user_registration_my_account(\s\S+){0,3}\]|\[user_registration_login(\s\S+){0,3}\]/', $myaccount_page->post_content );
-					if ( 1 > absint( $matched ) ) {
-						$matched = preg_match( '/\[woocommerce_my_account(\s\S+){0,3}\]/', $myaccount_page->post_content );
-					}
-					if ( 0 < absint( $matched ) ) {
-						break;
-					}
-				}
+		} elseif ( ! empty( $myaccount_page ) && 0 !== $page_id ) {
+			$matched    = ur_find_my_account_in_page( $myaccount_page->ID );
+			if ( $matched > 0 ) {
+				$page_id = $myaccount_page->ID;
 			}
-			$page_id = $myaccount_page->ID;
 		}
 
-		if ( ! ( defined( 'UR_DISABLE_PREVENT_CORE_LOGIN' ) && true === UR_DISABLE_PREVENT_CORE_LOGIN ) && ur_option_checked( 'user_registration_login_options_prevent_core_login', false ) && 1 <= absint( $matched ) ) {
+		if ( ! ( defined( 'UR_DISABLE_PREVENT_CORE_LOGIN' ) && true === UR_DISABLE_PREVENT_CORE_LOGIN ) && ur_option_checked( 'user_registration_login_options_prevent_core_login', false ) && 0 < absint( $matched ) ) {
 
 			// Redirect to core login reset password page on multisite.
 			if ( is_multisite() && ( 'lostpassword' === $action || 'resetpass' === $action ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Previously, We were using preg match to find shortcode in the post content but by doing that not all editors was compatible such as oxygen editor. This oxygen editor is not saving data in the post content it saves in the post meta table. This PR will make all editors compatible.

### How to test the changes in this Pull Request:

1. Enter Shortcode by edit with oxygen builder.
2. Disable Wordpress Default Login.( Prevent core login ) enable this option and select the my account page.
3. Verify whether the Wordpress default login was redirect to myaccount page or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Make login shortcode compatible with all editors.
