### PR TITLE
UR-1121 Fix - Conflict with TranslatePress

### DIFF
--- a/includes/functions-ur-page.php
+++ b/includes/functions-ur-page.php
@@ -76,7 +76,7 @@ function ur_get_page_id( $page ) {
 			$translations = pll_get_post_translations( $page );
 			$page         = isset( $translations[ pll_current_language() ] ) ? $translations[ pll_current_language() ] : $page;
 		}
-	} elseif ( $page > 0 && has_filter( 'wpml_current_language' ) ) {
+	} elseif ( $page > 0 && class_exists( 'SitePress', false ) ) {
 		$page = ur_get_wpml_page_language( $page );
 	}
 
@@ -116,7 +116,7 @@ function ur_get_page_permalink( $page ) {
 			$translations = pll_get_post_translations( $page_id );
 			$page         = isset( $translations[ pll_current_language() ] ) ? $translations[ pll_current_language() ] : $page_id;
 		}
-	} elseif ( $page_id > 0 && has_filter( 'wpml_current_language' ) ) {
+	} elseif ( $page_id > 0 && class_exists( 'SitePress', false ) ) {
 		$page = ur_get_wpml_page_language( $page_id );
 	}
 
@@ -140,7 +140,7 @@ if ( ! function_exists( 'ur_get_login_url' ) ) {
 				$translations       = pll_get_post_translations( $my_account_page_id );
 				$my_account_page_id = isset( $translations[ pll_current_language() ] ) ? $translations[ pll_current_language() ] : $my_account_page_id;
 			}
-		} elseif ( $my_account_page_id > 0 && has_filter( 'wpml_current_language' ) ) {
+		} elseif ( $my_account_page_id > 0 && class_exists( 'SitePress', false ) ) {
 			$my_account_page_id = ur_get_wpml_page_language( $my_account_page_id );
 		}
 
@@ -170,7 +170,7 @@ if ( ! function_exists( 'ur_get_my_account_url' ) ) {
 				$translations       = pll_get_post_translations( $my_account_page_id );
 				$my_account_page_id = isset( $translations[ pll_current_language() ] ) ? $translations[ pll_current_language() ] : $my_account_page_id;
 			}
-		} elseif ( $my_account_page_id > 0 && has_filter( 'wpml_current_language' ) ) {
+		} elseif ( $my_account_page_id > 0 && class_exists( 'SitePress', false ) ) {
 			$my_account_page_id = ur_get_wpml_page_language( $my_account_page_id );
 		}
 
@@ -205,7 +205,7 @@ if ( ! function_exists( 'ur_get_current_language' ) ) {
 
 		if ( function_exists( 'pll_current_language' ) ) {
 			$current_language = pll_current_language();
-		} elseif ( has_filter( 'wpml_current_language' ) ) {
+		} elseif ( class_exists( 'SitePress', false ) ) {
 			$current_language = apply_filters( 'wpml_current_language', $current_language );
 		}
 		return $current_language;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When WPML plugin is not installed and TranslatePress plugin activated then got undefined function error. Issue occurs due to previously we were checking wpml installed or not using has_filter but the same filter was used by the TranslatePress then our plugin detect that wpml is installed and it called icl function which is in the wpml plugin and since wpml plugin is not installed then it throws error. This PR fixes this issue.

### How to test the changes in this Pull Request:

1. Install TranslatePress plugin and then translate myaccount page
2. Try to open myaccount page in different language and validate whether you are not getting any error.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Conflict with TranslatePress.
