### PR TITLE
Feature - Deny Smart Tag in Admin Approval.

### DIFF
--- a/includes/admin/class-ur-admin-user-manager.php
+++ b/includes/admin/class-ur-admin-user-manager.php
@@ -450,7 +450,7 @@ class UR_Admin_User_Manager {
 		$status_map = array(
 			'approved' => 1,
 			'pending' => 0,
-			'denied' => -1
+			'denied' => -1,
 		);
 
 		if ( isset( $status_map[ $status_label ] ) ) {

--- a/includes/admin/class-ur-admin-user-manager.php
+++ b/includes/admin/class-ur-admin-user-manager.php
@@ -104,7 +104,7 @@ class UR_Admin_User_Manager {
 			case self::DENIED:
 				$action_label = 'denied';
 				if ( 'admin_approval_after_email_confirmation' === $login_option ) {
-					update_user_meta( $this->user->ID, 'ur_admin_approval_after_email_confirmation', 'false' );
+					update_user_meta( $this->user->ID, 'ur_admin_approval_after_email_confirmation', 'denied' );
 				} elseif ( 'email_confirmation' === $login_option ) {
 					update_user_meta( $this->user->ID, 'ur_confirm_email', $status );
 				}

--- a/includes/admin/settings/emails/class-ur-settings-approval-link-email.php
+++ b/includes/admin/settings/emails/class-ur-settings-approval-link-email.php
@@ -106,7 +106,7 @@ if ( ! class_exists( 'UR_Settings_Approval_Link_Email', false ) ) :
 					Please review the user role and details at \'<b>Users</b>\' menu in your WP dashboard. <br/><br />
 
 					Click on this link to approve this user directly :  {{approval_link}} <br />
-					Click on this link to deny this user directly :  {{denail_link}} <br /><br />
+					Click on this link to deny this user directly :  {{denial_link}} <br /><br />
 					Thank You!',
 					'user-registration'
 				)

--- a/includes/admin/settings/emails/class-ur-settings-approval-link-email.php
+++ b/includes/admin/settings/emails/class-ur-settings-approval-link-email.php
@@ -105,7 +105,8 @@ if ( ! class_exists( 'UR_Settings_Approval_Link_Email', false ) ) :
 
 					Please review the user role and details at \'<b>Users</b>\' menu in your WP dashboard. <br/><br />
 
-					Click on this link to approve this user directly :  {{approval_link}} <br /><br />
+					Click on this link to approve this user directly :  {{approval_link}} <br />
+					Click on this link to deny this user directly :  {{denail_link}} <br /><br />
 					Thank You!',
 					'user-registration'
 				)

--- a/includes/class-ur-email-approval.php
+++ b/includes/class-ur-email-approval.php
@@ -58,6 +58,7 @@ class UR_Email_Approval {
 						$user_manager->save_status( UR_Admin_User_Manager::APPROVED, true );
 
 						delete_user_meta( $user_id, 'ur_confirm_approval_token' );
+						delete_user_meta( $user_id, 'ur_confirm_denial_token' );
 
 						add_action( 'admin_notices', array( __CLASS__, 'approved_success' ) );
 
@@ -109,6 +110,7 @@ class UR_Email_Approval {
 						$user_manager->save_status( UR_Admin_User_Manager::DENIED, true );
 
 						delete_user_meta( $user_id, 'ur_confirm_denial_token' );
+						delete_user_meta( $user_id, 'ur_confirm_approval_token' );
 
 						add_action( 'admin_notices', array( __CLASS__, 'denied_success' ) );
 

--- a/includes/class-ur-email-approval.php
+++ b/includes/class-ur-email-approval.php
@@ -21,7 +21,9 @@ class UR_Email_Approval {
 	 */
 	public function __construct() {
 		add_action( 'user_registration_after_register_user_action', array( $this, 'set_approval_status' ), 5, 3 );
+		add_action( 'user_registration_after_register_user_action', array( $this, 'set_denail_status' ), 5, 3 );
 		add_action( 'admin_init', array( __CLASS__, 'approve_user_after_verification' ) );
+		add_action( 'admin_init', array( __CLASS__, 'deny_user_after_verification' ) );
 	}
 
 	/**
@@ -76,10 +78,68 @@ class UR_Email_Approval {
 	}
 
 	/**
+	 * Verify the token and deny the user if the token matches
+	 */
+	public static function deny_user_after_verification() {
+		if ( ! isset( $_GET['ur_denail_token'] ) || empty( $_GET['ur_denail_token'] ) ) {
+			return;
+		} else {
+			if ( current_user_can( 'edit_users' ) ) {
+
+				$ur_denail_token_raw = sanitize_text_field( wp_unslash( $_GET['ur_denail_token'] ) );
+				$ur_denail_token     = str_split( $ur_denail_token_raw, 50 );
+				$token_string = $ur_denail_token[1];
+
+				if ( 2 < count( $ur_denail_token ) ) {
+					unset( $ur_denail_token[0] );
+					$token_string = join( '', $ur_denail_token );
+				}
+				$output     = crypt_the_string( $token_string, 'd' );
+				$output     = explode( '_', $output );
+				$user_id    = absint( $output[0] );
+				$form_id    = ur_get_form_id_by_userid( $user_id );
+
+				$email_approval_enabled = ur_get_single_post_meta( $form_id, 'user_registration_form_setting_enable_email_approval', get_option( 'user_registration_login_option_enable_email_approval', false ) );
+
+				if ( $email_approval_enabled ) {
+					$saved_token = get_user_meta( $user_id, 'ur_confirm_denail_token', true );
+
+					if ( $ur_denail_token_raw === $saved_token ) {
+						$user_manager = new UR_Admin_User_Manager( $user_id );
+						$user_manager->save_status( UR_Admin_User_Manager::DENIED, true );
+
+						delete_user_meta( $user_id, 'ur_confirm_denail_token' );
+
+						add_action( 'admin_notices', array( __CLASS__, 'denied_success' ) );
+
+						$redirect_url = admin_url() . 'users.php';
+						wp_redirect( $redirect_url );
+						exit;
+
+					} else {
+						add_action( 'admin_notices', array( __CLASS__, 'invalid_approval_token_message' ) );
+					}
+				} else {
+					add_action( 'admin_notices', array( __CLASS__, 'email_denail_disabled_message' ) );
+				}
+			} else {
+				return;
+			}
+		}
+	}
+
+	/**
 	 * Message to show when user approved successfully
 	 */
 	public static function approved_success() {
 		echo '<div class="notice notice-success"><p>' . esc_html__( 'User approved successfully.', 'user-registration' );
+	}
+
+	/**
+	 * Message to show when user denied successfully
+	 */
+	public static function denied_success() {
+		echo '<div class="notice notice-success"><p>' . esc_html__( 'User denied successfully.', 'user-registration' );
 	}
 
 	/**
@@ -94,6 +154,13 @@ class UR_Email_Approval {
 	 */
 	public static function email_approval_disabled_message() {
 		echo '<div class="notice notice-warning"><p>' . esc_html__( 'Failed to approve user. Email Approval Option is Disabled.', 'user-registration' ) . '</p></div>';
+	}
+
+	/**
+	 * Email Denail Disabled Message
+	 */
+	public static function email_denail_disabled_message() {
+		echo '<div class="notice notice-warning"><p>' . esc_html__( 'Failed to deny user. Email Approval Option is Disabled.', 'user-registration' ) . '</p></div>';
 	}
 
 	/**
@@ -138,6 +205,27 @@ class UR_Email_Approval {
 		if ( ( 'admin_approval' == $login_option || 'admin_approval_after_email_confirmation' == $login_option ) && ( $email_approval_enabled ) ) {
 			$token = $this->get_token( $user_id );
 			update_user_meta( $user_id, 'ur_confirm_approval_token', $token );
+		} else {
+			return;
+		}
+	}
+
+	/**
+	 * Set the denail token of the user and update it to usermeta table in database.
+	 *
+	 * @param array $valid_form_data Form filled data.
+	 * @param int   $form_id         Form ID.
+	 * @param int   $user_id         User ID.
+	 */
+	public function set_denail_status( $valid_form_data, $form_id, $user_id ) {
+		$form_id = isset( $form_id ) ? $form_id : get_user_meta( $this->user->ID, 'ur_form_id', true );
+		$login_option = ur_get_user_login_option( $user_id );
+
+		$email_approval_enabled = ur_get_single_post_meta( $form_id, 'user_registration_form_setting_enable_email_approval', get_option( 'user_registration_login_option_enable_email_approval', false ) );
+
+		if ( ( 'admin_approval' == $login_option || 'admin_approval_after_email_confirmation' == $login_option ) && ( $email_approval_enabled ) ) {
+			$token = $this->get_token( $user_id );
+			update_user_meta( $user_id, 'ur_confirm_denail_token', $token );
 		} else {
 			return;
 		}

--- a/includes/class-ur-email-approval.php
+++ b/includes/class-ur-email-approval.php
@@ -21,7 +21,7 @@ class UR_Email_Approval {
 	 */
 	public function __construct() {
 		add_action( 'user_registration_after_register_user_action', array( $this, 'set_approval_status' ), 5, 3 );
-		add_action( 'user_registration_after_register_user_action', array( $this, 'set_denail_status' ), 5, 3 );
+		add_action( 'user_registration_after_register_user_action', array( $this, 'set_denial_status' ), 5, 3 );
 		add_action( 'admin_init', array( __CLASS__, 'approve_user_after_verification' ) );
 		add_action( 'admin_init', array( __CLASS__, 'deny_user_after_verification' ) );
 	}
@@ -81,18 +81,18 @@ class UR_Email_Approval {
 	 * Verify the token and deny the user if the token matches
 	 */
 	public static function deny_user_after_verification() {
-		if ( ! isset( $_GET['ur_denail_token'] ) || empty( $_GET['ur_denail_token'] ) ) {
+		if ( ! isset( $_GET['ur_denial_token'] ) || empty( $_GET['ur_denial_token'] ) ) {
 			return;
 		} else {
 			if ( current_user_can( 'edit_users' ) ) {
 
-				$ur_denail_token_raw = sanitize_text_field( wp_unslash( $_GET['ur_denail_token'] ) );
-				$ur_denail_token     = str_split( $ur_denail_token_raw, 50 );
-				$token_string = $ur_denail_token[1];
+				$ur_denial_token_raw = sanitize_text_field( wp_unslash( $_GET['ur_denial_token'] ) );
+				$ur_denial_token     = str_split( $ur_denial_token_raw, 50 );
+				$token_string = $ur_denial_token[1];
 
-				if ( 2 < count( $ur_denail_token ) ) {
-					unset( $ur_denail_token[0] );
-					$token_string = join( '', $ur_denail_token );
+				if ( 2 < count( $ur_denial_token ) ) {
+					unset( $ur_denial_token[0] );
+					$token_string = join( '', $ur_denial_token );
 				}
 				$output     = crypt_the_string( $token_string, 'd' );
 				$output     = explode( '_', $output );
@@ -102,13 +102,13 @@ class UR_Email_Approval {
 				$email_approval_enabled = ur_get_single_post_meta( $form_id, 'user_registration_form_setting_enable_email_approval', get_option( 'user_registration_login_option_enable_email_approval', false ) );
 
 				if ( $email_approval_enabled ) {
-					$saved_token = get_user_meta( $user_id, 'ur_confirm_denail_token', true );
+					$saved_token = get_user_meta( $user_id, 'ur_confirm_denial_token', true );
 
-					if ( $ur_denail_token_raw === $saved_token ) {
+					if ( $ur_denial_token_raw === $saved_token ) {
 						$user_manager = new UR_Admin_User_Manager( $user_id );
 						$user_manager->save_status( UR_Admin_User_Manager::DENIED, true );
 
-						delete_user_meta( $user_id, 'ur_confirm_denail_token' );
+						delete_user_meta( $user_id, 'ur_confirm_denial_token' );
 
 						add_action( 'admin_notices', array( __CLASS__, 'denied_success' ) );
 
@@ -120,7 +120,7 @@ class UR_Email_Approval {
 						add_action( 'admin_notices', array( __CLASS__, 'invalid_approval_token_message' ) );
 					}
 				} else {
-					add_action( 'admin_notices', array( __CLASS__, 'email_denail_disabled_message' ) );
+					add_action( 'admin_notices', array( __CLASS__, 'email_denial_disabled_message' ) );
 				}
 			} else {
 				return;
@@ -157,9 +157,9 @@ class UR_Email_Approval {
 	}
 
 	/**
-	 * Email Denail Disabled Message
+	 * Email denial Disabled Message
 	 */
-	public static function email_denail_disabled_message() {
+	public static function email_denial_disabled_message() {
 		echo '<div class="notice notice-warning"><p>' . esc_html__( 'Failed to deny user. Email Approval Option is Disabled.', 'user-registration' ) . '</p></div>';
 	}
 
@@ -211,13 +211,13 @@ class UR_Email_Approval {
 	}
 
 	/**
-	 * Set the denail token of the user and update it to usermeta table in database.
+	 * Set the denial token of the user and update it to usermeta table in database.
 	 *
 	 * @param array $valid_form_data Form filled data.
 	 * @param int   $form_id         Form ID.
 	 * @param int   $user_id         User ID.
 	 */
-	public function set_denail_status( $valid_form_data, $form_id, $user_id ) {
+	public function set_denial_status( $valid_form_data, $form_id, $user_id ) {
 		$form_id = isset( $form_id ) ? $form_id : get_user_meta( $this->user->ID, 'ur_form_id', true );
 		$login_option = ur_get_user_login_option( $user_id );
 
@@ -225,7 +225,7 @@ class UR_Email_Approval {
 
 		if ( ( 'admin_approval' == $login_option || 'admin_approval_after_email_confirmation' == $login_option ) && ( $email_approval_enabled ) ) {
 			$token = $this->get_token( $user_id );
-			update_user_meta( $user_id, 'ur_confirm_denail_token', $token );
+			update_user_meta( $user_id, 'ur_confirm_denial_token', $token );
 		} else {
 			return;
 		}

--- a/includes/class-ur-emailer.php
+++ b/includes/class-ur-emailer.php
@@ -419,9 +419,9 @@ class UR_Emailer {
 		// If enabled approval via email setting.
 		if ( ( 'admin_approval' === $login_option || 'admin_approval_after_email_confirmation' === $login_option ) ) {
 			$values['approval_token'] = get_user_meta( $user_id, 'ur_confirm_approval_token', true );
-			$values['denail_token'] = get_user_meta( $user_id, 'ur_confirm_denail_token', true );
+			$values['denial_token'] = get_user_meta( $user_id, 'ur_confirm_denial_token', true );
 			$values['approval_link']  = '<a href="' . admin_url( '/' ) . '?ur_approval_token=' . $values['approval_token'] . '">' . esc_html__( 'Approve Now', 'user-registration' ) . '</a><br />';
-			$values['denail_link']  = '<a href="' . admin_url( '/' ) . '?ur_denail_token=' . $values['denail_token'] . '">' . esc_html__( 'Deny Now', 'user-registration' ) . '</a><br />';
+			$values['denial_link']  = '<a href="' . admin_url( '/' ) . '?ur_denial_token=' . $values['denial_token'] . '">' . esc_html__( 'Deny Now', 'user-registration' ) . '</a><br />';
 		}
 
 		list( $message, $subject ) = user_registration_email_content_overrider( ur_get_form_id_by_userid( $user_id ), $settings, $message, $subject );
@@ -491,9 +491,9 @@ class UR_Emailer {
 		// If enabled approval via email setting.
 		if ( ( 'admin_approval' === $login_option || 'admin_approval_after_email_confirmation' === $login_option ) && ( 1 === absint( $email_approval_enabled ) ) ) {
 			$values['approval_token'] = get_user_meta( $user_id, 'ur_confirm_approval_token', true );
-			$values['denail_token'] = get_user_meta( $user_id, 'ur_confirm_denail_token', true );
+			$values['denial_token'] = get_user_meta( $user_id, 'ur_confirm_denial_token', true );
 			$values['approval_link']  = '<a href="' . admin_url( '/' ) . '?ur_approval_token=' . $values['approval_token'] . '">' . esc_html__( 'Approve Now', 'user-registration' ) . '</a><br />';
-			$values['denail_link']  = '<a href="' . admin_url( '/' ) . '?ur_denail_token=' . $values['denail_token'] . '">' . esc_html__( 'Deny Now', 'user-registration' ) . '</a><br />';
+			$values['denial_link']  = '<a href="' . admin_url( '/' ) . '?ur_denial_token=' . $values['denial_token'] . '">' . esc_html__( 'Deny Now', 'user-registration' ) . '</a><br />';
 		}
 
 		list( $message, $subject ) = user_registration_email_content_overrider( ur_get_form_id_by_userid( $user_id ), $settings, $message, $subject );

--- a/includes/class-ur-emailer.php
+++ b/includes/class-ur-emailer.php
@@ -419,7 +419,9 @@ class UR_Emailer {
 		// If enabled approval via email setting.
 		if ( ( 'admin_approval' === $login_option || 'admin_approval_after_email_confirmation' === $login_option ) ) {
 			$values['approval_token'] = get_user_meta( $user_id, 'ur_confirm_approval_token', true );
+			$values['denail_token'] = get_user_meta( $user_id, 'ur_confirm_denail_token', true );
 			$values['approval_link']  = '<a href="' . admin_url( '/' ) . '?ur_approval_token=' . $values['approval_token'] . '">' . esc_html__( 'Approve Now', 'user-registration' ) . '</a><br />';
+			$values['denail_link']  = '<a href="' . admin_url( '/' ) . '?ur_denail_token=' . $values['denail_token'] . '">' . esc_html__( 'Deny Now', 'user-registration' ) . '</a><br />';
 		}
 
 		list( $message, $subject ) = user_registration_email_content_overrider( ur_get_form_id_by_userid( $user_id ), $settings, $message, $subject );
@@ -489,7 +491,9 @@ class UR_Emailer {
 		// If enabled approval via email setting.
 		if ( ( 'admin_approval' === $login_option || 'admin_approval_after_email_confirmation' === $login_option ) && ( 1 === absint( $email_approval_enabled ) ) ) {
 			$values['approval_token'] = get_user_meta( $user_id, 'ur_confirm_approval_token', true );
+			$values['denail_token'] = get_user_meta( $user_id, 'ur_confirm_denail_token', true );
 			$values['approval_link']  = '<a href="' . admin_url( '/' ) . '?ur_approval_token=' . $values['approval_token'] . '">' . esc_html__( 'Approve Now', 'user-registration' ) . '</a><br />';
+			$values['denail_link']  = '<a href="' . admin_url( '/' ) . '?ur_denail_token=' . $values['denail_token'] . '">' . esc_html__( 'Deny Now', 'user-registration' ) . '</a><br />';
 		}
 
 		list( $message, $subject ) = user_registration_email_content_overrider( ur_get_form_id_by_userid( $user_id ), $settings, $message, $subject );

--- a/includes/class-ur-smart-tags.php
+++ b/includes/class-ur-smart-tags.php
@@ -348,7 +348,7 @@ class UR_Smart_Tags {
 							}
 						}
 						break;
-					case 'denail_link':
+					case 'denial_link':
 						if ( isset( $values['email'] ) && '' !== $values['email'] ) {
 							$user    = get_user_by( 'email', $values['email'] );
 							$user_id = $user->ID;
@@ -357,9 +357,9 @@ class UR_Smart_Tags {
 
 							// If enabled approval via email setting.
 							if ( ( 'admin_approval' === $login_option || 'admin_approval_after_email_confirmation' === $login_option ) ) {
-								$denail_token = get_user_meta( $user_id, 'ur_confirm_denail_token', true );
-								$denail_link  = '<a href="' . admin_url( '/' ) . '?ur_denail_token=' . $denail_token . '">' . esc_html__( 'Deny Now', 'user-registration' ) . '</a><br />';
-								$content        = str_replace( '{{' . $tag . '}}', $denail_link, $content );
+								$denial_token = get_user_meta( $user_id, 'ur_confirm_denial_token', true );
+								$denial_link  = '<a href="' . admin_url( '/' ) . '?ur_denial_token=' . $denial_token . '">' . esc_html__( 'Deny Now', 'user-registration' ) . '</a><br />';
+								$content        = str_replace( '{{' . $tag . '}}', $denial_link, $content );
 							}
 						}
 						break;

--- a/includes/class-ur-smart-tags.php
+++ b/includes/class-ur-smart-tags.php
@@ -348,6 +348,21 @@ class UR_Smart_Tags {
 							}
 						}
 						break;
+					case 'denail_link':
+						if ( isset( $values['email'] ) && '' !== $values['email'] ) {
+							$user    = get_user_by( 'email', $values['email'] );
+							$user_id = $user->ID;
+
+							$login_option = ur_get_user_login_option( $user_id );
+
+							// If enabled approval via email setting.
+							if ( ( 'admin_approval' === $login_option || 'admin_approval_after_email_confirmation' === $login_option ) ) {
+								$denail_token = get_user_meta( $user_id, 'ur_confirm_denail_token', true );
+								$denail_link  = '<a href="' . admin_url( '/' ) . '?ur_denail_token=' . $denail_token . '">' . esc_html__( 'Deny Now', 'user-registration' ) . '</a><br />';
+								$content        = str_replace( '{{' . $tag . '}}', $denail_link, $content );
+							}
+						}
+						break;
 					case 'display_name':
 						$user_id   = ! empty( $values['user_id'] ) ? $values['user_id'] : get_current_user_id();
 						$user_data = get_userdata( $user_id );

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -978,7 +978,7 @@ function ur_admin_form_settings_fields( $form_id ) {
 				'tip'               => __( 'Login method that should be used by the users registered through this form.', 'user-registration' ),
 			),
 			array(
-				'label'       => __( 'Send User Approval Link in Email', 'user-registration' ),
+				'label'       => __( 'Send User Approval and Denail Link in Email', 'user-registration' ),
 				'description' => '',
 				'id'          => 'user_registration_form_setting_enable_email_approval',
 				'type'        => 'toggle',

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -978,7 +978,7 @@ function ur_admin_form_settings_fields( $form_id ) {
 				'tip'               => __( 'Login method that should be used by the users registered through this form.', 'user-registration' ),
 			),
 			array(
-				'label'       => __( 'Send User Approval and Denail Link in Email', 'user-registration' ),
+				'label'       => __( 'Send User Approval and Denial Link in Email', 'user-registration' ),
 				'description' => '',
 				'id'          => 'user_registration_form_setting_enable_email_approval',
 				'type'        => 'toggle',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?


### Changes proposed in this Pull Request:

Previously, there was no link sent to Admin to "Deny" user directly through "Admin Approval" and "Admin Approval after Email Confirmation". This PR introduces "{{denial_link}}" smart tag similar to "{{approval_link}}".

Closes # .

### How to test the changes in this Pull Request:

1. Switch to this PR and Goto Form settings of a Form.
2. Set to "Admin Approval" or "Admin Approval after Email Confirmation" for User Approval and Login Option.
3. Register a user, test if "Deny Now" Link works on admin email for denying user for both test cases.
4. Keep in mind the use of {{denail_link}} smart tag on admin email in User Registration > Settings > Email.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Feature - Deny Smart Tag in Admin Approval.
