### PR TITLE
UR 1462 Fix - Denied is not working when email confirmation is enabled.

### DIFF
--- a/includes/admin/class-ur-admin-user-manager.php
+++ b/includes/admin/class-ur-admin-user-manager.php
@@ -229,7 +229,7 @@ class UR_Admin_User_Manager {
 
 			$result = array(
 				'login_option'    => 'email_confirmation',
-				'user_status'     => $user_status,
+				'user_status'     => '' == $user_status ? $user_email_status : $user_status,
 				'email_status'    => $user_email_status,
 				'approval_status' => $user_status,
 			);

--- a/includes/admin/class-ur-admin-user-manager.php
+++ b/includes/admin/class-ur-admin-user-manager.php
@@ -229,7 +229,7 @@ class UR_Admin_User_Manager {
 
 			$result = array(
 				'login_option'    => 'email_confirmation',
-				'user_status'     => $user_email_status,
+				'user_status'     => $user_status,
 				'email_status'    => $user_email_status,
 				'approval_status' => $user_status,
 			);

--- a/includes/class-ur-user-approval.php
+++ b/includes/class-ur-user-approval.php
@@ -278,7 +278,12 @@ class UR_User_Approval {
 
 			$url = substr( $url, 0, strpos( $url, '?' ) );
 			$url = wp_nonce_url( $url . '?ur_resend_id=' . crypt_the_string( $user->ID . '_' . time(), 'e' ) . '&ur_resend_token=true', 'ur_resend_token' );
+			//if login option is email_confirmation but admin denies user
 
+			if( UR_Admin_User_Manager::DENIED === ( int ) $status['user_status'] ) {
+				$message = '<strong>' . __( 'ERROR:', 'user-registration' ) . '</strong> ' . __( 'Your account has been denied.', 'user-registration' );
+				return new WP_Error( 'denied_access', $message );
+			}
 			if ( '0' === $status['user_status'] ) {
 				/* translators: %s - Resend Verification Link. */
 				$message = '<strong>' . esc_html__( 'ERROR:', 'user-registration' ) . '</strong> ' . sprintf( __( 'Your account is still pending approval. Verify your email by clicking on the link sent to your email. %s', 'user-registration' ), '<a id="resend-email" href="' . esc_url( $url ) . '">' . __( 'Resend Verification Link', 'user-registration' ) . '</a>' );

--- a/includes/class-ur-user-approval.php
+++ b/includes/class-ur-user-approval.php
@@ -278,7 +278,7 @@ class UR_User_Approval {
 
 			$url = substr( $url, 0, strpos( $url, '?' ) );
 			$url = wp_nonce_url( $url . '?ur_resend_id=' . crypt_the_string( $user->ID . '_' . time(), 'e' ) . '&ur_resend_token=true', 'ur_resend_token' );
-			// if login option is email_confirmation but admin denies user
+			// if login option is email_confirmation but admin denies user.
 
 			if( UR_Admin_User_Manager::DENIED === ( int ) $status['user_status'] ) {
 				$message = '<strong>' . __( 'ERROR:', 'user-registration' ) . '</strong> ' . __( 'Your account has been denied.', 'user-registration' );

--- a/includes/class-ur-user-approval.php
+++ b/includes/class-ur-user-approval.php
@@ -280,7 +280,7 @@ class UR_User_Approval {
 			$url = wp_nonce_url( $url . '?ur_resend_id=' . crypt_the_string( $user->ID . '_' . time(), 'e' ) . '&ur_resend_token=true', 'ur_resend_token' );
 			// if login option is email_confirmation but admin denies user.
 
-			if( UR_Admin_User_Manager::DENIED === ( int ) $status['user_status'] ) {
+			if( UR_Admin_User_Manager::DENIED === (int) $status['user_status'] ) {
 				$message = '<strong>' . __( 'ERROR:', 'user-registration' ) . '</strong> ' . __( 'Your account has been denied.', 'user-registration' );
 				return new WP_Error( 'denied_access', $message );
 			}

--- a/includes/class-ur-user-approval.php
+++ b/includes/class-ur-user-approval.php
@@ -280,10 +280,12 @@ class UR_User_Approval {
 			$url = wp_nonce_url( $url . '?ur_resend_id=' . crypt_the_string( $user->ID . '_' . time(), 'e' ) . '&ur_resend_token=true', 'ur_resend_token' );
 			// if login option is email_confirmation but admin denies user.
 
-			if( UR_Admin_User_Manager::DENIED === (int) $status['user_status'] ) {
+			if ( UR_Admin_User_Manager::DENIED === (int) $status['user_status'] ) {
 				$message = '<strong>' . __( 'ERROR:', 'user-registration' ) . '</strong> ' . __( 'Your account has been denied.', 'user-registration' );
+
 				return new WP_Error( 'denied_access', $message );
 			}
+
 			if ( '0' === $status['user_status'] ) {
 				/* translators: %s - Resend Verification Link. */
 				$message = '<strong>' . esc_html__( 'ERROR:', 'user-registration' ) . '</strong> ' . sprintf( __( 'Your account is still pending approval. Verify your email by clicking on the link sent to your email. %s', 'user-registration' ), '<a id="resend-email" href="' . esc_url( $url ) . '">' . __( 'Resend Verification Link', 'user-registration' ) . '</a>' );

--- a/includes/class-ur-user-approval.php
+++ b/includes/class-ur-user-approval.php
@@ -278,7 +278,7 @@ class UR_User_Approval {
 
 			$url = substr( $url, 0, strpos( $url, '?' ) );
 			$url = wp_nonce_url( $url . '?ur_resend_id=' . crypt_the_string( $user->ID . '_' . time(), 'e' ) . '&ur_resend_token=true', 'ur_resend_token' );
-			//if login option is email_confirmation but admin denies user
+			// if login option is email_confirmation but admin denies user
 
 			if( UR_Admin_User_Manager::DENIED === ( int ) $status['user_status'] ) {
 				$message = '<strong>' . __( 'ERROR:', 'user-registration' ) . '</strong> ' . __( 'Your account has been denied.', 'user-registration' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Previously wrong message was shown when a user registered from forms created with login option `auto approval after email confirmation`  tried to login after they have been denied by the admin. This PR fixes the issue along with the issue where the deny option kept showing on the user's list even after the user was denied by the admin.

Closes # .

### How to test the changes in this Pull Request:

1. Create a form with `auto approval after email confirmation` login option under form settings.
2. Register a user using that specific form.
3. Do not confirm from the link provided in the mail instead deny the user from the users list page.
4. Now try to logIn.
5. Correct message i.e. `ERROR: Your account has been denied. ` must appear instead of  `ERROR: Your account is still pending approval. Verify your email by clicking on the link sent to your email.`

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed wrong message on login and deny option appearance case on user list for users created with login option `auto approval after email confirmation`.
