### PR TITLE
Fix - Select field option not changing instantly

### DIFF
--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -3040,8 +3040,7 @@
 									$this_obj
 										.siblings(
 											'input[data-field="default_value"]'
-										)
-										.is(":checked")
+										).length>0
 								) {
 									URFormBuilder.render_select_box($(this));
 								} else if (
@@ -3826,15 +3825,28 @@
 			 * @param object this_node Select field from field settings.
 			 */
 			render_select_box: function (this_node) {
-				var value = this_node.val().trim();
+				var value = '';
+				if(this_node.is(":checked")) {
+					var value = this_node.val().trim();
+				}
 				var wrapper = $(".ur-selected-item.ur-item-active");
 				var checked_index = this_node.closest("li").index();
 				var select = wrapper.find(".ur-field").find("select");
 
+				if(this_node.hasClass('ur-type-radio-label')) {
+					value = select.val();
+				}
+
+				var options = this_node.closest('.ur-general-setting-options').find('input.ur-general-setting-field.ur-type-radio-label').map(function(){
+					return $(this).val();
+				});
+
 				select.html("");
-				select.append(
-					"<option value='" + value + "'>" + value + "</option>"
-				);
+				$.each(options, function(key, option){
+					select.append(
+						"<option value='" + option + "' "+(value === option ? 'selected' : '')+">" + option + "</option>"
+					);
+				});
 
 				// Loop through options in active fields general setting hidden div.
 				wrapper


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Previously, when we updated the option of select field. And if we choose that select field in the assigned role conditionally from the form setting without refreshing the page then the value of that updated option didn't come. This PR fixes that issue.


### How to test the changes in this Pull Request:

1. Edit the form and Change the select field option.
2. Form setting > enable assign role conditionally > choose select field
3. Verify its value.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?


### Changelog entry

> Fix - Select field option not changing instantly.
