### PR TITLE
Fix - Fields select 2 and multi select option not changing instantly in builder setting area

### DIFF
--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -3032,11 +3032,15 @@
 						case "options":
 							$this_obj.on("keyup", function () {
 								if (
-									$this_obj
+									($this_obj
 										.closest(".ur-general-setting-block")
 										.hasClass(
 											"ur-general-setting-select"
-										) &&
+										) || $this_obj
+										.closest(".ur-general-setting-block")
+										.hasClass(
+											"ur-general-setting-select2"
+										) ) &&
 									$this_obj
 										.siblings(
 											'input[data-field="default_value"]'
@@ -3044,6 +3048,19 @@
 								) {
 									URFormBuilder.render_select_box($(this));
 								} else if (
+									$this_obj
+										.closest(".ur-general-setting-block")
+										.hasClass(
+											"ur-general-setting-multi_select2"
+										) &&
+									$this_obj
+										.siblings(
+											'input[data-field="default_value"]'
+										).length>0
+								) {
+									URFormBuilder.render_multi_select_box($(this));
+								}
+								 else if (
 									$this_obj
 										.closest(".ur-general-setting-block")
 										.hasClass("ur-general-setting-radio")
@@ -3843,6 +3860,51 @@
 				}
 
 				var options = this_node.closest('.ur-general-setting-options').find('input.ur-general-setting-field.ur-type-radio-label').map(function(){
+					return $(this).val();
+				});
+
+				select.html("");
+				$.each(options, function(key, option){
+					select.append(
+						"<option value='" + option + "' "+(value === option ? 'selected' : '')+">" + option + "</option>"
+					);
+				});
+
+				// Loop through options in active fields general setting hidden div.
+				wrapper
+					.find(
+						".ur-general-setting-options > ul.ur-options-list > li"
+					)
+					.each(function (index, element) {
+						var radio_input = $(element).find(
+							'[data-field="default_value"]'
+						);
+						if (index === checked_index) {
+							radio_input.prop("checked", true);
+						} else {
+							radio_input.prop("checked", false);
+						}
+					});
+			},
+			/**
+			 * Reflects changes in multi select field of field settings into selected field in form builder area.
+			 *
+			 * @param object this_node Multi Select field from field settings.
+			 */
+			render_multi_select_box: function (this_node) {
+				var value = '';
+				if(this_node.is(":checked")) {
+					var value = this_node.val().trim();
+				}
+				var wrapper = $(".ur-selected-item.ur-item-active");
+				var checked_index = this_node.closest("li").index();
+				var select = wrapper.find(".ur-field").find("select");
+
+				if(this_node.hasClass('ur-type-checkbox-label')) {
+					value = select.val();
+				}
+
+				var options = this_node.closest('.ur-general-setting-options').find('input.ur-general-setting-field.ur-type-checkbox-label').map(function(){
 					return $(this).val();
 				});
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Previously, when we updated the option of select2 and multi-select field. And if we choose that select2 and multi-select field in the assigned role conditionally or condition redirection from the form setting without refreshing the page then the value of that updated option didn't come. This PR fixes that issue.


### How to test the changes in this Pull Request:

1. Edit the form and Change the select2 and multi-select field option.
2. Form setting > enable assign role conditionally > choose select2 and multi-select field
3. Verify its value.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?


### Changelog entry

> Fix - Fields select 2 and multi select option not changing instantly in builder setting area
