### PR TITLE
UR-1240 Lost password page redirecting to login page.

### DIFF
--- a/includes/shortcodes/class-ur-shortcode-my-account.php
+++ b/includes/shortcodes/class-ur-shortcode-my-account.php
@@ -307,6 +307,9 @@ class UR_Shortcode_My_Account {
 
 			if ( isset( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ] ) && 0 < strpos( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ], ':' ) ) { // phpcs:ignore
 				list( $rp_login, $rp_key ) = array_map( 'ur_clean', explode( ':', wp_unslash( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ] ), 2 ) ); // phpcs:ignore
+				$user = get_user_by( 'id', $rp_login );
+				$rp_login = isset( $user->user_login ) ? $user->user_login : $rp_login;
+
 				$user                      = self::check_password_reset_key( $rp_key, $rp_login );
 
 				if ( ! empty( $user ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously, in rp_login variable instead of username it's returning user_id due to that wordpress default function was unable to identify the user and returning Invalid Key error message. In This this issue resolved.

### How to test the changes in this Pull Request:

1. Check Lost Password functionality working properly.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

>  Lost password page redirecting to login page.
