### PR TITLE
Fix - Login Redirection complete after email confirmation.

### DIFF
--- a/includes/class-ur-email-confirmation.php
+++ b/includes/class-ur-email-confirmation.php
@@ -269,11 +269,11 @@ class UR_Email_Confirmation {
 						add_filter( 'user_registration_login_form_before_notice', array( $this, 'custom_email_confirmed_admin_await_message' ) );
 					} else {
 						$allow_automatic_user_login = apply_filters( 'user_registration_allow_automatic_user_login_email_confirmation', true );
+						add_filter( 'login_message', array( $this, 'custom_registration_message' ) );
+						add_filter( 'user_registration_login_form_before_notice', array( $this, 'custom_registration_message' ) );
 						if ( $allow_automatic_user_login ) {
 							ur_automatic_user_login( $user );
 						}
-						add_filter( 'login_message', array( $this, 'custom_registration_message' ) );
-						add_filter( 'user_registration_login_form_before_notice', array( $this, 'custom_registration_message' ) );
 					}
 				}
 			} else {

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -4678,7 +4678,15 @@ if ( ! function_exists( 'ur_automatic_user_login' ) ) {
 		$remember = apply_filters( 'user_registration_autologin_remember_user', false );
 		wp_set_auth_cookie( $user->id, $remember );
 
-		wp_redirect( ur_get_my_account_url() );
+		/**
+		 * Filters the login redirection.
+		 *
+		 * @param string   $redirect The original redirect URL after successful login.
+		 * @param WP_User  $user     The user object representing the newly registered user.
+		 */
+		$redirect = apply_filters( 'user_registration_login_redirect', ur_get_my_account_url(), $user );
+
+		wp_redirect( $redirect );
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?


### Changes proposed in this Pull Request:
When there was automatic user login after email confirmation, the login redirect conditions such as (Role based redirection after login). This PR fixes this issue.

Closes # .

### How to test the changes in this Pull Request:

1. Goto User Registration > Misc > Settings and apply Roles based Redirection on Login.
2. Set the form settings login option to email confirmation.
3. Register user and Confirm email and verify whether redirection works properly.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Login Redirection complete after email confirmation.
