### PR TITLE
UR-1386 Fix Backend validation for Number field

### DIFF
--- a/includes/form/class-ur-form-field-number.php
+++ b/includes/form/class-ur-form-field-number.php
@@ -122,6 +122,31 @@ class UR_Form_Field_Number extends UR_Form_Field {
 				);
 			}
 		}
+
+		if ( isset( $single_form_field->advance_setting->step ) && '' !== $single_form_field->advance_setting->step ) {
+			$step = $single_form_field->advance_setting->step;
+			if ( floatval( $value ) % floatval( $step ) != 0 ) {
+				$message = array(
+					/* translators: %s - validation message */
+					$label       => sprintf( __( 'Please enter multiple of %d', 'user-registration' ), $step ),
+					'individual' => true,
+				);
+				add_filter(
+					$filter_hook,
+					function ( $msg ) use ( $label, $message ) {
+						if ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX || ! ur_option_checked( 'user_registration_ajax_form_submission_on_edit_profile', false ) ) {
+							return sprintf( $message[ $label ] );
+						} else {
+							wp_send_json_error(
+								array(
+									'message' => $message,
+								)
+							);
+						}
+					}
+				);
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
Previously, when number field is added to form having some step value. It only validates the step value in the frontend side. This PR ensures that step value is validated through backend properly.
Closes # .

### How to test the changes in this Pull Request:

1. Add the number field by giving value to step in advanced setting, in form builder. Preview the form.
2. Input number by disabling the step attribute from frontend.
3.  It will not submit the form. 

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Backend validation for Number field.
