### PR TITLE
UR-1116 Fix - Lost Password not working for translated myaccount page.

### DIFF
--- a/includes/functions-ur-page.php
+++ b/includes/functions-ur-page.php
@@ -62,22 +62,16 @@ function ur_get_page_id( $page ) {
 	 * Check if the page sent as parameter is My Account page and return the id,
 	 * Else use the page's page_id sent as parameter.
 	 */
-	if ( 'myaccount' === $page && ur_post_content_has_shortcode( 'user_registration_my_account' ) && $page_id === $my_account_page_id ) {
-		$page = $page_id;
-	} elseif ( 'myaccount' !== $page && ur_post_content_has_shortcode( 'user_registration_login' ) && $page_id !== $my_account_page_id ) {
-		$page = $page_id;
-	} else {
-		$page = apply_filters( 'user_registration_get_' . $page . '_page_id', get_option( 'user_registration_' . $page . '_page_id' ) );
-	}
+	$page = ur_find_my_account_in_page( $page_id );
 
 	if ( $page > 0 && function_exists( 'pll_current_language' ) ) {
 		$current_language = pll_current_language();
 		if ( ! empty( $current_language ) ) {
-			$translations = pll_get_post_translations( $page );
-			$page         = isset( $translations[ pll_current_language() ] ) ? $translations[ pll_current_language() ] : $page;
+			$translations = pll_get_post_translations( $page_id );
+			$page         = isset( $translations[ pll_current_language() ] ) ? $translations[ pll_current_language() ] : $page_id;
 		}
 	} elseif ( $page > 0 && has_filter( 'wpml_current_language' ) ) {
-		$page = ur_get_wpml_page_language( $page );
+		$page = ur_get_wpml_page_language( $page_id );
 	}
 
 	return $page ? absint( $page ) : - 1;
@@ -268,13 +262,13 @@ function ur_nav_menu_items( $items ) {
 				if ( empty( $item->url ) ) {
 					continue;
 				}
-				$path  = parse_url( $item->url, PHP_URL_PATH );
-				$query = parse_url( $item->url, PHP_URL_QUERY );
+				$path  = parse_url( $item->url, PHP_URL_PATH ) ?? '';
+				$query = parse_url( $item->url, PHP_URL_QUERY ) ?? '';
 
-				if ( null !== $path && null !== $customer_logout ) {
-					if ( strstr( $path, $customer_logout ) || strstr( $query, $customer_logout ) ) {
+				$customer_logout = $customer_logout ?? '';
+
+				if (strstr($path, $customer_logout) !== false || strstr($query, $customer_logout) !== false) {
 						unset( $items[ $key ] );
-					}
 				}
 			}
 		}

--- a/includes/functions-ur-page.php
+++ b/includes/functions-ur-page.php
@@ -56,7 +56,7 @@ add_filter( 'the_title', 'ur_page_endpoint_title', 10 );
  */
 function ur_get_page_id( $page ) {
 	$my_account_page_id = get_option( 'user_registration_myaccount_page_id' );
-	$page_id            = get_the_ID();
+	$page_id            = get_the_ID() ? get_the_ID() : $my_account_page_id;
 
 	/**
 	 * Check if the page sent as parameter is My Account page and return the id,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When we request for lost password via different language then Reset Password link in email is valid but when you click on that link it say's invalid key and it will not allow to reset new password. This issue is fixed in this PR.

### How to test the changes in this Pull Request:

1. Translate My Account Page and Request for Reset password.
2. You will get reset password link in email.
3. when you click on that link then you should allow to reset new password page.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Lost Password not working for translated myaccount page.
