### PR TITLE
UR-1020 Fix - Woocommerce my account edit profile sync.

### DIFF
--- a/includes/frontend/class-ur-frontend-form-handler.php
+++ b/includes/frontend/class-ur-frontend-form-handler.php
@@ -245,6 +245,10 @@ class UR_Frontend_Form_Handler {
 				}
 				update_user_meta( $user_id, $field_name, $data->value );
 			}
+			if ( 'user_url' === $data->field_name ) {
+				$data->value = sanitize_text_field( $data->value );
+				update_user_meta( $user_id, $data->field_name, $data->value );
+			}
 		}
 		update_user_meta( $user_id, 'ur_form_id', $form_id );
 


### PR DESCRIPTION
PR dependency on https://github.com/wpeverest/user-registration-woocommerce/compare/master...UR-1020-woocommerce-my-account-edit-profile-support
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously UR MyAccount->edit profile an WooCommerce MyAccount->edit profile was not sync. This PR makes sure that both are synced.
### How to test the changes in this Pull Request:

Note: while making form make a website field and see if its value is retrieved
1.Register user in WooCommerce with UR form. Login and check if edit profile in both WooCommerce and UR edit profile are synced.
2.Register user in WooCommerce with UR form while checkout. Login and check if edit profile in both WooCommerce and UR edit profile are synced.


### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev Compatibility - WooCommerce My-Account Edit Profile sync.
