### PR TITLE
UR-1487 Dev - Compatibility for user edit.

### DIFF
--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -311,9 +311,9 @@ class UR_Form_Handler {
 		 *
 		 * @param string $message The message.
 		 */
-		$message     = apply_filters( 'user_registration_email_change_email_content', $message );
-		$message     = UR_Emailer::parse_smart_tags( $message, $values, $name_value );
-		$subject     = UR_Emailer::parse_smart_tags( $subject, $values, $name_value );
+		$message = apply_filters( 'user_registration_email_change_email_content', $message );
+		$message = UR_Emailer::parse_smart_tags( $message, $values, $name_value );
+		$subject = UR_Emailer::parse_smart_tags( $subject, $values, $name_value );
 
 		$headers = array(
 			'From:' . $from_name . ' <' . $sender_email . '>',
@@ -535,7 +535,7 @@ class UR_Form_Handler {
 						 * Filter to modify the recaptcha domain.
 						 * Default value is https://www.google.com/recaptcha
 						 */
-						$url  = apply_filters( 'user_registration_recaptcha_domain', 'https://www.google.com/recaptcha/' );
+						$url  = apply_filters( 'user_registration_recaptcha_domain', 'https://www.google.com/recaptcha' );
 						$data = wp_remote_get( $url . 'api/siteverify?secret=' . $secret_key . '&response=' . $recaptcha_value );
 						$data = json_decode( wp_remote_retrieve_body( $data ) );
 						/**
@@ -653,15 +653,15 @@ class UR_Form_Handler {
 	 * Handle Export Personal data confirmation request.
 	 */
 	public static function export_confirmation_request() {
-		if ( isset( $_REQUEST['action'] ) && 'confirmaction' === $_REQUEST['action'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			if ( ! isset( $_GET['request_id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_REQUEST['action'] ) && 'confirmaction' === $_REQUEST['action'] ) {
+			if ( ! isset( $_GET['request_id'] ) ) {
 				return;
 			}
 
-			$request_id = (int) $_GET['request_id']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$request_id = (int) $_GET['request_id'];
 
-			if ( isset( $_GET['confirm_key'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				$key    = sanitize_text_field( wp_unslash( $_GET['confirm_key'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			if ( isset( $_GET['confirm_key'] ) ) {
+				$key    = sanitize_text_field( wp_unslash( $_GET['confirm_key'] ) );
 				$result = wp_validate_user_request_key( $request_id, $key );
 			} else {
 				$result = new WP_Error( 'invalid_key', __( 'Invalid Key', 'user-registration' ) );

--- a/includes/functions-ur-form.php
+++ b/includes/functions-ur-form.php
@@ -41,7 +41,7 @@ function ur_get_form_field_keys( $form_id ) {
 
 	$field_keys = array();
 
-	if ( ! empty( $form_fields ) && is_array( $form_fields )) {
+	if ( ! empty( $form_fields ) && is_array( $form_fields ) ) {
 		$field_keys = array_keys( $form_fields );
 	}
 
@@ -57,11 +57,10 @@ function ur_get_form_field_keys( $form_id ) {
  * @return array
  */
 function ur_get_form_field_data( $form_id = 0 ) {
-
+	require_once UR_ABSPATH . 'includes/frontend/class-ur-frontend-form-handler.php';
 	$post_content_array = ( $form_id ) ? UR()->form->get_form( $form_id, array( 'content_only' => true ) ) : array();
 
 	$form_field_data = UR_Frontend_Form_Handler::get_form_field_data( $post_content_array );
 
 	return $form_field_data;
 }
-

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -642,20 +642,32 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 						$field .= '<input data-rules="' . esc_attr( $rules ) . '" data-id="' . esc_attr( $key ) . '" type="' . esc_attr( $args['type'] ) . '" class="input-text ' . esc_attr( $timpicker_class ) . ' ' . esc_attr( implode( ' ', $args['input_class'] ) ) . '" name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '"  value="' . esc_attr( $value ) . '" ' . implode( ' ', $custom_attributes ) . ' ' . $attr . ' />';
 					}
 				}
-
 				if ( isset( $args['field_key'] ) && 'user_email' === $args['field_key'] ) {
-					$user_id       = get_current_user_id();
+
+					$user_id       = is_admin() ? ( ( ( $user = get_user_by( 'email', $args['value'] ) ) ? $user->ID : 0 ) ) : get_current_user_id();
 					$pending_email = get_user_meta( $user_id, 'user_registration_pending_email', true );
 					$expiration    = get_user_meta( $user_id, 'user_registration_pending_email_expiration', true );
-					$cancel_url    = esc_url(
-						add_query_arg(
-							array(
-								'cancel_email_change' => $user_id,
-								'_wpnonce'            => wp_create_nonce( 'cancel_email_change_nonce' ),
+					if ( is_admin() ) {
+						$cancel_url = esc_url(
+							add_query_arg(
+								array(
+									'action'              => 'edit',
+									'cancel_email_change' => $user_id,
+								),
+								$_SERVER['REQUEST_URI']
 							),
-							ur_get_my_account_url() . get_option( 'user_registration_myaccount_edit_profile_endpoint', 'edit-profile' )
-						)
-					);
+						);
+					} else {
+						$cancel_url = esc_url(
+							add_query_arg(
+								array(
+									'cancel_email_change' => $user_id,
+									'_wpnonce'            => wp_create_nonce( 'cancel_email_change_nonce' ),
+								),
+								ur_get_my_account_url() . get_option( 'user_registration_myaccount_edit_profile_endpoint', 'edit-profile' )
+							)
+						);
+					}
 
 					if ( ! empty( $pending_email ) && time() <= $expiration ) {
 						$field .= sprintf(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
Previously when user edit form users table was clicked it would redirect to WordPress default user edit. This PR introduces a new template to allow users edit from our plugin.

### How to test the changes in this Pull Request:

1.`User-Registartion`=> `users`=>`action`=>`edit`
2.Ensure all fields works and have proper validations while editing users.


### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Feature to edit user from UR users.
