### PR TITLE
UR-1499 Fix - Enquing style and script only to UR screens.

### DIFF
--- a/includes/admin/class-ur-admin-assets.php
+++ b/includes/admin/class-ur-admin-assets.php
@@ -62,11 +62,7 @@ class UR_Admin_Assets {
 		wp_style_add_data( 'user-registration-admin', 'rtl', 'replace' );
 
 		// Sitewide menu CSS.
-		wp_enqueue_style( 'user-registration-menu' );
-		wp_enqueue_style( 'user-registration-metabox' );
-		wp_enqueue_style( 'user-registration-form-modal-css' );
 
-		wp_enqueue_style( 'select2', UR()->plugin_url() . '/assets/css/select2/select2.css', array(), '4.0.6' );
 		wp_enqueue_style( 'ur-notice' );
 
 		// Admin styles for UR pages only.
@@ -84,6 +80,12 @@ class UR_Admin_Assets {
 			wp_enqueue_style( 'jquery-confirm-style' );
 			wp_enqueue_style( 'tooltipster' );
 			wp_enqueue_style( 'tooltipster-borderless-theme' );
+
+			wp_enqueue_style( 'user-registration-menu' );
+			wp_enqueue_style( 'user-registration-metabox' );
+			wp_enqueue_style( 'user-registration-form-modal-css' );
+
+			wp_enqueue_style( 'select2', UR()->plugin_url() . '/assets/css/select2/select2.css', array(), '4.0.6' );
 		}
 		// Enqueue flatpickr on user profile screen.
 		if ( 'user-edit' === $screen_id || 'profile' === $screen_id || 'user-registration_page_add-new-registration' === $screen_id ) {
@@ -262,10 +264,6 @@ class UR_Admin_Assets {
 			)
 		);
 
-		wp_enqueue_script( 'user-registration-form-modal-js' );
-		wp_enqueue_script( 'ur-enhanced-select' );
-
-		wp_enqueue_script( 'ur-notice', UR()->plugin_url() . '/assets/js/admin/ur-notice' . $suffix . '.js', array(), UR_VERSION, false );
 		wp_localize_script(
 			'ur-notice',
 			'ur_notice_params',
@@ -413,6 +411,10 @@ class UR_Admin_Assets {
 
 				)
 			);
+			wp_enqueue_script( 'user-registration-form-modal-js' );
+			wp_enqueue_script( 'ur-enhanced-select' );
+
+			wp_enqueue_script( 'ur-notice', UR()->plugin_url() . '/assets/js/admin/ur-notice' . $suffix . '.js', array(), UR_VERSION, false );
 		}
 
 		// Enqueue flatpickr on user profile screen.

--- a/includes/admin/class-ur-admin-assets.php
+++ b/includes/admin/class-ur-admin-assets.php
@@ -44,7 +44,6 @@ class UR_Admin_Assets {
 		wp_register_style( 'user-registration-admin', UR()->plugin_url() . '/assets/css/admin.css', array( 'nav-menus', 'wp-color-picker' ), UR_VERSION );
 		wp_register_style( 'user-registration-settings', UR()->plugin_url() . '/assets/css/settings.css', array( 'nav-menus' ), UR_VERSION );
 		wp_register_style( 'jquery-ui-style', UR()->plugin_url() . '/assets/css/jquery-ui/jq-smoothness.css', array(), $jquery_version );
-		wp_register_style( 'flatpickr', UR()->plugin_url() . '/assets/css/flatpickr/flatpickr.min.css', array(), '4.6.9' );
 		wp_register_style( 'perfect-scrollbar', UR()->plugin_url() . '/assets/css/perfect-scrollbar/perfect-scrollbar.css', array(), '1.5.0' );
 		wp_register_style( 'sweetalert2', UR()->plugin_url() . '/assets/css/sweetalert2/sweetalert2.min.css', array(), '10.16.7' );
 
@@ -67,6 +66,8 @@ class UR_Admin_Assets {
 
 		// Admin styles for UR pages only.
 		if ( in_array( $screen_id, ur_get_screen_ids(), true ) ) {
+			wp_register_style( 'flatpickr', UR()->plugin_url() . '/assets/css/flatpickr/flatpickr.min.css', array(), '4.6.9' );
+
 			wp_enqueue_style( 'user-registration-admin' );
 
 			if ( strpos( $screen_id, 'user-registration-settings' ) ) {

--- a/includes/admin/class-ur-admin-assets.php
+++ b/includes/admin/class-ur-admin-assets.php
@@ -44,6 +44,7 @@ class UR_Admin_Assets {
 		wp_register_style( 'user-registration-admin', UR()->plugin_url() . '/assets/css/admin.css', array( 'nav-menus', 'wp-color-picker' ), UR_VERSION );
 		wp_register_style( 'user-registration-settings', UR()->plugin_url() . '/assets/css/settings.css', array( 'nav-menus' ), UR_VERSION );
 		wp_register_style( 'jquery-ui-style', UR()->plugin_url() . '/assets/css/jquery-ui/jq-smoothness.css', array(), $jquery_version );
+		wp_register_style( 'flatpickr', UR()->plugin_url() . '/assets/css/flatpickr/flatpickr.min.css', array(), '4.6.9' );
 		wp_register_style( 'perfect-scrollbar', UR()->plugin_url() . '/assets/css/perfect-scrollbar/perfect-scrollbar.css', array(), '1.5.0' );
 		wp_register_style( 'sweetalert2', UR()->plugin_url() . '/assets/css/sweetalert2/sweetalert2.min.css', array(), '10.16.7' );
 
@@ -66,8 +67,6 @@ class UR_Admin_Assets {
 
 		// Admin styles for UR pages only.
 		if ( in_array( $screen_id, ur_get_screen_ids(), true ) ) {
-			wp_register_style( 'flatpickr', UR()->plugin_url() . '/assets/css/flatpickr/flatpickr.min.css', array(), '4.6.9' );
-
 			wp_enqueue_style( 'user-registration-admin' );
 
 			if ( strpos( $screen_id, 'user-registration-settings' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
Previously, our `JS` and `CSS` files were enqueued outside our screens. This pull request ensures that all `JS` and `CSS` files are now enqueued only within our screens

**PR Dependency:** https://github.com/wpeverest/user-registration-pro/pull/370
### How to test the changes in this Pull Request:

1. `Activate UR Plugin` -> inspect source (ensure you are not in UR screens).
2. Only **Dashboard-related** JS and CSS should be enqueued.
3. Check if JS and CSS are working in UR screens.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Enquing style and script only to UR screens.
