### PR TITLE
 Fix - Remove extra password field value in mail

### DIFF
--- a/includes/class-ur-emailer.php
+++ b/includes/class-ur-emailer.php
@@ -230,6 +230,10 @@ class UR_Emailer {
 					$value = esc_html__( 'Accepted', 'user-registration' );
 				}
 
+				if ('password' === $form_data['type']){
+					$value = '';
+				}
+
 				if ( 'country' === $form_data['field_key'] && '' !== $value ) {
 					$country_class = ur_load_form_field_class( $form_data['field_key'] );
 					$countries     = $country_class::get_instance()->get_country();
@@ -245,6 +249,7 @@ class UR_Emailer {
 				if ( 'user_email' === $field_name ) {
 					$email = $value;
 				}
+
 				$tmp_data['value']        = $value;
 				$tmp_data['field_type']   = $form_data['type'];
 				$tmp_data['label']        = $form_data['label'];

--- a/includes/class-ur-emailer.php
+++ b/includes/class-ur-emailer.php
@@ -231,7 +231,7 @@ class UR_Emailer {
 				}
 
 				if ('password' === $form_data['type']){
-					$value = '';
+					$value = esc_html__('Chosen Password', 'user-registration');
 				}
 
 				if ( 'country' === $form_data['field_key'] && '' !== $value ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?


### Changes proposed in this Pull Request:

Previously, the password was visible in the mail if  extra password field was used in the form. If user updates the detail on form having extra password field and the email enabled for the admin account.

Closes # .

### How to test the changes in this Pull Request:

1. Go to UR Settings > Emails
2. Enable toggle for Profile Details Changed Admin Email
3. Create a form using an extra password field
4. Register a user using the newly created form
5. Go to Edit profile page of the user account
6. And update the user details
7. Now, go to admin email mail box
8. And check where the password is visible on the user detail or not.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?


### Changelog entry

> Fix - Remove extra password field value in mail
