### PR TITLE
UR-1130 Fix - Incorrect filtering of pending users

### DIFF
--- a/includes/admin/class-ur-admin-user-list-manager.php
+++ b/includes/admin/class-ur-admin-user-list-manager.php
@@ -187,20 +187,34 @@ class UR_Admin_User_List_Manager {
 				'relation' => 'AND',
 				array(
 					'key'     => 'ur_user_status',
-					'value'   => 0,
+					'value'   => '0',
 					'compare' => '=',
 				),
 				array(
-					'relation' => 'OR',
+					'relation' => 'AND',
 					array(
-						'key'     => 'ur_confirm_email',
-						'value'   => '0',
-						'compare' => '!=',
+						'relation' => 'OR',
+						array(
+							'key'     => 'ur_confirm_email',
+							'value'   => '0',
+							'compare' => '!=',
+						),
+						array(
+							'key'     => 'ur_confirm_email',
+							'compare' => 'NOT EXISTS',
+						),
 					),
 					array(
-						'key'     => 'ur_admin_approval_after_email_confirmation',
-						'value'   => 'false',
-						'compare' => '!=',
+						'relation' => 'OR',
+						array(
+							'key'     => 'ur_admin_approval_after_email_confirmation',
+							'value'   => 'false',
+							'compare' => '=',
+						),
+						array(
+							'key'     => 'ur_admin_approval_after_email_confirmation',
+							'compare' => 'NOT EXISTS',
+						),
 					),
 				),
 			),
