### PR TITLE
Fix - Checkbox not updating properly on profile update when all unchecked.

### DIFF
--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -128,6 +128,10 @@ class UR_Form_Handler {
 						if ( 'disabled' !== $disabled ) {
 							if ( isset( $_POST[ $key ] ) ) {
 								update_user_meta( $user_id, $update_key, wp_unslash( $_POST[ $key ] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+							} else {
+								if ( 'checkbox' === $field['field_key'] ) {
+									update_user_meta( $user_id, $update_key, '' );
+								}
 							}
 						}
 					}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?


### Changes proposed in this Pull Request:

Previously, when all the options of the checkbox on the Account Page are unchecked while saving the profile details ( only on POST update ) , it reverts back to the previously checked option.


### How to test the changes in this Pull Request:

1. Insert Checkbox on a Form and Register a user.
2. Login as user and goto My Account > Profile Details.
3. Uncheck all the options from that Checkbox and verify whether it is working properly or not.
4. Also verify by checking and unchecking the "AJAX Submission on Profile Update" option from User Registration > General Settings.
5. Cross check by applying Conditional Logic and Field Visibility on that Field.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Checkbox not updating properly on profile update when all unchecked.
