### PR TITLE
UR-1564 Fix - Avoid multiple query for the same info

### DIFF
--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -39,15 +39,17 @@ class UR_Form_Handler {
 	 * Remove key and login from querystring, set cookie, and redirect to account page to show the form.
 	 */
 	public static function redirect_reset_password_link() {
-		$page_id                     = ur_get_page_id( 'myaccount' );
-		$is_ur_login_or_account_page = ur_find_my_account_in_page( $page_id );
+		if ( ! empty( $_GET['key'] ) && ! empty( $_GET['login'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			$page_id                     = ur_get_page_id( 'myaccount' );
+			$is_ur_login_or_account_page = ur_find_my_account_in_page( $page_id );
 
-		if ( $is_ur_login_or_account_page && ! empty( $_GET['key'] ) && ! empty( $_GET['login'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$value = sprintf( '%s:%s', sanitize_text_field( wp_unslash( $_GET['login'] ) ), sanitize_text_field( wp_unslash( $_GET['key'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification
-			UR_Shortcode_My_Account::set_reset_password_cookie( $value );
+			if ( $is_ur_login_or_account_page ) {
+				$value = sprintf( '%s:%s', sanitize_text_field( wp_unslash( $_GET['login'] ) ), sanitize_text_field( wp_unslash( $_GET['key'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification
+				UR_Shortcode_My_Account::set_reset_password_cookie( $value );
 
-			wp_safe_redirect( add_query_arg( 'show-reset-form', 'true', ur_lostpassword_url() ) );
-			exit;
+				wp_safe_redirect( add_query_arg( 'show-reset-form', 'true', ur_lostpassword_url() ) );
+				exit;
+			}
 		}
 	}
 

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -3055,11 +3055,12 @@ if ( ! function_exists( 'user_registration_install_pages_notice' ) ) {
 		if ( $my_account_page ) {
 			$myaccount_page = get_post( $my_account_page );
 		}
-
 		if ( ! empty( $myaccount_page ) ) {
-			$matched = ur_find_my_account_in_page( $myaccount_page->ID );
-		}
 
+			if ( isset( $_GET['page'] ) && 'user-registration-settings' === $_GET['page'] ) { //phpcs:ignore WordPress.Security.NonceVerification
+				$matched = ur_find_my_account_in_page( $myaccount_page->ID );
+			}
+		}
 		if ( 0 === $matched ) {
 			$my_account_setting_link = admin_url() . 'admin.php?page=user-registration-settings#user_registration_myaccount_page_id';
 

--- a/includes/functions-ur-page.php
+++ b/includes/functions-ur-page.php
@@ -62,20 +62,13 @@ function ur_get_page_id( $page ) {
 	if ( 'myaccount' == $page || 'login' == $page ) {
 		$page_id = ! empty( $my_account_page_id ) ? $my_account_page_id : $page_id;
 	}
-
-	/**
-	 * Check if the page sent as parameter is My Account page and return the id,
-	 * Else use the page's page_id sent as parameter.
-	 */
-	$page = ur_find_my_account_in_page( $page_id );
-
-	if ( $page > 0 && function_exists( 'pll_current_language' ) ) {
+	if ( function_exists( 'pll_current_language' ) ) {
 		$current_language = pll_current_language();
 		if ( ! empty( $current_language ) ) {
 			$translations = pll_get_post_translations( $page_id );
 			$page_id      = isset( $translations[ pll_current_language() ] ) ? $translations[ pll_current_language() ] : $page_id;
 		}
-	} elseif ( $page > 0 && class_exists( 'SitePress', false ) ) {
+	} elseif ( class_exists( 'SitePress', false ) ) {
 		$page_id = ur_get_wpml_page_language( $page_id );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously, The function ur_find_my_account_in_page is called multiple times. This PR optimizes this performance and calls the function once whenever it is needed.
https://i.imgur.com/dzqtXnH.png

### How to test the changes in this Pull Request:

1. Install Query Monitor and search for this ur_find_my_account_in_page  in the Database Queries section. 
2. Check whether it calls only when it needed and whether it calls once or more.

**Note**: These changes might cause issues for translating my-account page, Please test extensively. 

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Avoid multiple query for the same info.