@@ -306,11 +320,13 @@ class UR_Admin_User_List_Manager {
 			$user_manager = new UR_Admin_User_Manager( $user_id );
 			$status       = $user_manager->get_user_status();
 
-			if ( '0' == $status['user_status'] ) {
-				if ( in_array( $status['login_option'], array( 'email_confirmation', 'admin_approval_after_email_confirmation' ), true ) ) {
+			if ( in_array( $status['login_option'], array( 'email_confirmation', 'admin_approval_after_email_confirmation' ), true ) ) {
+				if ( '0' == $status['approval_status'] || '' == $status['approval_status'] ) {
 					if ( 0 == $status['email_status'] || 'false' == $status['email_status'] ) {
 						return __( 'Awaiting Email Confirmation', 'user-registration' );
 					}
+				} elseif ( '-1' == $status['approval_status'] ) {
+					return UR_Admin_User_Manager::get_status_label( '-1' );
 				}
 			}
 

--- a/includes/admin/class-ur-admin-user-list-manager.php
+++ b/includes/admin/class-ur-admin-user-list-manager.php
@@ -184,16 +184,24 @@ class UR_Admin_User_List_Manager {
 
 		$args = array(
 			'meta_query' => array(
-				'relation' => 'OR',
+				'relation' => 'AND',
 				array(
 					'key'     => 'ur_user_status',
 					'value'   => 0,
 					'compare' => '=',
 				),
 				array(
-					'key'     => 'ur_confirm_email',
-					'value'   => 0,
-					'compare' => '=',
+					'relation' => 'OR',
+					array(
+						'key'     => 'ur_confirm_email',
+						'value'   => '0',
+						'compare' => '!=',
+					),
+					array(
+						'key'     => 'ur_admin_approval_after_email_confirmation',
+						'value'   => 'false',
+						'compare' => '!=',
+					),
 				),
 			),
 		);
@@ -297,6 +305,14 @@ class UR_Admin_User_List_Manager {
 		if ( 'ur_user_user_status' === $column_name ) {
 			$user_manager = new UR_Admin_User_Manager( $user_id );
 			$status       = $user_manager->get_user_status();
+
+			if ( '0' == $status['user_status'] ) {
+				if ( in_array( $status['login_option'], array( 'email_confirmation', 'admin_approval_after_email_confirmation' ), true ) ) {
+					if ( 0 == $status['email_status'] || 'false' == $status['email_status'] ) {
+						return __( 'Awaiting Email Confirmation', 'user-registration' );
+					}
+				}
+			}
 
 			if ( ! empty( $status ) ) {
 				return UR_Admin_User_Manager::get_status_label( $status['user_status'] );

--- a/includes/admin/class-ur-admin-user-list-manager.php
+++ b/includes/admin/class-ur-admin-user-list-manager.php
@@ -363,6 +363,8 @@ class UR_Admin_User_List_Manager {
 		$pending_label  = UR_Admin_User_Manager::get_status_label( UR_Admin_User_Manager::PENDING );
 		$denied_label   = UR_Admin_User_Manager::get_status_label( UR_Admin_User_Manager::DENIED );
 
+		$pending_email_label = __( 'Awaiting Email Confirmation', 'user-registration' );
+
 		?>
 		</div><!-- .alignleft.actions opened in extra_tablenav() - class-wp-users-list-table.php:259 -->
 		<div class="alignleft actions">
@@ -376,6 +378,7 @@ class UR_Admin_User_List_Manager {
 		echo '<option value="approved" ' . esc_attr( selected( 'approved', $status_filter_value ) ) . '>' . esc_html( $approved_label ) . '</option>';
 		echo '<option value="pending" ' . esc_attr( selected( 'pending', $status_filter_value ) ) . '>' . esc_html( $pending_label ) . '</option>';
 		echo '<option value="denied" ' . esc_attr( selected( 'denied', $status_filter_value ) ) . '>' . esc_html( $denied_label ) . '</option>';
+		echo '<option value="pending_email" ' . esc_attr( selected( 'pending_email', $status_filter_value ) ) . '>' . esc_html( $pending_email_label ) . '</option>';
 		?>
 		</select>
 
@@ -445,6 +448,8 @@ class UR_Admin_User_List_Manager {
 				case 'denied':
 					$status = UR_Admin_User_Manager::DENIED;
 					break;
+				case 'pending_email':
+					break;
 				default:
 					return;
 			}
@@ -477,6 +482,10 @@ class UR_Admin_User_List_Manager {
 					),
 				);
 			}
+		}
+
+		if ( 'pending_email' == $status ) {
+			$meta_query = $this->get_pending_email_meta_query();
 		}
 
 		// Deduct meta_query to filter user according to form id and approval status set.
@@ -685,6 +694,41 @@ class UR_Admin_User_List_Manager {
 							'key'     => 'ur_admin_approval_after_email_confirmation',
 							'compare' => 'NOT EXISTS',
 						),
+					),
+				),
+			),
+		);
+
+		return $meta_query;
+	}
+
+	/**
+	 * Returns meta query array to fetch email pending users.
+	 *
+	 * @return array
+	 */
+	private function get_pending_email_meta_query() {
+		$meta_query = array(
+			'meta_query' => array(
+
+				array(
+					'relation' => 'AND',
+					array(
+						'relation' => 'OR',
+						array(
+							'key'     => 'ur_user_status',
+							'compare' => 'NOT EXISTS',
+						),
+						array(
+							'key'     => 'ur_user_status',
+							'value'   => '0',
+							'compare' => '=',
+						),
+					),
+					array(
+						'key'     => 'ur_confirm_email',
+						'value'   => '0',
+						'compare' => '=',
 					),
 				),
 			),

--- a/includes/admin/class-ur-admin-user-list-manager.php
+++ b/includes/admin/class-ur-admin-user-list-manager.php
@@ -481,11 +481,11 @@ class UR_Admin_User_List_Manager {
 						'value' => UR_Admin_User_Manager::APPROVED,
 					),
 				);
+			} elseif ( UR_Admin_User_Manager::DENIED == $status ) {
+				$meta_query = $this->get_denied_users_meta_query();
+			} elseif ( 'pending_email' == $status ) {
+				$meta_query = $this->get_pending_email_meta_query();
 			}
-		}
-
-		if ( 'pending_email' == $status ) {
-			$meta_query = $this->get_pending_email_meta_query();
 		}
 
 		// Deduct meta_query to filter user according to form id and approval status set.
@@ -695,6 +695,31 @@ class UR_Admin_User_List_Manager {
 							'compare' => 'NOT EXISTS',
 						),
 					),
