### PR TITLE
Tweak  - Redirection back to previous page after registration

### DIFF
--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -1129,6 +1129,7 @@ function ur_admin_form_settings_fields( $form_id ) {
 						'no-redirection' => __( 'No Redirection', 'user-registration' ),
 						'internal-page'  => __( 'Internal Page', 'user-registration' ),
 						'external-url'   => __( 'External URL', 'user-registration' ),
+						'previous-page'  => __( 'Previous Page', 'user-registration' ),
 					)
 				),
 				'default'           => ur_get_single_post_meta( $form_id, 'user_registration_form_setting_redirect_after_registration', 'no-redirection' ),

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -90,6 +90,9 @@ if ( ! function_exists( 'ur_get_form_redirect_url' ) ) {
 						$redirect_url = $external_url;
 
 						break;
+					case 'previous-page':
+						$redirect_url = apply_filters( 'user_registration_redirection_back_to_previous_page_url', isset( $_SERVER['HTTP_REFERER'] ) ? $_SERVER['HTTP_REFERER'] : $redirect_url, $form_id );
+						break;
 
 					default:
 				}

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -91,7 +91,7 @@ if ( ! function_exists( 'ur_get_form_redirect_url' ) ) {
 
 						break;
 					case 'previous-page':
-						$redirect_url = apply_filters( 'user_registration_redirection_back_to_previous_page_url', isset( $_SERVER['HTTP_REFERER'] ) ? $_SERVER['HTTP_REFERER'] : $redirect_url, $form_id );
+						$redirect_url = apply_filters( 'user_registration_redirection_back_to_previous_page_url', isset( $_SERVER['HTTP_REFERER'] ) ? esc_url_raw( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : $redirect_url, $form_id );
 						break;
 
 					default:


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:
This PR introduces the **Previous page** option in the redirection after registration which redirect back to previous page URL after registration
### How to test the changes in this Pull Request:

1. Create a form
2. Goto to form settings >General > choose the previous page in redirection after the registration section
3. Verify.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Tweak  - Redirection back to previous page after registration
