### PR TITLE
UR-1409 Fix - Change the tooltip text in the limit username option

### DIFF
--- a/includes/form/settings/class-ur-setting-user_login.php
+++ b/includes/form/settings/class-ur-setting-user_login.php
@@ -60,8 +60,8 @@ class UR_Setting_User_Login extends UR_Field_Settings {
 				'type'        => 'number',
 				'required'    => false,
 				'default'     => $this->field_id . '_username_length',
-				'placeholder' => __( 'Min Value', 'user-registration' ),
-				'tip'         => __( 'Enter minimum number of length of username.', 'user-registration' ),
+				'placeholder' => __( 'Max Value', 'user-registration' ),
+				'tip'         => __( 'The maximum number of characters allowed.', 'user-registration' ),
 			),
 			'username_character' => array(
 				'label'       => __( 'Allow Special Character', 'user-registration' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously, behaviour of limit username option is opposite to the text of tooltip text. This PR change the message of tooltip.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

When we create the form using username field, in advance setting there is change of message in tooltip of limit username option.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix issue change the tooltip text in the limit username option
