### PR TITLE
Fix - Country Field default value none Frontend Issue.

### DIFF
--- a/includes/form/class-ur-form-field-country.php
+++ b/includes/form/class-ur-form-field-country.php
@@ -366,6 +366,7 @@ class UR_Form_Field_Country extends UR_Form_Field {
 		$this->field_defaults = array(
 			'default_label'      => __( 'Country', 'user-registration' ),
 			'default_field_name' => 'country_' . ur_get_random_number(),
+			'default_placeholder' => __( 'Select a country', 'user-registration' ),
 		);
 	}
 

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -644,7 +644,7 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 						$options .= '<option value="" selected ' . esc_attr( $disalbed ) . '>' . esc_html( $args['placeholder'] ) . '</option>';
 					}
 
-					if ( 'country' === $args['field_key'] && empty( $args['placeholder'] ) && empty( $value ) ) {
+					if ( isset( $args['field_key'] ) && 'country' === $args['field_key'] && empty( $args['placeholder'] ) && empty( $value ) ) {
 						$options .= '<option value="" selected >' . esc_html__( 'Select a country', 'user-registration' ) . '</option>';
 					}
 

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -644,6 +644,10 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 						$options .= '<option value="" selected ' . esc_attr( $disalbed ) . '>' . esc_html( $args['placeholder'] ) . '</option>';
 					}
 
+					if ( 'country' === $args['field_key'] && empty( $args['placeholder'] ) && empty( $value ) ) {
+						$options .= '<option value="" selected >' . esc_html__( 'Select a country', 'user-registration' ) . '</option>';
+					}
+
 					$custom_attributes[] = 'data-allow_clear="true"';
 					foreach ( $args['options'] as $option_key => $option_text ) {
 						$selected_attribute = '';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?


### Changes proposed in this Pull Request:

Previously, when we select default value of Country field to 'None', the field on the frontend was showing 'Afghanistan' (first country) as default. This PR fixes this issue.

Closes # .

### How to test the changes in this Pull Request:

1. Drag a country field in your form.
2. Erase the placeholder (empty) and select default value as 'None'.
3. Check on the frontend. (Also try entering a placeholder value and verify if it is working properly or not).

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Country Field default value none Frontend Issue.
