### PR TITLE
Tweak - Tooltip message for Username, Text and Textarea of Length Advance Settings.

### DIFF
--- a/includes/form/settings/class-ur-setting-text.php
+++ b/includes/form/settings/class-ur-setting-text.php
@@ -50,7 +50,7 @@ class UR_Setting_Text extends UR_Field_Settings {
 				'required'    => false,
 				'default'     => 'false',
 				'placeholder' => '',
-				'tip'         => __( 'Allowed maximum number of characters / words.', 'user-registration' ),
+				'tip'         => __( 'Allow Limiting of Length.', 'user-registration' ),
 			),
 			'limit_length_limit_count' => array(
 				'label'       => __( 'Limit Count', 'user-registration' ),
@@ -76,7 +76,7 @@ class UR_Setting_Text extends UR_Field_Settings {
 				'required'    => false,
 				'default'     => 'characters',
 				'placeholder' => '',
-				'tip'         => __( 'Allowed maximum number of characters / words.', 'user-registration' ),
+				'tip'         => __( 'Maximum limit by characters / words.', 'user-registration' ),
 			),
 			'minimum_length' => array(
 				'label'       => __( 'Minimum Length', 'user-registration' ),
@@ -87,7 +87,7 @@ class UR_Setting_Text extends UR_Field_Settings {
 				'required'    => false,
 				'default'     => 'false',
 				'placeholder' => '',
-				'tip'         => __( 'Allowed maximum number of characters / words.', 'user-registration' ),
+				'tip'         => __( 'Allow Minimizing of Length.', 'user-registration' ),
 			),
 			'minimum_length_limit_count' => array(
 				'label'       => __( 'Minimum Count', 'user-registration' ),
@@ -98,7 +98,7 @@ class UR_Setting_Text extends UR_Field_Settings {
 				'required'    => false,
 				'default'     => 10,
 				'placeholder' => '',
-				'tip'         => __( 'Allowed maximum number of characters / words.', 'user-registration' ),
+				'tip'         => __( 'Allowed minimum number of characters / words.', 'user-registration' ),
 			),
 			'minimum_length_limit_mode' => array(
 				'label'       => __( 'Limit Mode', 'user-registration' ),
@@ -113,7 +113,7 @@ class UR_Setting_Text extends UR_Field_Settings {
 				'required'    => false,
 				'default'     => 'characters',
 				'placeholder' => '',
-				'tip'         => __( 'Allowed maximum number of characters / words.', 'user-registration' ),
+				'tip'         => __( 'Minimum limit by characters / words.', 'user-registration' ),
 			),
 			'default_value' => array(
 				'label'       => __( 'Default Value', 'user-registration' ),

--- a/includes/form/settings/class-ur-setting-text.php
+++ b/includes/form/settings/class-ur-setting-text.php
@@ -42,7 +42,7 @@ class UR_Setting_Text extends UR_Field_Settings {
 	public function register_fields() {
 		$fields = array(
 			'limit_length' => array(
-				'label'       => __( 'Limit Length', 'user-registration' ),
+				'label'       => __( 'Maximum Length', 'user-registration' ),
 				'data-id'     => $this->field_id . '_limit_length',
 				'name'        => $this->field_id . '[limit_length]',
 				'class'       => $this->default_class . ' ur-settings-limit-length',
@@ -50,10 +50,10 @@ class UR_Setting_Text extends UR_Field_Settings {
 				'required'    => false,
 				'default'     => 'false',
 				'placeholder' => '',
-				'tip'         => __( 'Allow Limiting of Length.', 'user-registration' ),
+				'tip'         => __( 'Allow Maximizing of Length.', 'user-registration' ),
 			),
 			'limit_length_limit_count' => array(
-				'label'       => __( 'Limit Count', 'user-registration' ),
+				'label'       => __( 'Maximum Count', 'user-registration' ),
 				'data-id'     => $this->field_id . '_limit_length_limit_count',
 				'name'        => $this->field_id . '[limit_length_limit_count]',
 				'class'       => $this->default_class . ' ur-settings-limit-length-limit-count',
@@ -76,7 +76,7 @@ class UR_Setting_Text extends UR_Field_Settings {
 				'required'    => false,
 				'default'     => 'characters',
 				'placeholder' => '',
-				'tip'         => __( 'Maximum limit by characters / words.', 'user-registration' ),
+				'tip'         => __( 'Maximize by characters / words.', 'user-registration' ),
 			),
 			'minimum_length' => array(
 				'label'       => __( 'Minimum Length', 'user-registration' ),
@@ -113,7 +113,7 @@ class UR_Setting_Text extends UR_Field_Settings {
 				'required'    => false,
 				'default'     => 'characters',
 				'placeholder' => '',
-				'tip'         => __( 'Minimum limit by characters / words.', 'user-registration' ),
+				'tip'         => __( 'Minimize by characters / words.', 'user-registration' ),
 			),
 			'default_value' => array(
 				'label'       => __( 'Default Value', 'user-registration' ),

--- a/includes/form/settings/class-ur-setting-text.php
+++ b/includes/form/settings/class-ur-setting-text.php
@@ -50,7 +50,7 @@ class UR_Setting_Text extends UR_Field_Settings {
 				'required'    => false,
 				'default'     => 'false',
 				'placeholder' => '',
-				'tip'         => __( 'Allow Maximizing of Length.', 'user-registration' ),
+				'tip'         => __( 'Allow Limitation for Maximum Length.', 'user-registration' ),
 			),
 			'limit_length_limit_count' => array(
 				'label'       => __( 'Maximum Count', 'user-registration' ),
@@ -87,7 +87,7 @@ class UR_Setting_Text extends UR_Field_Settings {
 				'required'    => false,
 				'default'     => 'false',
 				'placeholder' => '',
-				'tip'         => __( 'Allow Minimizing of Length.', 'user-registration' ),
+				'tip'         => __( 'Allow Limitation for Minimum Length.', 'user-registration' ),
 			),
 			'minimum_length_limit_count' => array(
 				'label'       => __( 'Minimum Count', 'user-registration' ),

--- a/includes/form/settings/class-ur-setting-textarea.php
+++ b/includes/form/settings/class-ur-setting-textarea.php
@@ -52,7 +52,7 @@ class UR_Setting_Textarea extends UR_Field_Settings {
 				'required'    => false,
 				'default'     => 'false',
 				'placeholder' => '',
-				'tip'         => __( 'Allowed maximum number of characters / words.', 'user-registration' ),
+				'tip'         => __( 'Allow Limiting of Length.', 'user-registration' ),
 			),
 			'limit_length_limit_count'   => array(
 				'label'       => __( 'Limit Count', 'user-registration' ),
@@ -78,7 +78,7 @@ class UR_Setting_Textarea extends UR_Field_Settings {
 				'required'    => false,
 				'default'     => 'characters',
 				'placeholder' => '',
-				'tip'         => __( 'Allowed maximum number of characters / words.', 'user-registration' ),
+				'tip'         => __( 'Maximum limit by characters / words.', 'user-registration' ),
 			),
 			'minimum_length'             => array(
 				'label'       => __( 'Minimum Length', 'user-registration' ),
@@ -89,7 +89,7 @@ class UR_Setting_Textarea extends UR_Field_Settings {
 				'required'    => false,
 				'default'     => 'false',
 				'placeholder' => '',
-				'tip'         => __( 'Allowed maximum number of characters / words.', 'user-registration' ),
+				'tip'         => __( 'Allow Minimizing of Length.', 'user-registration' ),
 			),
 			'minimum_length_limit_count' => array(
 				'label'       => __( 'Limit Count', 'user-registration' ),
@@ -100,7 +100,7 @@ class UR_Setting_Textarea extends UR_Field_Settings {
 				'required'    => false,
 				'default'     => 100,
 				'placeholder' => '',
-				'tip'         => __( 'Allowed maximum number of characters / words.', 'user-registration' ),
+				'tip'         => __( 'Allowed minimum number of characters / words.', 'user-registration' ),
 			),
 			'minimum_length_limit_mode'  => array(
 				'label'       => __( 'Limit Mode', 'user-registration' ),
@@ -115,7 +115,7 @@ class UR_Setting_Textarea extends UR_Field_Settings {
 				'required'    => false,
 				'default'     => 'characters',
 				'placeholder' => '',
-				'tip'         => __( 'Allowed maximum number of characters / words.', 'user-registration' ),
+				'tip'         => __( 'Minimum limit by characters / words.', 'user-registration' ),
 			),
 			'default_value'              => array(
 				'label'       => __( 'Default Value', 'user-registration' ),

--- a/includes/form/settings/class-ur-setting-textarea.php
+++ b/includes/form/settings/class-ur-setting-textarea.php
@@ -52,7 +52,7 @@ class UR_Setting_Textarea extends UR_Field_Settings {
 				'required'    => false,
 				'default'     => 'false',
 				'placeholder' => '',
-				'tip'         => __( 'Allow Maximizing of Length.', 'user-registration' ),
+				'tip'         => __( 'Allow Limitation for Maximum Length.', 'user-registration' ),
 			),
 			'limit_length_limit_count'   => array(
 				'label'       => __( 'Maximum Count', 'user-registration' ),
@@ -89,7 +89,7 @@ class UR_Setting_Textarea extends UR_Field_Settings {
 				'required'    => false,
 				'default'     => 'false',
 				'placeholder' => '',
-				'tip'         => __( 'Allow Minimizing of Length.', 'user-registration' ),
+				'tip'         => __( 'Allow Limitation for Minimum Length.', 'user-registration' ),
 			),
 			'minimum_length_limit_count' => array(
 				'label'       => __( 'Limit Count', 'user-registration' ),

--- a/includes/form/settings/class-ur-setting-textarea.php
+++ b/includes/form/settings/class-ur-setting-textarea.php
@@ -44,7 +44,7 @@ class UR_Setting_Textarea extends UR_Field_Settings {
 
 		$fields = array(
 			'limit_length'               => array(
-				'label'       => __( 'Limit Length', 'user-registration' ),
+				'label'       => __( 'Maximum Length', 'user-registration' ),
 				'data-id'     => $this->field_id . '_limit_length',
 				'name'        => $this->field_id . '[limit_length]',
 				'class'       => $this->default_class . ' ur-settings-limit-length',
@@ -52,10 +52,10 @@ class UR_Setting_Textarea extends UR_Field_Settings {
 				'required'    => false,
 				'default'     => 'false',
 				'placeholder' => '',
-				'tip'         => __( 'Allow Limiting of Length.', 'user-registration' ),
+				'tip'         => __( 'Allow Maximizing of Length.', 'user-registration' ),
 			),
 			'limit_length_limit_count'   => array(
-				'label'       => __( 'Limit Count', 'user-registration' ),
+				'label'       => __( 'Maximum Count', 'user-registration' ),
 				'data-id'     => $this->field_id . '_limit_length_limit_count',
 				'name'        => $this->field_id . '[limit_length_limit_count]',
 				'class'       => $this->default_class . ' ur-settings-limit-length-limit-count',
@@ -78,7 +78,7 @@ class UR_Setting_Textarea extends UR_Field_Settings {
 				'required'    => false,
 				'default'     => 'characters',
 				'placeholder' => '',
-				'tip'         => __( 'Maximum limit by characters / words.', 'user-registration' ),
+				'tip'         => __( 'Maximize characters / words.', 'user-registration' ),
 			),
 			'minimum_length'             => array(
 				'label'       => __( 'Minimum Length', 'user-registration' ),
@@ -115,7 +115,7 @@ class UR_Setting_Textarea extends UR_Field_Settings {
 				'required'    => false,
 				'default'     => 'characters',
 				'placeholder' => '',
-				'tip'         => __( 'Minimum limit by characters / words.', 'user-registration' ),
+				'tip'         => __( 'Minimize by characters / words.', 'user-registration' ),
 			),
 			'default_value'              => array(
 				'label'       => __( 'Default Value', 'user-registration' ),

--- a/includes/form/settings/class-ur-setting-user_login.php
+++ b/includes/form/settings/class-ur-setting-user_login.php
@@ -60,8 +60,8 @@ class UR_Setting_User_Login extends UR_Field_Settings {
 				'type'        => 'number',
 				'required'    => false,
 				'default'     => $this->field_id . '_username_length',
-				'placeholder' => __( 'Min Value', 'user-registration' ),
-				'tip'         => __( 'Enter minimum number of length of username.', 'user-registration' ),
+				'placeholder' => __( 'Maximum Value', 'user-registration' ),
+				'tip'         => __( 'Enter maximum number of length of username.', 'user-registration' ),
 			),
 			'username_character' => array(
 				'label'       => __( 'Allow Special Character', 'user-registration' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?


### Changes proposed in this Pull Request:

This PR fixes the tooltip message for Length Settings of Username, Input and Textarea fields.

Closes # .

### How to test the changes in this Pull Request:

1. Goto Form Builder and drag Username, Input and Textarea Fields.
2. Goto advance setttings and verify tooltip message for Length Settings.


### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Tooltip message for Username, Text and Textarea of Length Advance Settings.