+				),
+			),
+		);
+
+		return $meta_query;
+	}
+
+	/**
+	 * Returns meta query array to fetch denied users.
+	 *
+	 * @return array
+	 */
+	private function get_denied_users_meta_query() {
+		$meta_query = array(
+			'meta_query' => array(
+				'relation' => 'OR',
+				array(
+					'key'     => 'ur_user_status',
+					'value'   => '-1',
+					'compare' => '=',
+				),
+				array(
+					'key'     => 'ur_confirm_email',
+					'value'   => '-1',
+					'compare' => '=',
 				),
 			),
 		);

--- a/includes/admin/class-ur-admin-user-list-manager.php
+++ b/includes/admin/class-ur-admin-user-list-manager.php
@@ -182,43 +182,7 @@ class UR_Admin_User_List_Manager {
 	 */
 	public function user_registration_pending_users_notices() {
 
-		$args = array(
-			'meta_query' => array(
-				'relation' => 'AND',
-				array(
-					'key'     => 'ur_user_status',
-					'value'   => '0',
-					'compare' => '=',
-				),
-				array(
-					'relation' => 'AND',
-					array(
-						'relation' => 'OR',
-						array(
-							'key'     => 'ur_confirm_email',
-							'value'   => '0',
-							'compare' => '!=',
-						),
-						array(
-							'key'     => 'ur_confirm_email',
-							'compare' => 'NOT EXISTS',
-						),
-					),
-					array(
-						'relation' => 'OR',
-						array(
-							'key'     => 'ur_admin_approval_after_email_confirmation',
-							'value'   => 'false',
-							'compare' => '=',
-						),
-						array(
-							'key'     => 'ur_admin_approval_after_email_confirmation',
-							'compare' => 'NOT EXISTS',
-						),
-					),
-				),
-			),
-		);
+		$args = $this->get_pending_users_meta_query();
 
 		// Remove previously set filter to get exact pending users count.
 		remove_filter( 'pre_get_users', array( $this, 'filter_users_by_approval_status' ) );
@@ -485,19 +449,7 @@ class UR_Admin_User_List_Manager {
 					return;
 			}
 
-			$meta_query = array(
-				'relation' => 'OR',
-				array(
-					'key'     => 'ur_user_status',
-					'value'   => $status,
-					'compare' => '=',
-				),
-				array(
-					'key'     => 'ur_confirm_email',
-					'value'   => $status,
-					'compare' => '=',
-				),
-			);
+			$meta_query = $this->get_pending_users_meta_query();
 
 			if ( UR_Admin_User_Manager::APPROVED === $status ) {
 				$meta_query = array(
@@ -692,6 +644,53 @@ class UR_Admin_User_List_Manager {
 			$new_status = sanitize_text_field( wp_unslash( $_POST['ur_user_email_confirmation_status'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
 			return update_user_meta( absint( $user_id ), 'ur_confirm_email', $new_status );
 		}
+	}
+
+	/**
+	 * Returns meta query array to fetch pending users.
+	 *
+	 * @return array
+	 */
+	private function get_pending_users_meta_query() {
+		$meta_query = array(
+			'meta_query' => array(
+				'relation' => 'AND',
+				array(
+					'key'     => 'ur_user_status',
+					'value'   => '0',
+					'compare' => '=',
+				),
+				array(
+					'relation' => 'AND',
+					array(
+						'relation' => 'OR',
+						array(
+							'key'     => 'ur_confirm_email',
+							'value'   => '0',
+							'compare' => '!=',
+						),
+						array(
+							'key'     => 'ur_confirm_email',
+							'compare' => 'NOT EXISTS',
+						),
+					),
+					array(
+						'relation' => 'OR',
+						array(
+							'key'     => 'ur_admin_approval_after_email_confirmation',
+							'value'   => 'false',
+							'compare' => '=',
+						),
+						array(
+							'key'     => 'ur_admin_approval_after_email_confirmation',
+							'compare' => 'NOT EXISTS',
+						),
+					),
+				),
+			),
+		);
+
+		return $meta_query;
 	}
 }
 

--- a/includes/admin/class-ur-admin-user-manager.php
+++ b/includes/admin/class-ur-admin-user-manager.php
@@ -202,16 +202,20 @@ class UR_Admin_User_Manager {
 			$this->user_status = $admin_approval_after_email_confirmation_status;
 
 			$result = array(
-				'login_option' => 'admin_approval_after_email_confirmation',
-				'user_status'  => $admin_approval_after_email_confirmation_status,
+				'login_option'    => 'admin_approval_after_email_confirmation',
+				'user_status'     => $admin_approval_after_email_confirmation_status,
+				'email_status'    => $user_email_status,
+				'approval_status' => $admin_approval_after_email_confirmation_status,
 			);
 		} elseif ( ( '' === $user_status && '' !== $user_email_status ) || ( '' !== $user_status && '' !== $user_email_status ) ) {
 
 			$this->user_status = $user_email_status;
 
 			$result = array(
-				'login_option' => 'email_confirmation',
-				'user_status'  => $user_email_status,
+				'login_option'    => 'email_confirmation',
+				'user_status'     => $user_email_status,
+				'email_status'    => $user_email_status,
+				'approval_status' => $user_status,
 			);
 		}
 		return $result;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Previously, there was an issue with the counting of pending users. When the pending user was denied, the pending notice still showed the same number of pending users. This PR fixes that and filters pending users properly. Also, a new label '**_Awaiting Email Confirmation'_** is added for users who have not confirmed their email instead of just _**Pending.**_

### How to test the changes in this Pull Request:

1. Test the above-mentioned changes with different login options.
2. Make sure that the reported issues are fixed.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> UR-1130 Fix - Incorrect filtering of pending users
