### PR TITLE
UR-874 Dev - Compatibility for not being able to delete password field even if auto password generation is enabled.

### DIFF
--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -569,6 +569,11 @@
 				var required_fields = $.makeArray(
 					user_registration_form_builder_data.form_required_fields
 				);
+
+				if( $("#user_registration_pro_auto_password_activate").is(":checked") ) {
+					required_fields.splice( required_fields.indexOf('user_pass'), 1 );
+				}
+
 				var response = {
 					validation_status: true,
 					message: "",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously when the auto-generated password was enabled the password field was hidden in the frontend form but users were not able to delete the password field from the form builder. This PR fixes this inconsistency.

### How to test the changes in this Pull Request:

1. Test this PR of pro https://github.com/wpeverest/user-registration-pro/pull/386 and review this PR.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Compatibility for not being able to delete password field even if auto password generation is enabled.
