### PR TITLE
Sync changes with pro for qna verification type

### DIFF
--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -315,6 +315,8 @@
 					URFormBuilder.get_form_conditional_submit_data();
 				var email_content_override_settings_data =
 					URFormBuilder.get_form_email_content_override_data();
+				var form_restriction_submit_data =
+					URFormBuilder.get_form_restriction_submit_data();
 
 				/** TODO:: Handle from multistep forms add-on if possible. */
 				var multipart_page_setting = $(
@@ -348,6 +350,8 @@
 							profile_completeness__custom_percentage,
 						form_restriction_extra_settings_data:
 							form_restriction_extra_settings_data,
+						form_restriction_submit_data:
+							form_restriction_submit_data
 					},
 				};
 
@@ -975,6 +979,19 @@
 						}
 					}
 				);
+				// Validate empty fields for question and answer block.
+				$.each(
+					$(".urfr-qna-block"),
+					function() {
+						var questionValue = $(this).find("input[name='urfr_qna_question']").val();
+						var answer = $(this).find("input[name='urfr_qna_answer']").val();
+						if(questionValue === '' || answer === '') {
+							response.validation_status = false;
+							response.message =
+								user_registration_form_builder_data.i18n_admin
+									.i18n_urfr_field_required_error;
+						}
+					})
 				return response;
 			},
 			/**
@@ -1419,6 +1436,20 @@
 			 */
 			ur_math_ceil: function (value) {
 				return Math.ceil(value, 0);
+			},
+			/**
+			 * Get all the data related to form_restriction
+			 */
+			get_form_restriction_submit_data: function() {
+				const form_data = $('.urfr-qna-block').map(function(k, item) {
+					let question = $(item).find('input[name="urfr_qna_question"]').val();
+					let answer = $(item).find('input[name="urfr_qna_answer"]').val();
+					return {
+						question: question,
+						answer: answer
+					};
+				}).get();
+				return JSON.stringify(form_data);
 			},
 			/**
 			 * Get all the conditions datas that the user has set in conditionally assign user role settings.

--- a/includes/admin/class-ur-admin-assets.php
+++ b/includes/admin/class-ur-admin-assets.php
@@ -562,7 +562,7 @@ class UR_Admin_Assets {
 			'i18n_max_upload_size'                   => _x( 'input of max upload size must less than ' . $max_upload_size_ini . ' set in ini configuration', 'user registration admin', 'user-registration' ), // phpcs:ignore
 			'i18n_pc_profile_completion_error'       => esc_html__( 'You cannot set the zero less than zero to the completion percentage.', 'user-registration' ),
 			'i18n_pc_custom_percentage_filed_error'  => esc_html__( 'Sum of progress percentage for each field cannot be greater than the completion perecentage.', 'user-registration' ),
-			'i18n_urfr_field_required_error'         => esc_html__( 'Form Restriction: Empty Question or Answer field.', 'user-registration' )
+			'i18n_urfr_field_required_error'         => esc_html__( 'Form Restriction: Empty Question or Answer field.', 'user-registration' ),
 		);
 
 		return $i18n;

--- a/includes/admin/class-ur-admin-assets.php
+++ b/includes/admin/class-ur-admin-assets.php
@@ -562,6 +562,7 @@ class UR_Admin_Assets {
 			'i18n_max_upload_size'                   => _x( 'input of max upload size must less than ' . $max_upload_size_ini . ' set in ini configuration', 'user registration admin', 'user-registration' ), // phpcs:ignore
 			'i18n_pc_profile_completion_error'       => esc_html__( 'You cannot set the zero less than zero to the completion percentage.', 'user-registration' ),
 			'i18n_pc_custom_percentage_filed_error'  => esc_html__( 'Sum of progress percentage for each field cannot be greater than the completion perecentage.', 'user-registration' ),
+			'i18n_urfr_field_required_error'         => esc_html__( 'Form Restriction: Empty Question or Answer field.', 'user-registration' )
 		);
 
 		return $i18n;

--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -882,11 +882,13 @@ class UR_AJAX {
 				$_POST['data']['form_id'] = $post_id; // Form id for new form.
 
              $post_data_setting = isset( $_POST['data']['form_setting_data'] ) ? $_POST['data']['form_setting_data'] : array(); //phpcs:ignore
-				if ( isset( $_POST['data']["form_restriction_submit_data"] ) && ! empty( $_POST['data']["form_restriction_submit_data"] ) ) {
-					$post_data_setting[] = [
-						"name"  => "urfr_qna_restriction_data",
-						"value" => $_POST['data']["form_restriction_submit_data"]
-					];
+				if ( isset( $_POST['data']['form_restriction_submit_data'] ) && ! empty( $_POST['data']['form_restriction_submit_data'] ) ) {
+					$post_data_setting = array(
+						array(
+							'name'  => 'urfr_qna_restriction_data',
+							'value' => sanitize_text_field( wp_unslash( $_POST['data']['form_restriction_submit_data'] ) ),
+						),
+					);
 				}
 				ur_update_form_settings( $post_data_setting, $post_id );
 

--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -882,6 +882,12 @@ class UR_AJAX {
 				$_POST['data']['form_id'] = $post_id; // Form id for new form.
 
              $post_data_setting = isset( $_POST['data']['form_setting_data'] ) ? $_POST['data']['form_setting_data'] : array(); //phpcs:ignore
+				if ( isset( $_POST['data']["form_restriction_submit_data"] ) && ! empty( $_POST['data']["form_restriction_submit_data"] ) ) {
+					$post_data_setting[] = [
+						"name"  => "urfr_qna_restriction_data",
+						"value" => $_POST['data']["form_restriction_submit_data"]
+					];
+				}
 				ur_update_form_settings( $post_data_setting, $post_id );
 
 				// Form row_id save.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Changes in this PR include code to fetch submit data from the form restriction add-ons for newly added QNA verification.

Closes # .

### How to test the changes in this Pull Request:

1. Testing depends on changes pushed from [this PR](https://github.com/wpeverest/user-registration-form-restriction/pull/5) 
2. Test accordingly to the above-mentioned PR's `How to test section`

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> UR 1471 Enhancement - Q&A based form access in form restriction.
