### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Set env
         id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF:10}
+        run: echo "tag=${GITHUB_REF:10}" >> $GITHUB_OUTPUT
       - name: Build
         id: build
         uses: wpeverest/action-build@3.0.0

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Set env
         id: vars
-        run: echo "tag=${GITHUB_REF:10}" >> $GITHUB_OUTPUT
+        run: echo "tag=${GITHUB_REF:10}" >> "$GITHUB_OUTPUT"
       - name: Build
         id: build
         uses: wpeverest/action-build@3.0.0


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


