### PR TITLE
UR-1170 Fix - User fields not saving

### DIFF
--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -3886,14 +3886,14 @@ if ( ! function_exists( 'user_registration_conditional_user_meta_filter') ) {
 	 */
 	function user_registration_conditional_user_meta_filter( $valid_form_data, $user_id, $form_id ) {
 		if ( $user_id <= 0 ) {
-			return;
+			return $valid_form_data;
 		}
 
 		$field_name   = '';
-		$hidden_field = $_POST['urcl_hide_fields'];
+		$hidden_field = isset( $_POST['urcl_hide_fields'] ) ? ur_clean( $_POST['urcl_hide_fields'] ) : array();
 
-		if ( ! isset( $hidden_field ) ) {
-			return;
+		if ( empty( $hidden_field ) ) {
+			return $valid_form_data;
 		}
 
 		$hidden_array_field = json_decode( stripslashes( $hidden_field ) );

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -660,6 +660,8 @@ if ( ! function_exists( 'ur_get_field_name_with_prefix_usermeta' ) ) {
 	/**
 	 * Returns user registration meta fields with prefix before registration.
 	 *
+	 * @param string $field_name Field name.
+	 *
 	 * @return string
 	 */
 	function ur_get_field_name_with_prefix_usermeta( $field_name ) {
@@ -2867,12 +2869,12 @@ if ( ! function_exists( 'ur_find_my_account_in_page' ) ) {
 		$post_meta_table = $wpdb->prefix . 'postmeta';
 
 		$matched = $wpdb->get_var(
-			$wpdb->prepare("SELECT COUNT(*) FROM {$post_table} WHERE ID = '{$login_page_id}' AND ( post_content LIKE '%[user_registration_login%' OR post_content LIKE '%[user_registration_my_account%' OR post_content LIKE '%[woocommerce_my_account%' )" )
+			$wpdb->prepare( "SELECT COUNT(*) FROM {$post_table} WHERE ID = '{$login_page_id}' AND ( post_content LIKE '%[user_registration_login%' OR post_content LIKE '%[user_registration_my_account%' OR post_content LIKE '%[woocommerce_my_account%' )" ) //phpcs:ignore
 		);
 
 		if ( $matched <= 0 ){
 			$matched = $wpdb->get_var(
-				$wpdb->prepare("SELECT COUNT(*) FROM {$post_meta_table} WHERE post_id = '{$login_page_id}' AND ( meta_value LIKE '%[user_registration_login%' OR meta_value LIKE '%[user_registration_my_account%' OR meta_value LIKE '%[woocommerce_my_account%' )" )
+				$wpdb->prepare( "SELECT COUNT(*) FROM {$post_meta_table} WHERE post_id = '{$login_page_id}' AND ( meta_value LIKE '%[user_registration_login%' OR meta_value LIKE '%[user_registration_my_account%' OR meta_value LIKE '%[woocommerce_my_account%' )" ) //phpcs:ignore
 			);
 		}
 		return $matched;

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -3894,7 +3894,7 @@ if ( ! function_exists( 'user_registration_conditional_user_meta_filter' ) ) {
 		}
 
 		$field_name   = '';
-		$hidden_field = isset( $_POST['urcl_hide_fields'] ) ? ur_clean( $_POST['urcl_hide_fields'] ) : array();
+		$hidden_field = isset( $_POST['urcl_hide_fields'] ) ? ur_clean( $_POST['urcl_hide_fields'] ) : array(); //phpcs:ignore
 
 		if ( empty( $hidden_field ) ) {
 			return $valid_form_data;
@@ -3906,17 +3906,16 @@ if ( ! function_exists( 'user_registration_conditional_user_meta_filter' ) ) {
 			foreach ( $hidden_array_field as $field ) {
 				$field_name = $field;
 				if ( in_array( $field_name, array_keys( $valid_form_data ) ) ) {
-					unset( $valid_form_data[$field_name] );
+					unset( $valid_form_data[ $field_name ] );
 				}
 			}
 		} else {
 			foreach ( $hidden_array_field as $field ) {
 				$field_name = 'user_registration_' . $field;
 				if ( in_array( $field_name, array_keys( $valid_form_data ) ) ) {
-					unset( $valid_form_data[$field_name] );
+					unset( $valid_form_data[ $field_name ] );
 				}
 			}
-
 		}
 
 		return $valid_form_data;

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -2872,7 +2872,7 @@ if ( ! function_exists( 'ur_find_my_account_in_page' ) ) {
 			$wpdb->prepare( "SELECT COUNT(*) FROM {$post_table} WHERE ID = '{$login_page_id}' AND ( post_content LIKE '%[user_registration_login%' OR post_content LIKE '%[user_registration_my_account%' OR post_content LIKE '%[woocommerce_my_account%' )" ) //phpcs:ignore
 		);
 
-		if ( $matched <= 0 ){
+		if ( $matched <= 0 ) {
 			$matched = $wpdb->get_var(
 				$wpdb->prepare( "SELECT COUNT(*) FROM {$post_meta_table} WHERE post_id = '{$login_page_id}' AND ( meta_value LIKE '%[user_registration_login%' OR meta_value LIKE '%[user_registration_my_account%' OR meta_value LIKE '%[woocommerce_my_account%' )" ) //phpcs:ignore
 			);
@@ -3857,6 +3857,8 @@ if ( ! function_exists( 'ur_maybe_unserialize' ) ) {
 	 * UR Unserialize data.
 	 *
 	 * @param string $data Data that might be unserialized.
+	 * @param array  $options Options.
+	 *
 	 * @return mixed Unserialized data can be any type.
 	 *
 	 * @since 3.0.2
@@ -3866,7 +3868,7 @@ if ( ! function_exists( 'ur_maybe_unserialize' ) ) {
 		if ( is_serialized( $data ) ) {
 			if ( version_compare( PHP_VERSION, '7.1.0', '>=' ) ) {
 				$options = wp_parse_args( $options, array( 'allowed_classes' => false ) );
-				return @unserialize( trim( $data ), $options );
+				return @unserialize( trim( $data ), $options ); //phpcs:ignore
 			}
 			return @unserialize( trim( $data ) );
 		}
@@ -3875,13 +3877,13 @@ if ( ! function_exists( 'ur_maybe_unserialize' ) ) {
 	}
 }
 
-if ( ! function_exists( 'user_registration_conditional_user_meta_filter') ) {
+if ( ! function_exists( 'user_registration_conditional_user_meta_filter' ) ) {
 	/**
 	 * Filter user meta field when conditinal logic applied.
 	 *
 	 * @param array $valid_form_data Form Data.
-	 * @param int $user_id User Id.
-	 * @param int $form_id Form Id.
+	 * @param int   $user_id User Id.
+	 * @param int   $form_id Form Id.
 	 * @return array array of form data.
 	 *
 	 * @since 3.0.4
@@ -3900,7 +3902,7 @@ if ( ! function_exists( 'user_registration_conditional_user_meta_filter') ) {
 
 		$hidden_array_field = json_decode( stripslashes( $hidden_field ) );
 
-		if ( isset( $_POST['action'] ) && 'user_registration_user_form_submit' ===  $_POST['action'] ) {
+		if ( isset( $_POST['action'] ) && 'user_registration_user_form_submit' ===  $_POST['action'] ) { //phpcs:ignore
 			foreach ( $hidden_array_field as $field ) {
 				$field_name = $field;
 				if ( in_array( $field_name, array_keys( $valid_form_data ) ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes a bug due to which the field values for registered users was not being saved.

### How to test the changes in this Pull Request:

1. Register a user using any user registration form.
2. Verify if all the input values are being saved.
3. Also verify that the values are being saved during edit profile action.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> UR-1170 Fix - User fields not saving
