### PR TITLE
UR-1091 Refactor -Remove payments addon dependency form stripe.

### DIFF
--- a/includes/admin/class-ur-admin-menus.php
+++ b/includes/admin/class-ur-admin-menus.php
@@ -78,56 +78,16 @@ if ( ! class_exists( 'UR_Admin_Menus', false ) ) :
 					'slug'        => 'learndash',
 					'name'        => __( 'User Registration LearnDash', 'user-registration' ),
 				),
+				array(
+					'id'          => 'user_registration_stripe_gateway',
+					'label'       => 'Stripe Gateway',
+					'icon'        => 'ur-icon ur-icon-credit-card',
+					'field_class' => 'UR_Form_Field_Stripe_Gateway',
+					'plan'        => 'ThemeGrill Agency Plan or Professional Plan or Plus Plan',
+					'slug'        => array( 'stripe' ),
+					'name'        => array( __( 'User Registration Stripe', 'user-registration' ) ),
+				),
 			);
-
-			if ( ! is_plugin_active( 'user-registration-payments/user-registration-payments.php' ) && ! is_plugin_active( 'user-registration-stripe/user-registration-stripe.php' ) ) {
-				$fields = array_merge(
-					$fields,
-					array(
-						array(
-							'id'          => 'user_registration_stripe_gateway',
-							'label'       => 'Stripe Gateway',
-							'icon'        => 'ur-icon ur-icon-credit-card',
-							'field_class' => 'UR_Form_Field_Stripe_Gateway',
-							'plan'        => 'ThemeGrill Agency Plan or Professional Plan or Plus Plan',
-							'slug'        => array( 'payments', 'stripe' ),
-							'name'        => array( __( 'User Registration Payments', 'user-registration' ), __( 'User Registration Stripe', 'user-registration' ) ),
-						),
-					)
-				);
-			} else {
-				if ( ! is_plugin_active( 'user-registration-payments/user-registration-payments.php' ) && is_plugin_active( 'user-registration-stripe/user-registration-stripe.php' ) ) {
-					$fields = array_merge(
-						$fields,
-						array(
-							array(
-								'id'          => 'user_registration_stripe_gateway',
-								'label'       => 'Stripe Gateway',
-								'icon'        => 'ur-icon ur-icon-credit-card',
-								'field_class' => 'UR_Form_Field_Stripe_Gateway',
-								'plan'        => 'ThemeGrill Agency Plan or Professional Plan or Plus Plan',
-								'slug'        => 'payments',
-								'name'        => __( 'User Registration Payments', 'user-registration' ),
-							),
-						)
-					);
-				} elseif ( is_plugin_active( 'user-registration-payments/user-registration-payments.php' ) && ! is_plugin_active( 'user-registration-stripe/user-registration-stripe.php' ) ) {
-					$fields = array_merge(
-						$fields,
-						array(
-							array(
-								'id'          => 'user_registration_stripe_gateway',
-								'label'       => 'Stripe Gateway',
-								'icon'        => 'ur-icon ur-icon-credit-card',
-								'field_class' => 'UR_Form_Field_Stripe_Gateway',
-								'plan'        => 'ThemeGrill Agency Plan or Professional Plan or Plus Plan',
-								'slug'        => 'stripe',
-								'name'        => __( 'User Registration Stripe', 'user-registration' ),
-							),
-						)
-					);
-				}
-			}
 
 			foreach ( $fields as $field ) {
 				if ( 'user_registration_learndash' === $field['id'] ) {
@@ -348,8 +308,8 @@ if ( ! class_exists( 'UR_Admin_Menus', false ) ) :
 					'section_title'       => 'Payment Fields',
 					'fields_parent_class' => 'User_Registration_Payments_Admin',
 					'plan'                => 'ThemeGrill Agency Plan or Professional Plan or Plus Plan',
-					'slug'                => 'payments',
-					'name'                => __( 'User Registration Payments', 'user-registration' ),
+					'slug'                => array( 'payments', 'stripe' ),
+					'name'                => array( __( 'User Registration Payments', 'user-registration' ), __( 'User Registration Stripe', 'user-registration' ) ),
 					'fields'              => array(
 						array(
 							'id'    => 'user_registration_single_item',
@@ -495,7 +455,6 @@ if ( ! class_exists( 'UR_Admin_Menus', false ) ) :
 					)
 				);
 			}
-
 		}
 
 			/**
@@ -603,7 +562,7 @@ if ( ! class_exists( 'UR_Admin_Menus', false ) ) :
 		public function registration_page() {
 			global $registration_table_list;
 			if ( isset( $_GET['tab'] ) && 'login-forms' === $_GET['tab'] ) { //phpcs:ignore WordPress.Security.NonceVerification
-				include_once dirname( __FILE__ ) . '/views/html-login-page-forms.php';
+				include_once __DIR__ . '/views/html-login-page-forms.php';
 			} else {
 				$registration_table_list->display_page();
 			}
@@ -665,13 +624,13 @@ if ( ! class_exists( 'UR_Admin_Menus', false ) ) :
 			);
 			if ( isset( $_GET['edit-registration'] ) ) {
 				// Forms view.
-				include_once dirname( __FILE__ ) . '/views/html-admin-page-forms.php';
+				include_once __DIR__ . '/views/html-admin-page-forms.php';
 			} else {
 				UR_Admin_Form_Templates::load_template_view();
 			}
 
 			// Forms view.
-			include_once dirname( __FILE__ ) . '/views/html-admin-page-forms.php';
+			include_once __DIR__ . '/views/html-admin-page-forms.php';
 		}
 
 			/**
@@ -757,7 +716,7 @@ if ( ! class_exists( 'UR_Admin_Menus', false ) ) :
 									name="menu-item[<?php echo esc_attr( $i ); ?>][menu-item-classes]"/>
 							</li>
 						<?php
-						$i --;
+						--$i;
 						endforeach;
 			?>
 					</ul>
@@ -907,7 +866,7 @@ if ( ! class_exists( 'UR_Admin_Menus', false ) ) :
 
 					foreach ( $rows as $grid_lists ) {
 
-						$grid_id ++;
+						++$grid_id;
 
 						echo '<div ur-grid-id="' . esc_attr( $grid_id ) . '" class="ur-grid-list-item ui-sortable" style="width: 48%; min-height: 70px;">';
 
@@ -1017,7 +976,6 @@ if ( ! class_exists( 'UR_Admin_Menus', false ) ) :
 			if ( null !== $class_name ) {
 				echo wp_kses_post( $class_name::get_instance()->get_registered_admin_fields() );
 			}
-
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Previously, To use stripe addon user have to install payments addon to use payments fields and global settings, Now we decided to remove it's dependency and move all payments fields to PRO and it will be visible only if the PayPal or stripe addon activated. 
Please verify whether all payments functionality works individually and Combinedly.

### How to test the changes in this Pull Request:

1. Test all payments functionality individually activating addon paypal and stripe.
2. Test all payments functionality by activating both addon paypal and stripe.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> UR-1091 Refactor -Remove payments addon dependency form stripe.