### PR TITLE
UR-1578 Fix - Add Capability and nonce for license activation and deactivation.

### DIFF
--- a/includes/admin/class-ur-admin-profile.php
+++ b/includes/admin/class-ur-admin-profile.php
@@ -431,7 +431,6 @@ if ( ! class_exists( 'UR_Admin_Profile', false ) ) :
 		 * @param int $user_id User ID of the user being saved.
 		 */
 		public function update_user_profile( $user_id ) {
-			error_log( print_r( 'hellooo', true ) );
 
 			$save_fields = $this->get_user_meta_by_form_fields( $user_id );
 

--- a/includes/admin/class-ur-admin-settings.php
+++ b/includes/admin/class-ur-admin-settings.php
@@ -464,6 +464,18 @@ class UR_Admin_Settings {
 									$settings .= '</div>';
 									$settings .= '</div>';
 									break;
+								case 'nonce':
+									$settings .= '<div class="user-registration-global-settings">';
+									$settings .= '<div class="user-registration-global-settings--field">';
+									$settings .= '<input
+											name="' . esc_attr( $value['id'] ) . '"
+											id="' . esc_attr( $value['id'] ) . '"
+											type="hidden"
+											value="' . esc_attr( wp_create_nonce( $value['action'] ) ) . '"
+											/>';
+									$settings .= '</div>';
+									$settings .= '</div>';
+									break;
 
 								// Color picker.
 								case 'color':

--- a/includes/admin/settings/class-ur-settings-license.php
+++ b/includes/admin/settings/class-ur-settings-license.php
@@ -85,6 +85,11 @@ if ( ! class_exists( 'UR_Settings_License' ) ) :
 									'css'      => 'min-width: 350px;',
 									'desc_tip' => true,
 								),
+								array(
+									'id'     => 'ur_license_nonce',
+									'action' => '_ur_license_nonce',
+									'type'   => 'nonce',
+								),
 							),
 						),
 					),
@@ -104,7 +109,7 @@ if ( ! class_exists( 'UR_Settings_License' ) ) :
 						'buttons'  => array(
 							array(
 								'title' => __( 'Deactivate License', 'user-registration' ),
-								'href'  => remove_query_arg( array( 'deactivated_license', 'activated_license' ), add_query_arg( 'user-registration_deactivate_license', 1 ) ),
+								'href'  => wp_nonce_url( remove_query_arg( array( 'deactivated_license', 'activated_license' ), add_query_arg( 'user-registration_deactivate_license', 1 ), ), '_ur_license_nonce' ),
 								'class' => 'user_registration-deactivate-license-key',
 							),
 						),

--- a/includes/admin/views/html-license-form.php
+++ b/includes/admin/views/html-license-form.php
@@ -17,6 +17,9 @@ $license_key = sanitize_title( $this->plugin_slug . '_license_key' );
 		<?php $this->user_registration_error_notices(); ?>
 		<input type="checkbox" name="checked[]" value="1" checked="checked" style="display: none;">
 		<div class="update-message inline user-registration-updater-license-key">
+		<?php
+			wp_nonce_field( '_ur_license_nonce', 'ur_license_nonce' );
+		?>
 			<label for="<?php echo esc_attr( $license_key ); ?>"><?php esc_html_e( 'License:', 'user-registration' ); ?></label>
 			<input type="text" id="<?php echo esc_attr( $license_key ); ?>" name="<?php echo esc_attr( $license_key ); ?>" placeholder="<?php echo esc_attr__( 'XXXX-XXXX-XXXX-XXXX', 'user-registration' ); ?>" />
 			<span class="description"><?php esc_html_e( 'Enter your license key and hit return. A valid key is required for updates.', 'user-registration' ); ?> <?php printf( 'Lost your key? <a href="%s">Retrieve it here</a>.', esc_url( 'https://wpeverest.com/my-account' ) ); ?></span>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
While license activation and deactivation we were not checking capability and nonce. This PR handles this by checking nonce and capability.

Note : Our license activation and deactivation code was written in user-registration, But Since now we have pro addon these code are no longer needed for user-registration, we need to move this code to pro. 

### How to test the changes in this Pull Request:

1. 'plugin_requests' this function will not trigger any case from user-registration, so you have test this in User Registration Pro Addon. 
2. License Activation from plugin list and Global Settings-> License. Check license activated properly or not.
3. License  Deactivation from plugin list and Global Settings-> License. Check license deactivated properly or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Add Capability and nonce for license activation and deactivation.
