### PR TITLE
UR-1218  Fix- Avatar files are left behind after deleting user.

### DIFF
--- a/includes/admin/class-ur-admin.php
+++ b/includes/admin/class-ur-admin.php
@@ -29,6 +29,7 @@ class UR_Admin {
 		add_action( 'admin_notices', array( $this, 'survey_notice' ) );
 		add_action( 'admin_notices', array( $this, 'allow_usage_notice' ) );
 		add_action( 'admin_notices', array( $this, 'php_deprecation_notice' ) );
+		add_action( 'delete_user', 'ur_unlink_user_profile_pictures' );
 		add_action( 'admin_footer', 'ur_print_js', 25 );
 		add_filter( 'heartbeat_received', array( $this, 'new_user_live_notice' ), 10, 2 );
 		add_filter( 'admin_body_class', array( $this, 'user_registration_add_body_classes' ) );

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -4694,5 +4694,5 @@ if ( ! function_exists( 'ur_array_clone' ) ) {
 			}
 		}
 	}
-	add_action( 'remove_profile_pictures_and_metadata', 'ur_unlink_user_profile_pictures' );
+	add_action( 'ur_remove_profile_pictures_and_metadata', 'ur_unlink_user_profile_pictures' );
 }

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -4640,4 +4640,59 @@ if ( ! function_exists( 'ur_array_clone' ) ) {
 			$array
 		);
 	}
+	if ( ! function_exists( 'ur_unlink_user_profile_pictures' ) ) {
+		/**
+		 * Remove user uploaded profile pictures and related thumbnail.
+		 *
+		 * @param int $id User ID.
+		 */
+		function ur_unlink_user_profile_pictures( $id ) {
+			$profile_pic_url = get_user_meta( $id, 'user_registration_profile_pic_url', true );
+			if ( ! empty( $profile_pic_url ) ) {
+
+				$profile_id = get_post_meta( $profile_pic_url, '_wp_attachment_metadata' );
+
+				// Unlink profile picture before removing users.
+				if ( is_array( $profile_id ) && ! empty( $profile_id ) ) {
+					foreach ( $profile_id as $profile ) {
+						if ( is_array( $profile ) && isset( $profile['file'] ) ) {
+							$base_dir  = wp_upload_dir()['basedir'];
+							$file      = $profile['file'];
+							$full_path = trailingslashit( $base_dir ) . $file;
+
+							if ( file_exists( $full_path ) ) {
+								unlink( $full_path );
+							}
+
+							// unlink different size thumbnails of profile picture.
+							if ( isset( $profile['sizes'] ) && is_array( $profile['sizes'] ) ) {
+								foreach ( $profile['sizes'] as $size ) {
+									if ( is_array( $size ) && isset( $size['file'] ) ) {
+										$size_file      = $size['file'];
+										$full_size_path = UR_UPLOAD_PATH . 'profile-pictures/' . $size_file;
+
+										if ( file_exists( $full_size_path ) ) {
+											unlink( $full_size_path );
+										}
+									}
+								}
+							}
+
+							// Unlink original uploaded image.
+							if ( isset( $profile['original_image'] ) ) {
+								$original_file = UR_UPLOAD_PATH . 'profile-pictures/' . $profile['original_image'];
+								if ( file_exists( $original_file ) ) {
+									unlink( $original_file );
+								}
+							}
+						}
+					}
+				}
+				// Remove profile pictures related metadata from DB.
+				delete_post_meta( $profile_pic_url, '_wp_attachment_metadata' );
+				delete_post_meta( $profile_pic_url, '_wp_attached_file' );
+			}
+		}
+	}
+	add_action( 'remove_profile_pictures_and_metadata', 'ur_unlink_user_profile_pictures' );
 }


### PR DESCRIPTION
### All Submissions:
PR Dependency :  https://github.com/wpeverest/user-registration-pro/pull/330/files

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously Avatar/profile pictures files are left behind in /wp-content/uploads/user_registration_uploads/profile-pictures/. even if the user is deleted (with higher resolution pictures). This PR resolve that bug

### How to test the changes in this Pull Request:
Note: use higher resolution pictures or disable crop for profile pictures

Case I:
1.Register user with profile picture.
2.Remove user from user registration pro->users->delete.\
Case II:
1.Register user with profile picture again.
2.Remove user from users->delete (default users of wp).

After Case I or Case II:
 check  folder /wp-content/uploads/user_registration_uploads/profile-pictures/ recently deleted users all image should be removed and from wp_postmeta _wp_attached_file and _wp_attachment_metadata  meta key should be removed of particular users deleted




### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix- Avatar files are left behind after deleting user.