### PR TITLE
UR-870 Enhance - Test captcha from settings

### DIFF
--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -1357,6 +1357,12 @@ body {
 							min-width: 512px;
 							display: block;
 
+							#node_recaptcha_login {
+								iframe {
+									display: inline-block !important;
+								}
+							}
+
 							#ur-captcha-notice {
 								padding: 8px;
 								margin: 2px;

--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -1346,6 +1346,31 @@ body {
 								width: 30%;
 							}
 						}
+
+						#user_registration_captcha_setting_captcha_test {
+							.spinner {
+								visibility: visible !important;
+							}
+						}
+						
+						#ur-captcha-test-container {
+							min-width: 512px;
+							display: block;
+
+							#ur-captcha-notice {
+								padding: 8px;
+								margin: 2px;
+
+								&.success {
+									border: 1px solid green;
+								}
+
+								&.error {
+									border: 1px solid red;
+								}
+							}
+						}
+
 					}
 				}
 

--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -1352,27 +1352,31 @@ body {
 								visibility: visible !important;
 							}
 						}
-						
+
 						#ur-captcha-test-container {
 							min-width: 512px;
 							display: block;
 
-							#node_recaptcha_login {
-								iframe {
-									display: inline-block !important;
-								}
-							}
-
 							#ur-captcha-notice {
 								padding: 8px;
 								margin: 2px;
+								border-radius: 4px;
+								border-width: 0px !important;
 
 								&.success {
-									border: 1px solid green;
+									background: rgba(0,255,0,0.3);
+
+									#ur-captcha-notice--icon {
+										color: green;
+									}
 								}
 
 								&.error {
-									border: 1px solid red;
+									background: rgba(255,0,0,0.3);
+
+									#ur-captcha-notice--icon {
+										color: red;
+									}
 								}
 							}
 						}

--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -226,7 +226,9 @@
 			)
 				.closest(".user-registration-global-settings")
 				.hide();
-			$("#user_registration_captcha_setting_recaptcha_site_key_cloudflare")
+			$(
+				"#user_registration_captcha_setting_recaptcha_site_key_cloudflare"
+			)
 				.closest(".user-registration-global-settings")
 				.hide();
 			$(
@@ -234,9 +236,7 @@
 			)
 				.closest(".user-registration-global-settings")
 				.hide();
