### PR TITLE
Tweak - Introduce form name smart tag in user registration

### DIFF
--- a/includes/class-ur-smart-tags.php
+++ b/includes/class-ur-smart-tags.php
@@ -76,6 +76,7 @@ class UR_Smart_Tags {
 			'{{user_ip_address}}'  => esc_html__( 'User IP Address', 'user-registration' ),
 			'{{referrer_url}}'     => esc_html__( 'Referrer URL', 'user-registration' ),
 			'{{form_id}}'          => esc_html__( 'Form ID', 'user-registration' ),
+			'{{form_name}}'        => esc_html__( 'Form Name', 'user-registration' ),
 			'{{author_email}}'     => esc_html__( 'Author Email', 'user-registration' ),
 			'{{author_name}}'      => esc_html__( 'Author Name', 'user-registration' ),
 			'{{unique_id}}'        => esc_html__( 'Unique ID', 'user-registration' ),
@@ -275,6 +276,12 @@ class UR_Smart_Tags {
 						}
 
 						$content = str_replace( '{{' . $other_tag . '}}', $form_id, $content );
+						break;
+
+					case 'form_name':
+						$current_form_id = $values['form_id'];
+						$form_name       = ucfirst( get_the_title( $current_form_id ) );
+						$content         = str_replace( '{{' . $other_tag . '}}', $form_name, $content );
 						break;
 
 					case 'user_ip_address':

--- a/includes/class-ur-smart-tags.php
+++ b/includes/class-ur-smart-tags.php
@@ -279,7 +279,7 @@ class UR_Smart_Tags {
 						break;
 
 					case 'form_name':
-						$current_form_id = $values['form_id'];
+						$current_form_id = isset( $values['form_id'] );
 						$form_name       = ucfirst( get_the_title( $current_form_id ) );
 						$content         = str_replace( '{{' . $other_tag . '}}', $form_name, $content );
 						break;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?


### Changes proposed in this Pull Request:

There was no option to add {{form_name}} as the smart tag. This PR introduces the {{form_name}} smart tag.

Closes # .

### How to test the changes in this Pull Request:

1. Go to UR>Settings>Emails
2. Click on any email settings option
3. Click on Add Smart Tags button. It now includes Form Name on the list.
4. Add it on the email content
5. Register a user enabling the modified email content.
6. Now, verify if it is working accordingly or not.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Tweak - Introduce form name smart tag in user registration
