### PR TITLE
UR-648 - Tweak/timepicker UI enhancement library change

### DIFF
--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -903,6 +903,14 @@
 								".ur-advance-setting-block .ur-settings-time_interval"
 							)
 							.val();
+
+						var $time_format = $(this)
+							.closest(".ur-selected-item")
+							.find(
+							".ur-advance-setting-block .ur-settings-time_format"
+							)
+							.val();
+
 						var label = $(this)
 							.closest(".ur-selected-item")
 							.find(".ur-label label")

--- a/includes/abstracts/abstract-ur-form-field.php
+++ b/includes/abstracts/abstract-ur-form-field.php
@@ -335,9 +335,9 @@ abstract class UR_Form_Field {
 		}
 
 		if ( 'captcha' === $field_key ) {
-			$choices                 = isset( $data['advance_setting']->choices ) ? explode( ',', $data['advance_setting']->choices ) : array(); // Backward compatibility. Modified since 1.5.7.
-			$option_data             = isset( $data['general_setting']->options ) ? $data['general_setting']->options : $choices;
-			$options                 = array();
+			$choices     = isset( $data['advance_setting']->choices ) ? explode( ',', $data['advance_setting']->choices ) : array(); // Backward compatibility. Modified since 1.5.7.
+			$option_data = isset( $data['general_setting']->options ) ? $data['general_setting']->options : $choices;
+			$options     = array();
 
 			if ( is_array( $option_data ) ) {
 				foreach ( $option_data as $index_data => $option ) {
@@ -381,6 +381,7 @@ abstract class UR_Form_Field {
 		if ( 'timepicker' == $field_key ) {
 			$form_data['current_time']  = isset( $data['advance_setting']->current_time ) ? $data['advance_setting']->current_time : '';
 			$form_data['time_interval'] = isset( $data['advance_setting']->time_interval ) ? $data['advance_setting']->time_interval : '';
+			$form_data['time_format']   = isset( $data['advance_setting']->time_format ) ? $data['advance_setting']->time_format : '';
 			$form_data['time_min']      = ( isset( $data['advance_setting']->time_min ) && '' !== $data['advance_setting']->time_min ) ? $data['advance_setting']->time_min : '';
 			$form_data['time_max']      = ( isset( $data['advance_setting']->time_max ) && '' !== $data['advance_setting']->time_max ) ? $data['advance_setting']->time_max : '';
 			$timemin                    = isset( $form_data['time_min'] ) ? strtolower( substr( $form_data['time_min'], -2 ) ) : '';
@@ -416,7 +417,6 @@ abstract class UR_Form_Field {
 		if ( isset( $data['general_setting']->field_name ) ) {
 			user_registration_form_field( $data['general_setting']->field_name, $form_data );
 		}
-
 	}
 
 	/**
@@ -681,9 +681,9 @@ abstract class UR_Form_Field {
 
 					$general_setting_wrapper .= '/>';
 					break;
-				case 'captcha' :
+				case 'captcha':
 					$default_options          = isset( $this->field_defaults['default_options'] ) ? $this->field_defaults['default_options'] : array();
-					$old_options     		  = isset( $this->admin_data->advance_setting->choices ) ? explode( ',', trim( $this->admin_data->advance_setting->choices, ',' ) ) : $default_options;
+					$old_options              = isset( $this->admin_data->advance_setting->choices ) ? explode( ',', trim( $this->admin_data->advance_setting->choices, ',' ) ) : $default_options;
 					$options                  = isset( $this->admin_data->general_setting->options ) ? $this->admin_data->general_setting->options : $old_options;
 					$general_setting_wrapper .= '<ul class="ur-options-list">';
 
@@ -699,7 +699,7 @@ abstract class UR_Form_Field {
 						$general_setting_wrapper .= '<a class="add" href="#"><i class="dashicons dashicons-plus"></i></a>';
 						$general_setting_wrapper .= '<a class="remove" href="#"><i class="dashicons dashicons-minus"></i></a>';
 						$general_setting_wrapper .= '</li>';
-						}
+					}
 					$general_setting_wrapper .= '</ul>';
 					break;
 

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -1210,6 +1210,22 @@ function ur_login_option_with() {
 }
 
 /**
+ * Time Format for advanced settings
+ *
+ * @return array
+ */
+function ur_time_format_options() {
+
+	return apply_filters(
+		'user_registration_time_format_options',
+		array(
+			'H:i K'        => __( '12 H ', 'user-registration' ),
+			'H:i'   => __( '24 H', 'user-registration' ),
+		)
+	);
+}
+
+/**
  * Get Default value for Enable Email Approval Checkbox
  *
  * @param int $form_id Form ID.

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -414,6 +414,7 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 				$extra_params       = json_decode( get_user_meta( get_current_user_id(), $extra_params_key, true ) );
 				$current_time       = isset( $args['current_time'] ) ? $args['current_time'] : '';
 				$time_interval      = isset( $args['time_interval'] ) ? $args['time_interval'] : '';
+				$time_format        = isset( $args['time_format'] ) ? $args['time_format'] : '';
 				$time_min           = isset( $args['time_min'] ) ? $args['time_min'] : '';
 				$time_max           = isset( $args['time_max'] ) ? $args['time_max'] : '';
 				$username_length    = isset( $args['username_length'] ) ? $args['username_length'] : '';
@@ -429,6 +430,10 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 
 				if ( '' !== $time_interval ) {
 					$attr .= 'data-time-interval="' . $time_interval . '"';
+				}
+
+				if ( '' !== $time_format ) {
+					$attr .= 'data-time-format="' . $time_format . '"';
 				}
 
 				if ( '' !== $time_min ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Previously, the system was using the Time picker library for choosing the time for book. Now, we have implemented Flatpickr library for time picker booking. We have also added the option for displaying the time picking options in two different (24-hr and 12-hr) formats.

### How to test the changes in this Pull Request:

1. Create a user registration form by adding the time picker field
2. Add the minimum and maximum time to provide an option to display time within that time only. This is an optional.
3. Choose the time format for displaying the clock. (either 12-hr or 24-hr)
4. Register an user using the given form.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> UR-648 - Tweak/timepicker UI enhancement library change