-			$(
-				"#user_registration_captcha_setting_recaptcha_cloudflare_theme"
-			)
+			$("#user_registration_captcha_setting_recaptcha_cloudflare_theme")
 				.closest(".user-registration-global-settings")
 				.hide();
 		} else if (value == "hCaptcha") {
@@ -274,7 +274,9 @@
 			$("#user_registration_captcha_setting_invisible_recaptcha_v2")
 				.closest(".user-registration-global-settings")
 				.hide();
-			$("#user_registration_captcha_setting_recaptcha_site_key_cloudflare")
+			$(
+				"#user_registration_captcha_setting_recaptcha_site_key_cloudflare"
+			)
 				.closest(".user-registration-global-settings")
 				.hide();
 			$(
@@ -282,13 +284,13 @@
 			)
 				.closest(".user-registration-global-settings")
 				.hide();
-			$(
-				"#user_registration_captcha_setting_recaptcha_cloudflare_theme"
-			)
+			$("#user_registration_captcha_setting_recaptcha_cloudflare_theme")
 				.closest(".user-registration-global-settings")
 				.hide();
 		} else if (value == "cloudflare") {
-			$("#user_registration_captcha_setting_recaptcha_site_key_cloudflare")
+			$(
+				"#user_registration_captcha_setting_recaptcha_site_key_cloudflare"
+			)
 				.closest(".user-registration-global-settings")
 				.show();
 			$(
@@ -296,12 +298,10 @@
 			)
 				.closest(".user-registration-global-settings")
 				.show();
-			$(
-				"#user_registration_captcha_setting_recaptcha_cloudflare_theme"
-			)
+			$("#user_registration_captcha_setting_recaptcha_cloudflare_theme")
 				.closest(".user-registration-global-settings")
 				.show();
-				$("#user_registration_captcha_setting_recaptcha_site_key_hcaptcha")
+			$("#user_registration_captcha_setting_recaptcha_site_key_hcaptcha")
 				.closest(".user-registration-global-settings")
 				.hide();
 			$(
@@ -354,7 +354,9 @@
 				$("#user_registration_captcha_setting_recaptcha_site_secret")
 					.closest(".user-registration-global-settings")
 					.hide();
-				$("#user_registration_captcha_setting_recaptcha_site_key_cloudflare")
+				$(
+					"#user_registration_captcha_setting_recaptcha_site_key_cloudflare"
+				)
 					.closest(".user-registration-global-settings")
 					.hide();
 				$(
@@ -414,7 +416,9 @@
 			$("#user_registration_captcha_setting_recaptcha_site_secret_v3")
 				.closest(".user-registration-global-settings")
 				.hide();
-			$("#user_registration_captcha_setting_recaptcha_site_key_cloudflare")
+			$(
+				"#user_registration_captcha_setting_recaptcha_site_key_cloudflare"
+			)
 				.closest(".user-registration-global-settings")
 				.hide();
 			$(
@@ -422,9 +426,7 @@
 			)
 				.closest(".user-registration-global-settings")
 				.hide();
-			$(
-				"#user_registration_captcha_setting_recaptcha_cloudflare_theme"
-			)
+			$("#user_registration_captcha_setting_recaptcha_cloudflare_theme")
 				.closest(".user-registration-global-settings")
 				.hide();
 			$("#user_registration_captcha_setting_invisible_recaptcha_v2")
@@ -435,139 +437,171 @@
 
 	var captchaSettingsChanged = false;
 
-	$('.user-registration-global-settings').find('input').on('change', function() {
-		captchaSettingsChanged = true;
-		$( '#user_registration_captcha_setting_captcha_test' ).parent().hide();
-	});
+	$(".user-registration-global-settings")
+		.find("input, select")
+		.on("change", function () {
+			captchaSettingsChanged = true;
+			$("#user_registration_captcha_setting_captcha_test")
+				.parent()
+				.hide();
+		});
 
 	/**
 	 * Test Captcha from settings page.
 	 */
-	$('.user-registration').on('click', '#user_registration_captcha_setting_captcha_test', function (e) {
-		e.preventDefault();
-		e.stopPropagation();
+	$(".user-registration").on(
+		"click",
+		"#user_registration_captcha_setting_captcha_test",
+		function (e) {
+			e.preventDefault();
+			e.stopPropagation();
 
-		if (captchaSettingsChanged) {
-			alert(user_registration_settings_params.i18n.unsaved_changes);
-			return;
-		}
+			if (captchaSettingsChanged) {
+				alert(user_registration_settings_params.i18n.unsaved_changes);
+				return;
+			}
 
-		var spinner = $('#user_registration_captcha_setting_captcha_test .spinner');
-		spinner.show();
+			var spinner = $(
+				"#user_registration_captcha_setting_captcha_test .spinner"
+			);
+			spinner.show();
 
-		setTimeout(
-			function () {
+			setTimeout(function () {
 				spinner.hide();
-			},
-			2500
-		);
+			}, 2500);
 
-		var ur_recaptcha_node = $("#ur-captcha-node");
-		if (
-			"undefined" !== typeof ur_recaptcha_code &&
-			ur_recaptcha_code.site_key.length
-		) {
-			if (ur_recaptcha_node.length !== 0) {
-				switch (ur_recaptcha_code.version) {
-					case 'v2':
-						google_recaptcha_login = grecaptcha.render(
-							ur_recaptcha_node.find(".g-recaptcha").attr("id"),
-							{
-								sitekey: ur_recaptcha_code.site_key,
-								theme: "light",
-								style: "transform:scale(0.77);-webkit-transform:scale(0.77);transform-origin:0 0;-webkit-transform-origin:0 0;",
-							}
-						);
-
-						if (ur_recaptcha_code.is_invisible) {
-							grecaptcha
-								.execute(google_recaptcha_login)
-								.then(function (token) {
-									if (null !== token) {
-										display_captcha_test_status(user_registration_settings_params.i18n.captcha_failed, 'error');
-										return;
-									} else {
-										display_captcha_test_status(user_registration_settings_params.i18n.captcha_success, 'success');
-									}
-								});
-						}
-						break;
-
-					case 'v3':
-						try {
-							grecaptcha.execute(
-								ur_recaptcha_code.site_key,
-								{
-									action: 'click'
-								}
-							).then(function (d) {
-								display_captcha_test_status(user_registration_settings_params.i18n.captcha_success, 'success');
-							});
-						} catch (err) {
-							display_captcha_test_status(err.message, 'error');
-						}
-						break;
-
-					case 'hCaptcha':
-						google_recaptcha_login = hcaptcha.render(
-							ur_recaptcha_node
-								.find(".g-recaptcha-hcaptcha")
-								.attr("id"),
-							{
-								sitekey: ur_recaptcha_code.site_key,
-								theme: "light",
-								style: "transform:scale(0.77);-webkit-transform:scale(0.77);transform-origin:0 0;-webkit-transform-origin:0 0;",
-							}
-						)
-						break;
-
-					case 'cloudflare':
-						try {
-							turnstile.render(
-								'#' + ur_recaptcha_node.find('.cf-turnstile').attr('id'),
+			var ur_recaptcha_node = $("#ur-captcha-node");
+			if (
+				"undefined" !== typeof ur_recaptcha_code &&
+				ur_recaptcha_code.site_key.length
+			) {
+				if (ur_recaptcha_node.length !== 0) {
+					switch (ur_recaptcha_code.version) {
+						case "v2":
+							google_recaptcha_login = grecaptcha.render(
+								ur_recaptcha_node
+									.find(".g-recaptcha")
+									.attr("id"),
 								{
 									sitekey: ur_recaptcha_code.site_key,
-									theme: ur_recaptcha_code.theme_mode,
+									theme: "light",
 									style: "transform:scale(0.77);-webkit-transform:scale(0.77);transform-origin:0 0;-webkit-transform-origin:0 0;",
 								}
 							);
 
-								ur_recaptcha_node.find('iframe').css('display', 'block');
-						} catch (err) {
-							display_captcha_test_status(err.message, 'error');
-						}
-						break;
+							if (ur_recaptcha_code.is_invisible) {
+								grecaptcha
+									.execute(google_recaptcha_login)
+									.then(function (token) {
+										if (null !== token) {
+											display_captcha_test_status(
+												user_registration_settings_params
+													.i18n.captcha_failed,
+												"error"
+											);
+											return;
+										} else {
+											display_captcha_test_status(
+												user_registration_settings_params
+													.i18n.captcha_success,
+												"success"
+											);
+										}
+									});
+							}
+							break;
+
+						case "v3":
+							try {
+								grecaptcha
+									.execute(ur_recaptcha_code.site_key, {
+										action: "click",
+									})
+									.then(function (d) {
+										display_captcha_test_status(
+											user_registration_settings_params
+												.i18n.captcha_success,
+											"success"
+										);
+									});
+							} catch (err) {
+								display_captcha_test_status(
+									err.message,
+									"error"
+								);
+							}
+							break;
+
+						case "hCaptcha":
+							google_recaptcha_login = hcaptcha.render(
+								ur_recaptcha_node
+									.find(".g-recaptcha-hcaptcha")
+									.attr("id"),
+								{
+									sitekey: ur_recaptcha_code.site_key,
+									theme: "light",
+									style: "transform:scale(0.77);-webkit-transform:scale(0.77);transform-origin:0 0;-webkit-transform-origin:0 0;",
+								}
+							);
+							break;
+
+						case "cloudflare":
+							try {
+								turnstile.render(
+									"#" +
+										ur_recaptcha_node
+											.find(".cf-turnstile")
+											.attr("id"),
+									{
+										sitekey: ur_recaptcha_code.site_key,
+										theme: ur_recaptcha_code.theme_mode,
+										style: "transform:scale(0.77);-webkit-transform:scale(0.77);transform-origin:0 0;-webkit-transform-origin:0 0;",
+									}
+								);
+
+								ur_recaptcha_node
+									.find("iframe")
+									.css("display", "block");
+							} catch (err) {
+								display_captcha_test_status(
+									err.message,
+									"error"
+								);
+							}
+							break;
+					}
 				}
 			}
 		}
-	});
+	);
 
 	/**
 	 *
 	 * @param {string} notice Notice message.
 	 * @param {string} type Notice type.
 	 */
-	function display_captcha_test_status(notice = '', type = 'success') {
-
+	function display_captcha_test_status(notice = "", type = "success") {
 		if (notice.length) {
-			var notice_container = $('#ur-captcha-notice');
-			var notice_icon = $('#ur-captcha-notice--icon');
-			var notice_text = $('#ur-captcha-notice--text');
+			var notice_container = $("#ur-captcha-notice");
+			var notice_icon = $("#ur-captcha-notice--icon");
+			var notice_text = $("#ur-captcha-notice--text");
 
 			if (notice_text.length) {
 				notice_text.html(notice);
 
-				if ('success' === type) {
-					notice_container.removeClass().addClass('success');
-					notice_icon.addClass('dashicons dashicons-yes-alt');
-				} else if ('error' === type) {
-					notice_container.removeClass().addClass('error');
-					notice_icon.addClass('dashicons dashicons-dismiss');
+				if ("success" === type) {
+					notice_container.removeClass().addClass("success");
+					notice_icon.addClass("dashicons dashicons-yes-alt");
+				} else if ("error" === type) {
+					notice_container.removeClass().addClass("error");
+					notice_icon.addClass("dashicons dashicons-dismiss");
 				}
 			}
 		}
 
-		var spinner = $('#user_registration_captcha_setting_captcha_test .spinner');
+		var spinner = $(
+			"#user_registration_captcha_setting_captcha_test .spinner"
+		);
 		spinner.hide();
 	}
 

--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -485,18 +485,6 @@
 									}
 								});
 						}
-
-						var recaptchaV2Interval = setInterval(
-							function () {
-								var captchaResponse = grecaptcha.getResponse();
-
-								if (captchaResponse.length) {
-									clearInterval(recaptchaV2Interval);
-									display_captcha_test_status('Captcha test successful', 'success');
-								}
-							},
-							1000
-						);
 						break;
 
 					case 'v3':
@@ -537,6 +525,8 @@
 									style: "transform:scale(0.77);-webkit-transform:scale(0.77);transform-origin:0 0;-webkit-transform-origin:0 0;",
 								}
 							);
+
+								ur_recaptcha_node.find('iframe').css('display', 'block');
 						} catch (err) {
 							display_captcha_test_status(err.message, 'error');
 						}
@@ -550,10 +540,19 @@
 
 		if (notice.length) {
 			var notice_container = $('#ur-captcha-notice');
+			var notice_icon = $('#ur-captcha-notice--icon');
+			var notice_text = $('#ur-captcha-notice--text');
 
-			if (notice_container.length) {
-				notice_container.html(notice);
-				notice_container.removeClass().addClass(type);
+			if (notice_text.length) {
+				notice_text.html(notice);
+
+				if ('success' === type) {
+					notice_container.removeClass().addClass('success');
+					notice_icon.addClass('dashicons dashicons-yes-alt');
+				} else if ('error' === type) {
+					notice_container.removeClass().addClass('error');
+					notice_icon.addClass('dashicons dashicons-dismiss');
+				}
 			}
 		}
 

--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -437,6 +437,7 @@
 
 	$('.user-registration-global-settings').find('input').on('change', function() {
 		captchaSettingsChanged = true;
+		$( '#user_registration_captcha_setting_captcha_test' ).parent().hide();
 	});
 
 	/**

--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -439,12 +439,15 @@
 		captchaSettingsChanged = true;
 	});
 
+	/**
+	 * Test Captcha from settings page.
+	 */
 	$('.user-registration').on('click', '#user_registration_captcha_setting_captcha_test', function (e) {
 		e.preventDefault();
 		e.stopPropagation();
 
 		if (captchaSettingsChanged) {
-			alert('You have unsaved changes. Please save and try again.');
+			alert(user_registration_settings_params.i18n.unsaved_changes);
 			return;
 		}
 
@@ -480,8 +483,10 @@
 								.execute(google_recaptcha_login)
 								.then(function (token) {
 									if (null !== token) {
-										display_captcha_test_status('Some error occured', 'error');
+										display_captcha_test_status(user_registration_settings_params.i18n.captcha_failed, 'error');
 										return;
+									} else {
+										display_captcha_test_status(user_registration_settings_params.i18n.captcha_success, 'success');
 									}
 								});
 						}
@@ -495,7 +500,7 @@
 									action: 'click'
 								}
 							).then(function (d) {
-								display_captcha_test_status('Captcha test successful', 'success');
+								display_captcha_test_status(user_registration_settings_params.i18n.captcha_success, 'success');
 							});
 						} catch (err) {
 							display_captcha_test_status(err.message, 'error');
@@ -536,6 +541,11 @@
 		}
 	});
 
