### PR TITLE
Fix - Placeholder is not working in the country field

### DIFF
--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -2755,7 +2755,7 @@
 					$selected_countries_option_field
 						.on("change", function (e) {
 							var selected_countries_iso_s = $(this).val();
-							var html = "";
+							var html = "<option value=''>"+user_registration_form_settings_params.ur_default_country_value_option+"</option>";
 							var self = this;
 
 							// Get html of selected countries

--- a/assets/js/frontend/user-registration.js
+++ b/assets/js/frontend/user-registration.js
@@ -1742,6 +1742,21 @@
 				});
 			}
 		});
+		/**
+		 * Check the placeholder in the country and set as default option.
+		 *
+		 * @since 4.1.0
+		 */
+		var countryFields = $('.ur-frontend-form .ur-form-row').find('.field-country');
+		$.each(countryFields, function(index, countryField){
+			country = $(countryField).find('.ur-frontend-field');
+			placeholder = $(country).data('placeholder');
+			if(placeholder === '') {
+				return;
+			}
+			$(country).prepend("<option value='' selected>"+placeholder+"</option>");
+		});
+
 	};
 
 	/**
@@ -1793,6 +1808,18 @@
 	$(window).on("load", function () {
 		user_registration_form_init();
 	});
+
+
+	var countryFields = $('.ur-frontend-form .ur-form-row').find('.field-country');
+	$.each(countryFields, function(index, countryField){
+		country = $(countryField).find('.ur-frontend-field');
+		placeholder = $(country).data('placeholder');
+		if(typeof placeholder === 'undefined' || placeholder === '') {
+			return;
+		}
+		$(country).prepend("<option value='' selected>"+placeholder+"</option>");
+	});
+
 })(jQuery);
 
 function ur_includes(arr, item) {

--- a/assets/js/frontend/user-registration.js
+++ b/assets/js/frontend/user-registration.js
@@ -1742,20 +1742,6 @@
 				});
 			}
 		});
-		/**
-		 * Check the placeholder in the country and set as default option.
-		 *
-		 * @since 4.1.0
-		 */
-		var countryFields = $('.ur-frontend-form .ur-form-row').find('.field-country');
-		$.each(countryFields, function(index, countryField){
-			country = $(countryField).find('.ur-frontend-field');
-			placeholder = $(country).data('placeholder');
-			if(placeholder === '') {
-				return;
-			}
-			$(country).prepend("<option value='' selected>"+placeholder+"</option>");
-		});
 
 	};
 
@@ -1807,17 +1793,6 @@
 	 */
 	$(window).on("load", function () {
 		user_registration_form_init();
-	});
-
-
-	var countryFields = $('.ur-frontend-form .ur-form-row').find('.field-country');
-	$.each(countryFields, function(index, countryField){
-		country = $(countryField).find('.ur-frontend-field');
-		placeholder = $(country).data('placeholder');
-		if(typeof placeholder === 'undefined' || placeholder === '') {
-			return;
-		}
-		$(country).prepend("<option value='' selected>"+placeholder+"</option>");
 	});
 
 })(jQuery);

--- a/includes/admin/class-ur-admin-assets.php
+++ b/includes/admin/class-ur-admin-assets.php
@@ -241,6 +241,8 @@ class UR_Admin_Assets {
 			)
 		);
 
+		wp_localize_script( 'user-registration-form-settings', 'user_registration_form_settings_params', array( 'ur_default_country_value_option' => apply_filters( 'user_registration_default_country_option', esc_html__( 'None', 'user-registration' ) ) ) );
+
 		wp_register_script( 'ur-form-templates', UR()->plugin_url() . '/assets/js/admin/form-templates' . $suffix . '.js', array( 'jquery' ), UR_VERSION, true );
 		wp_register_script( 'ur-copy', UR()->plugin_url() . '/assets/js/admin/ur-copy' . $suffix . '.js', 'jquery', UR_VERSION, false );
 		wp_register_script( 'ur-my-account', UR()->plugin_url() . '/assets/js/frontend/my-account' . $suffix . '.js', array( 'jquery' ), UR_VERSION, false );

