### PR TITLE
UR-1304 Fix - Send email change confirmation with templates

### DIFF
--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -408,7 +408,7 @@ class UR_AJAX {
 			);
 
 			if ( $email_updated ) {
-				UR_Form_Handler::send_confirmation_email( $user, $pending_email );
+				UR_Form_Handler::send_confirmation_email( $user, $pending_email, $form_id );
 				$response['oldUserEmail'] = $user->user_email;
 				/* translators: %s : user email */
 				$response['userEmailUpdateMessage'] = sprintf( __( 'Your email address has not been updated yet. Please check your inbox at <strong>%s</strong> for a confirmation email.', 'user-registration' ), $pending_email );

--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -142,7 +142,7 @@ class UR_Form_Handler {
 			$message = apply_filters( 'user_registration_profile_update_success_message', __( 'User profile updated successfully.', 'user-registration' ) );
 
 			if ( $email_updated ) {
-				self::send_confirmation_email( $user, $pending_email );
+				self::send_confirmation_email( $user, $pending_email, $form_id );
 				/* translators: user_email */
 				$user_email_update_message = sprintf( __( 'Your email address has not been updated yet. Please check your inbox at <strong>%s</strong> for a confirmation email.', 'user-registration' ), $pending_email );
 				ur_add_notice( $user_email_update_message, 'notice' );
@@ -245,7 +245,7 @@ class UR_Form_Handler {
 	 * @param email  $new_email Email.
 	 * @return void
 	 */
-	public static function send_confirmation_email( $user, $new_email ) {
+	public static function send_confirmation_email( $user, $new_email, $form_id ) {
 		// Generate a confirmation key for the email change.
 		$confirm_key = wp_generate_password( 20, false );
 
@@ -258,26 +258,32 @@ class UR_Form_Handler {
 		$subject      = apply_filters( 'user_registration_email_change_email_subject', __( 'Confirm Your Email Address Change', 'user-registration' ) );
 		$message      = sprintf(
 			/* translators: %1$s is the display name of the user, %2$s is the new email, %3$s is the confirmation link, %4$s is the blog name. */
-			__(
-				'Dear %1$s,<br /><br />
-		You recently requested to change your email address associated with your account to %2$s.<br /><br />
-		To confirm this change, please click on the following link:<br />
-		<a href="%3$s">%3$s</a><br /><br />
-		This link will only be active for 24 hours. If you did not request this change, please ignore this email or contact us for assistance.<br /><br />
-		Best regards,<br />
-		%4$s',
-				'user-registration'
-			),
-			$user->display_name,
-			$new_email,
-			$confirm_link,
-			get_bloginfo( 'name' )
+			esc_html__(
+				'Dear %1$s,
+You recently requested to change your email address associated with your account to %2$s.
+To confirm this change, please click on the following link:
+%3$s
+This link will only be active for 24 hours. If you did not request this change, please ignore this email or contact us for assistance.
+Best regards,
+%4$s',
+'user-registration'
+),
+			esc_html( $user->display_name ),
+			esc_html( $new_email ),
+			esc_url( $confirm_link ),
+			esc_html( get_bloginfo('name') )
 		);
+		$template_id = ur_get_single_post_meta( $form_id, 'user_registration_select_email_template' );
 		$message  = apply_filters( 'user_registration_email_change_email_content', $message );
-		$headers  = 'From: ' . get_bloginfo( 'name' ) . ' <' . get_option( 'admin_email' ) . ">\n";
-		$headers .= "Content-Type: text/html; charset=UTF-8\n";
+		$message  = user_registration_process_email_content( $message, $template_id );
 
-		wp_mail( $to, $subject, $message, $headers );
+		$headers = array(
+			'From' => get_bloginfo('name') . ' <' . get_option('admin_email') . '>',
+			'Content-Type:text/html; charset=UTF-8',
+		);
+
+
+		wp_mail( $to, $subject, $message, $headers, $template_id );
 
 		update_user_meta( $user->ID, 'user_registration_email_confirm_key', $confirm_key );
 		update_user_meta( $user->ID, 'user_registration_pending_email', $new_email );

--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -271,7 +271,7 @@ class UR_Form_Handler {
 			),
 			esc_html( $user->display_name ),
 			esc_html( $new_email ),
-			esc_url( $confirm_link ),
+			'<a href="' . esc_url( $confirm_link ) . '">Click here</a>',
 			esc_html( get_bloginfo( 'name' ) )
 		);
 		$template_id = ur_get_single_post_meta( $form_id, 'user_registration_select_email_template' );

--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -243,6 +243,7 @@ class UR_Form_Handler {
 	 *
 	 * @param object $user User.
 	 * @param email  $new_email Email.
+	 * @param int    $form_id FormId.
 	 * @return void
 	 */
 	public static function send_confirmation_email( $user, $new_email, $form_id ) {
@@ -260,28 +261,27 @@ class UR_Form_Handler {
 			/* translators: %1$s is the display name of the user, %2$s is the new email, %3$s is the confirmation link, %4$s is the blog name. */
 			esc_html__(
 				'Dear %1$s,
-You recently requested to change your email address associated with your account to %2$s.
-To confirm this change, please click on the following link:
-%3$s
-This link will only be active for 24 hours. If you did not request this change, please ignore this email or contact us for assistance.
-Best regards,
-%4$s',
-'user-registration'
-),
+				You recently requested to change your email address associated with your account to %2$s.
+				To confirm this change, please click on the following link:
+				%3$s
+				This link will only be active for 24 hours. If you did not request this change, please ignore this email or contact us for assistance.
+				Best regards,
+				%4$s',
+				'user-registration'
+			),
 			esc_html( $user->display_name ),
 			esc_html( $new_email ),
 			esc_url( $confirm_link ),
-			esc_html( get_bloginfo('name') )
+			esc_html( get_bloginfo( 'name' ) )
 		);
 		$template_id = ur_get_single_post_meta( $form_id, 'user_registration_select_email_template' );
-		$message  = apply_filters( 'user_registration_email_change_email_content', $message );
-		$message  = user_registration_process_email_content( $message, $template_id );
+		$message     = apply_filters( 'user_registration_email_change_email_content', $message );
+		$message     = user_registration_process_email_content( $message, $template_id );
 
 		$headers = array(
-			'From' => get_bloginfo('name') . ' <' . get_option('admin_email') . '>',
+			'From' => get_bloginfo( 'name' ) . ' <' . get_option( 'admin_email' ) . '>',
 			'Content-Type:text/html; charset=UTF-8',
 		);
-
 
 		wp_mail( $to, $subject, $message, $headers, $template_id );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously, Email change confirmation does not include email template design. This PR will fix this issue.

### How to test the changes in this Pull Request:

1. Switch to this branch and verify whether it is working properly or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> UR-1304 Fix - Send email change confirmation with templates