+	/**
+	 *
+	 * @param {string} notice Notice message.
+	 * @param {string} type Notice type.
+	 */
 	function display_captcha_test_status(notice = '', type = 'success') {
 
 		if (notice.length) {

--- a/includes/admin/class-ur-admin-assets.php
+++ b/includes/admin/class-ur-admin-assets.php
@@ -442,6 +442,13 @@ class UR_Admin_Assets {
 			array(),
 			UR_VERSION,
 		);
+
+		wp_register_script(
+			'ur-recaptcha-cloudflare',
+			'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit&onload=onloadURCallback',
+			array(),
+			UR_VERSION,
+		);
 	}
 
 	/**

--- a/includes/admin/class-ur-admin-assets.php
+++ b/includes/admin/class-ur-admin-assets.php
@@ -419,6 +419,29 @@ class UR_Admin_Assets {
 
 		wp_register_script( 'ur-live-user-notice', UR()->plugin_url() . '/assets/js/admin/live-user-notice' . $suffix . '.js', array( 'jquery', 'heartbeat' ), UR_VERSION, false );
 		wp_enqueue_script( 'ur-live-user-notice' );
+
+		wp_register_script(
+			'ur-google-recaptcha',
+			'https://www.google.com/recaptcha/api.js?onload=onloadURCallback&render=explicit',
+			array(),
+			'2.0.0',
+		);
+
+		$recaptcha_site_key_v3 = get_option( 'user_registration_captcha_setting_recaptcha_site_key_v3' );
+
+		wp_register_script(
+			'ur-google-recaptcha-v3',
+			'https://www.google.com/recaptcha/api.js?render=' . $recaptcha_site_key_v3,
+			array(),
+			'3.0.0',
+		);
+
+		wp_register_script(
+			'ur-recaptcha-hcaptcha',
+			'https://hcaptcha.com/1/api.js?onload=onloadURCallback&render=explicit',
+			array(),
+			UR_VERSION,
+		);
 	}
 
 	/**

--- a/includes/admin/class-ur-admin-settings.php
+++ b/includes/admin/class-ur-admin-settings.php
@@ -150,6 +150,11 @@ class UR_Admin_Settings {
 				'ajax_url'         => admin_url( 'admin-ajax.php' ),
 				'user_registration_search_global_settings_nonce' => wp_create_nonce( 'user_registration_search_global_settings' ),
 				'i18n_nav_warning' => esc_html__( 'The changes you made will be lost if you navigate away from this page.', 'user-registration' ),
+				'i18n'             => array(
+					'captcha_success' => esc_html__( 'Captcha Test Successful !', 'user-registration' ),
+					'captcha_failed'  => esc_html__( 'Some error occured. Please verify that the keys you entered are valid.', 'user-registration' ),
+					'unsaved_changes' => esc_html__( 'You have some unsaved changes. Please save and try again.', 'user-registration' ),
+				),
 			)
 		);
 

--- a/includes/admin/settings/class-ur-settings-captcha.php
+++ b/includes/admin/settings/class-ur-settings-captcha.php
@@ -319,6 +319,21 @@ if ( ! class_exists( 'UR_Settings_Captcha ' ) ) :
 							'invisible'  => $invisible,
 						);
 					}
+
+					if ( $invisible ) {
+						$site_key   = get_option( 'user_registration_captcha_setting_recaptcha_invisible_site_key' );
+						$secret_key = get_option( 'user_registration_captcha_setting_recaptcha_invisible_site_secret' );
+
+						if ( ! empty( $site_key ) && ! empty( $secret_key ) ) {
+							return array(
+								'type'       => 'invisible_v2',
+								'site_key'   => $site_key,
+								'secret_key' => $secret_key,
+								'invisible'  => $invisible,
+							);
+						}
+					}
+
 					break;
 
 				case 'v3':

--- a/includes/admin/settings/class-ur-settings-captcha.php
+++ b/includes/admin/settings/class-ur-settings-captcha.php
@@ -346,6 +346,20 @@ if ( ! class_exists( 'UR_Settings_Captcha ' ) ) :
 					}
 					break;
 
+				case 'cloudflare':
+					$site_key   = get_option( 'user_registration_captcha_setting_recaptcha_site_key_cloudflare' );
+					$secret_key = get_option( 'user_registration_captcha_setting_recaptcha_site_secret_cloudflare' );
+
+					if ( ! empty( $site_key ) && ! empty( $secret_key ) ) {
+						return array(
+							'type'       => 'cloudflare',
+							'site_key'   => $site_key,
+							'secret_key' => $secret_key,
+						);
+					}
+					break;
+
+
 			return apply_filters( 'user_registration_active_recaptcha', false );
 			}
 		}

--- a/includes/admin/settings/class-ur-settings-captcha.php
+++ b/includes/admin/settings/class-ur-settings-captcha.php
@@ -272,7 +272,10 @@ if ( ! class_exists( 'UR_Settings_Captcha ' ) ) :
 					<div>
 						<div id="ur-captcha-test-container">
 							<div id="ur-captcha-node">%s</div>
-							<div id="ur-captcha-notice"></div>
+							<div id="ur-captcha-notice">
+								<span id="ur-captcha-notice--icon"></span>
+								<span id="ur-captcha-notice--text"></span>
+							</div>
 
 
 						</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR introduces a feature that enables testing of the working of all captchas from the captcha settings page.

This feature aims to prevent the issue where the admins would set the captcha incorrectly and get locked out of system due to a captcha error.

### How to test the changes in this Pull Request:

1. Input valid and invalid keys in the captcha settings and test the captcha for all available captchas.
2. Check if the feature is handling errors and displaying errors properly.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> UR-870 Enhance - Test captcha from settings
