### PR TITLE
UR-989 Feature - User registered language with smart tag.

### DIFF
--- a/includes/class-ur-smart-tags.php
+++ b/includes/class-ur-smart-tags.php
@@ -58,24 +58,25 @@ class UR_Smart_Tags {
 	 */
 	public static function ur_unauthenticated_parsable_smart_tags_list() {
 		$smart_tags = array(
-			'{{blog_info}}'       => esc_html__( 'Blog Info', 'user-registration' ),
-			'{{home_url}}'        => esc_html__( 'Home URL', 'user-registration' ),
-			'{{admin_email}}'     => esc_html__( 'Site Admin Email', 'user-registration' ),
-			'{{site_name}}'       => esc_html__( 'Site Name', 'user-registration' ),
-			'{{site_url}}'        => esc_html__( 'Site URL', 'user-registration' ),
-			'{{page_title}}'      => esc_html__( 'Page Title', 'user-registration' ),
-			'{{page_url}}'        => esc_html__( 'Page URL', 'user-registration' ),
-			'{{page_id}}'         => esc_html__( 'Page ID', 'user-registration' ),
-			'{{post_title}}'      => esc_html__( 'Post Title', 'user-registration' ),
-			'{{current_date}}'    => esc_html__( 'Current Date', 'user-registration' ),
-			'{{current_time}}'    => esc_html__( 'Current Time', 'user-registration' ),
-			'{{email_token}}'     => esc_html__( 'Email Token', 'user-registration' ),
-			'{{key}}'             => esc_html__( 'Key', 'user-registration' ),
-			'{{user_ip_address}}' => esc_html__( 'User IP Address', 'user-registration' ),
-			'{{referrer_url}}'    => esc_html__( 'Referrer URL', 'user-registration' ),
-			'{{form_id}}'         => esc_html__( 'Form ID', 'user-registration' ),
-			'{{author_email}}'    => esc_html__( 'Author Email', 'user-registration' ),
-			'{{author_name}}'     => esc_html__( 'Author Name', 'user-registration' ),
+			'{{blog_info}}'        => esc_html__( 'Blog Info', 'user-registration' ),
+			'{{home_url}}'         => esc_html__( 'Home URL', 'user-registration' ),
+			'{{admin_email}}'      => esc_html__( 'Site Admin Email', 'user-registration' ),
+			'{{site_name}}'        => esc_html__( 'Site Name', 'user-registration' ),
+			'{{site_url}}'         => esc_html__( 'Site URL', 'user-registration' ),
+			'{{page_title}}'       => esc_html__( 'Page Title', 'user-registration' ),
+			'{{page_url}}'         => esc_html__( 'Page URL', 'user-registration' ),
+			'{{page_id}}'          => esc_html__( 'Page ID', 'user-registration' ),
+			'{{post_title}}'       => esc_html__( 'Post Title', 'user-registration' ),
+			'{{current_date}}'     => esc_html__( 'Current Date', 'user-registration' ),
+			'{{current_time}}'     => esc_html__( 'Current Time', 'user-registration' ),
+			'{{current_language}}' => esc_html__( 'Current Language', 'user-registration' ),
+			'{{email_token}}'      => esc_html__( 'Email Token', 'user-registration' ),
+			'{{key}}'              => esc_html__( 'Key', 'user-registration' ),
+			'{{user_ip_address}}'  => esc_html__( 'User IP Address', 'user-registration' ),
+			'{{referrer_url}}'     => esc_html__( 'Referrer URL', 'user-registration' ),
+			'{{form_id}}'          => esc_html__( 'Form ID', 'user-registration' ),
+			'{{author_email}}'     => esc_html__( 'Author Email', 'user-registration' ),
+			'{{author_name}}'      => esc_html__( 'Author Name', 'user-registration' ),
 		);
 		return apply_filters( 'user_registration_unauthenticated_smart_tags', $smart_tags );
 	}
@@ -292,6 +293,11 @@ class UR_Smart_Tags {
 					case 'current_time':
 						$current_time = date_i18n( get_option( 'time_format' ) );
 						$content      = str_replace( '{{' . $other_tag . '}}', sanitize_text_field( $current_time ), $content );
+						break;
+
+					case 'current_language':
+						$current_language =  ur_get_current_language();
+						$content      = str_replace( '{{' . $other_tag . '}}', sanitize_text_field( $current_language ), $content );
 						break;
 
 					case 'post_title':

--- a/includes/frontend/class-ur-frontend-form-handler.php
+++ b/includes/frontend/class-ur-frontend-form-handler.php
@@ -228,8 +228,10 @@ class UR_Frontend_Form_Handler {
 				}
 				update_user_meta( $user_id, $field_name, $data->value );
 			}
-			update_user_meta( $user_id, 'ur_form_id', $form_id );
 		}
+		update_user_meta( $user_id, 'ur_form_id', $form_id );
+		$current_language = ur_get_current_language();
+		update_user_meta( $user_id, 'ur_registered_language', $current_language );
 	}
 }
 return new UR_Frontend_Form_Handler();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When the admin approves the user, our plugin sends the approval email according to the default language. If the admin switches the dashboard language using the plugin language switcher and approves the user still, the default email will send instead of translated email. To resolve this issue in this PR we are storing the current language while user registration and also we can map the current language in the field via smart tag.

### How to test the changes in this Pull Request:

1. Register an user and check in the database usermeta table where you can see new meta key called **ur_registered_language** 
2. Goto form builder and in input box field in field option select smart tag called Current Language in the default box.
3. check whether current language is set in that field or not.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Feature - User registered language with smart tag.
