### PR TITLE
UR-1052 Enhance - Custom hold time before redirection after registration

### DIFF
--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -552,6 +552,18 @@ jQuery(function ($) {
 		}
 	};
 
+	/**
+	 * Prevent negative input for Waiting Period Before Redirection setting.
+	 */
+	$('#user_registration_form_setting_redirect_after').on('change input paste', function (e) {
+		e.preventDefault();
+		e.stopPropagation();
+
+		var $this = $(e.target);
+
+		$this.val(Math.abs($this.val()));
+	});
+
 	// Tooltips
 	$(document.body)
 		.on("init_tooltips", function () {

--- a/includes/frontend/class-ur-frontend-form-handler.php
+++ b/includes/frontend/class-ur-frontend-form-handler.php
@@ -131,8 +131,11 @@ class UR_Frontend_Form_Handler {
 				}
 				$success_params['success_message_positon'] = ur_get_single_post_meta( $form_id, 'user_registration_form_setting_success_message_position', '1' );
 				$success_params['form_login_option']       = $login_option;
-				$success_params['redirect_timeout']        = apply_filters( 'user_registration_hold_success_message_before_redirect', 2000 );
-				$success_params                            = apply_filters( 'user_registration_success_params', $success_params, self::$valid_form_data, $form_id, $user_id );
+
+				$redirect_timeout = (int) ur_get_single_post_meta( $form_id, 'user_registration_form_setting_redirect_after', '2' ) * 1000;
+
+				$success_params['redirect_timeout'] = apply_filters( 'user_registration_hold_success_message_before_redirect', $redirect_timeout );
+				$success_params                     = apply_filters( 'user_registration_success_params', $success_params, self::$valid_form_data, $form_id, $user_id );
 
 				if ( isset( $_POST['ur_stripe_payment_method'] ) ) { //phpcs:ignore WordPress.Security.NonceVerification
 					wp_send_json_success( $success_params );

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -1152,6 +1152,18 @@ function ur_admin_form_settings_fields( $form_id ) {
 				'default'           => ur_get_single_post_meta( $form_id, 'user_registration_form_setting_redirect_options', get_option( 'user_registration_general_setting_redirect_options', '' ) ),  // Getting redirect options from global settings for backward compatibility.
 				'tip'               => __( 'This option lets you enter redirect path after successful user registration.', 'user-registration' ),
 			),
+			array(
+				'type'              => 'number',
+				'label'             => __( 'Waiting Period Before Redirection ( In seconds )', 'user-registration' ),
+				'description'       => '',
+				'required'          => false,
+				'id'                => 'user_registration_form_setting_redirect_after',
+				'class'             => array(),
+				'input_class'       => array(),
+				'custom_attributes' => array(),
+				'default'           => ur_get_single_post_meta( $form_id, 'user_registration_form_setting_redirect_after', '2' ),
+				'tip'               => __( 'Time to wait after registration before redirecting user to another page.', 'user-registration' ),
+			),
 		),
 	);
 

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -1161,6 +1161,7 @@ function ur_admin_form_settings_fields( $form_id ) {
 				'class'             => array(),
 				'input_class'       => array(),
 				'custom_attributes' => array(),
+				'min'               => '0',
 				'default'           => ur_get_single_post_meta( $form_id, 'user_registration_form_setting_redirect_after', '2' ),
 				'tip'               => __( 'Time to wait after registration before redirecting user to another page.', 'user-registration' ),
 			),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a form setting to set hold period before redirecting the user to another page. By default, the hold period is set to 2 seconds.

### How to test the changes in this Pull Request:

1.  Without making any changes to the setting, check how many seconds the user is held before redirecting the user.
2. Now, change the setting to any value you like and see if the user is being held for the specified period.
3. Test for cases of Autologin, Redirection after Registration, and Paypal Payment.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> UR-1052 Enhance - Custom hold time before redirection after registration
