### PR TITLE
Fix - page_id, page_url, page_title smart tags not working on certain emails.

### DIFF
--- a/includes/class-ur-smart-tags.php
+++ b/includes/class-ur-smart-tags.php
@@ -325,6 +325,7 @@ class UR_Smart_Tags {
 						break;
 
 					case 'page_id':
+						$id = get_the_ID();
 						if ( empty( get_the_ID() ) && isset( $_SERVER['HTTP_REFERER'] ) ) {
 							$id = url_to_postid($_SERVER['HTTP_REFERER']);
 						}

--- a/includes/class-ur-smart-tags.php
+++ b/includes/class-ur-smart-tags.php
@@ -303,17 +303,33 @@ class UR_Smart_Tags {
 						break;
 
 					case 'page_title':
-						$page_title = get_the_title( get_the_ID() );
+						$id = get_the_ID();
+						if ( empty( get_the_ID() ) && isset( $_SERVER['HTTP_REFERER'] ) ) {
+							$id = url_to_postid($_SERVER['HTTP_REFERER']);
+						}
+
+						$page_title = get_the_title( $id );
 						$content    = str_replace( '{{' . $other_tag . '}}', $page_title, $content );
 						break;
 
 					case 'page_url':
-						$page_url = get_permalink( get_the_ID() );
+						$id = get_the_ID();
+						if ( empty( get_the_ID() ) && isset( $_SERVER['HTTP_REFERER'] ) ) {
+							$id = url_to_postid($_SERVER['HTTP_REFERER']);
+							$page_url = esc_url_raw(wp_unslash($_SERVER['HTTP_REFERER']));
+						} else {
+							$page_url = get_permalink( $id );
+						}
+
 						$content  = str_replace( '{{' . $other_tag . '}}', $page_url, $content );
 						break;
 
 					case 'page_id':
-						$page_id = get_the_ID();
+						if ( empty( get_the_ID() ) && isset( $_SERVER['HTTP_REFERER'] ) ) {
+							$id = url_to_postid($_SERVER['HTTP_REFERER']);
+						}
+
+						$page_id = $id;
 						$content = str_replace( '{{' . $other_tag . '}}', $page_id, $content );
 						break;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?


### Changes proposed in this Pull Request:

{{page_id}}, {{page_url}}, {{page_title}} smart tags were not working for certain emails such as forgot password, passwordless login, user registered successfully (etc.) (test yourself). 

### How to test the changes in this Pull Request:

1. Place above three smart tags on every emails.
2. Test and verify whether the smart tags are working properly or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - page_id, page_url, page_title smart tags not working on certain emails.
