### PR TITLE
UR-1307 Fix - Profile completeness hook mismatch issue

### DIFF
--- a/templates/myaccount/form-edit-profile.php
+++ b/templates/myaccount/form-edit-profile.php
@@ -19,10 +19,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-
 $user_id = get_current_user_id();
 $form_id = ur_get_form_id_by_userid( $user_id );
-do_action( 'user_registration_before_edit_profile_form', $user_id, $form_id );
+
+do_action_deprecated( 'user_registration_before_edit_profile_form', array(), '3.1.3', 'user_registration_before_edit_profile_form_data' );
+do_action( 'user_registration_before_edit_profile_form_data', $user_id, $form_id );
 ?>
 
 <div class="ur-frontend-form login ur-edit-profile" id="ur-frontend-form">

--- a/templates/myaccount/form-edit-profile.php
+++ b/templates/myaccount/form-edit-profile.php
@@ -19,10 +19,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-do_action( 'user_registration_before_edit_profile_form' );
 
 $user_id = get_current_user_id();
 $form_id = ur_get_form_id_by_userid( $user_id );
+do_action( 'user_registration_before_edit_profile_form', $user_id, $form_id );
 ?>
 
 <div class="ur-frontend-form login ur-edit-profile" id="ur-frontend-form">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
In this PR, we deprecated `user_registration_before_edit_profile_form` and introduce new hook with arguments `user_registration_before_edit_profile_form_data`.

### How to test the changes in this Pull Request:

1. Check profile completeness addon working properly or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Profile completeness hook mismatch issue.