--- a/includes/form/class-ur-form-field-country.php
+++ b/includes/form/class-ur-form-field-country.php
@@ -391,6 +391,10 @@ class UR_Form_Field_Country extends UR_Form_Field {
 		$field_label     = $single_form_field->general_setting->field_name;
 		$value           = isset( $form_data->value ) ? $form_data->value : '';
 		$valid_countries = $single_form_field->advance_setting->selected_countries;
+		$required = $single_form_field->general_setting->required;
+		if( ! ur_string_to_bool( $required ) ) {
+			return;
+		}
 
 		if ( ! in_array( $value, $valid_countries, true ) ) {
 			add_filter(

--- a/includes/form/class-ur-form-field-country.php
+++ b/includes/form/class-ur-form-field-country.php
@@ -301,12 +301,12 @@ class UR_Form_Field_Country extends UR_Form_Field {
 	 * @param [string] $field_name Field Name.
 	 */
 	public function get_selected_countries( $form_id, $field_name ) {
-		$countries = $this->get_country();
+		$countries          = $this->get_country();
 		$filtered_countries = array();
 		$selected_countries = array();
 
 		$form_data = UR()->form->get_form( $form_id, array( 'content_only' => true ) );
-		$fields = self::get_form_field_data( $form_data );
+		$fields    = self::get_form_field_data( $form_data );
 
 		// Get selected_countries data of the field.
 		foreach ( $fields as $field ) {
@@ -391,8 +391,8 @@ class UR_Form_Field_Country extends UR_Form_Field {
 		$field_label     = $single_form_field->general_setting->field_name;
 		$value           = isset( $form_data->value ) ? $form_data->value : '';
 		$valid_countries = $single_form_field->advance_setting->selected_countries;
-		$required = $single_form_field->general_setting->required;
-		if( ! ur_string_to_bool( $required ) ) {
+		$required        = $single_form_field->general_setting->required;
+		if ( ! ur_string_to_bool( $required ) ) {
 			return;
 		}
 

--- a/includes/form/settings/class-ur-setting-country.php
+++ b/includes/form/settings/class-ur-setting-country.php
@@ -100,6 +100,7 @@ class UR_Setting_Country extends UR_Field_Settings {
 			);
 			$value = array_merge( array( '' => apply_filters( 'user_registration_default_country_option', esc_html__( 'None', 'user-registration' ) ) ), $value );
 		}
+		$value = array_merge( array( '' => apply_filters( 'user_registration_default_country_option', esc_html__( 'None', 'user-registration' ) ) ), $value );
 
 		return $value;
 	}

--- a/includes/form/settings/class-ur-setting-country.php
+++ b/includes/form/settings/class-ur-setting-country.php
@@ -74,7 +74,7 @@ class UR_Setting_Country extends UR_Field_Settings {
 				'class'    => $this->default_class . ' ur-settings-default-value',
 				'type'     => 'select',
 				'required' => false,
-				'default'  => 'AF',
+				'default'  => '',
 				'options'  => $this->get_default_value_options(),
 				'tip'      => __( 'Default value for this field.', 'user-registration' ),
 			),
@@ -98,6 +98,7 @@ class UR_Setting_Country extends UR_Field_Settings {
 				UR_Form_Field_Country::get_instance()->get_country(),
 				array_flip( $selected_countries )
 			);
+			$value = array_merge( array( '' => apply_filters( 'user_registration_default_country_option', esc_html__( 'None', 'user-registration' ) ) ), $value );
 		}
 
 		return $value;

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -558,10 +558,10 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 					// If we have a blank option, select2 needs a placeholder.
 					if ( '' === $value && ! empty( $args['placeholder'] ) ) {
 						$disalbed = '';
-						if( 'country' !== $args['field_key'] ) {
+						if ( 'country' !== $args['field_key'] ) {
 							$disalbed = 'disabled';
 						}
-						$options .= '<option value="" selected '.esc_attr( $disalbed ).'>' . esc_html( $args['placeholder'] ) . '</option>';
+						$options .= '<option value="" selected ' . esc_attr( $disalbed ) . '>' . esc_html( $args['placeholder'] ) . '</option>';
 					}
 
 					$custom_attributes[] = 'data-allow_clear="true"';

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -557,7 +557,11 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 				if ( ! empty( $args['options'] ) ) {
 					// If we have a blank option, select2 needs a placeholder.
 					if ( '' === $value && ! empty( $args['placeholder'] ) ) {
-						$options .= '<option value="" selected disabled>' . esc_html( $args['placeholder'] ) . '</option>';
+						$disalbed = '';
+						if( 'country' !== $args['field_key'] ) {
+							$disalbed = 'disabled';
+						}
+						$options .= '<option value="" selected '.esc_attr( $disalbed ).'>' . esc_html( $args['placeholder'] ) . '</option>';
 					}
 
 					$custom_attributes[] = 'data-allow_clear="true"';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Previously, When the user wanted to select no default value of country there was no option for that. This PR gives those fixes.
### How to test the changes in this Pull Request:

1. Drag a country field.
2. Fill in the placeholder and verify the new option in the default value.
3. Also check if the field is a required case.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Fix - Placeholder is not working in the country field.
