### PR TITLE
UR-1693 Fix - The email content translation issues with WPML plugin.

### DIFF
--- a/assets/js/frontend/user-registration.js
+++ b/assets/js/frontend/user-registration.js
@@ -1011,6 +1011,7 @@
 									var form_id = 0;
 									var form_nonce = "0";
 									var captchaResponse = "";
+									var registration_language = "";
 									if (
 										"hcaptcha" ===
 										user_registration_params.recaptcha_type
@@ -1063,6 +1064,20 @@
 											)
 											.val();
 									}
+									if (
+										$(this)
+											.closest("form")
+											.find(
+												'input[name="ur-registration-language"]'
+											).length === 1
+									) {
+										registration_language = $(this)
+											.closest("form")
+											.find(
+												'input[name="ur-registration-language"]'
+											)
+											.val();
+									}
 
 									if (
 										$(this)
@@ -1086,6 +1101,7 @@
 										form_data: form_data,
 										captchaResponse: captchaResponse,
 										form_id: form_id,
+										registration_language: registration_language,
 										ur_frontend_form_nonce: form_nonce
 									};
 

--- a/includes/class-ur-emailer.php
+++ b/includes/class-ur-emailer.php
@@ -615,6 +615,8 @@ class UR_Emailer {
 			$message                   = $settings->ur_get_registration_denied_email();
 			$message                   = get_option( 'user_registration_registration_denied_email', $message );
 			list( $message, $subject ) = user_registration_email_content_overrider( $form_id, $settings, $message, $subject );
+			$message                   = ur_get_translated_string(  'admin_texts_user_registration_registration_denied_email', $message, $current_language, 'user_registration_registration_denied_email' );
+			$subject                   = ur_get_translated_string(  'admin_texts_user_registration_registration_denied_email_subject', $subject, $current_language, 'user_registration_registration_denied_email_subject' );
 			$message                   = self::parse_smart_tags( $message, $values, $name_value );
 			$subject                   = self::parse_smart_tags( $subject, $values, $name_value );
 
@@ -628,8 +630,8 @@ class UR_Emailer {
 			$message                   = $settings->ur_get_registration_approved_email();
 			$message                   = get_option( 'user_registration_registration_approved_email', $message );
 			list( $message, $subject ) = user_registration_email_content_overrider( $form_id, $settings, $message, $subject );
-			$message                   = ur_get_translated_string( $message, $current_language, 'user_registration_registration_approved_email' );
-			$subject                   = ur_get_translated_string( $subject, $current_language, 'user_registration_registration_approved_email_subject' );
+			$message                   = ur_get_translated_string(  'admin_texts_user_registration_registration_approved_email', $message, $current_language, 'user_registration_registration_approved_email' );
+			$subject                   = ur_get_translated_string(  'admin_texts_user_registration_registration_approved_email_subject', $subject, $current_language, 'user_registration_registration_approved_email_subject' );
 			$message                   = self::parse_smart_tags( $message, $values, $name_value );
 			$subject                   = self::parse_smart_tags( $subject, $values, $name_value );
 

--- a/includes/frontend/class-ur-frontend-form-handler.php
+++ b/includes/frontend/class-ur-frontend-form-handler.php
@@ -271,6 +271,7 @@ class UR_Frontend_Form_Handler {
 		update_user_meta( $user_id, 'ur_login_option', $login_option );
 
 		$current_language = ur_get_current_language();
+		$current_language = isset( $_POST['registration_language'] ) ? ur_clean( $_POST['registration_language'] ) : $current_language; //phpcs:ignore.
 		update_user_meta( $user_id, 'ur_registered_language', $current_language );
 	}
 }

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -5527,15 +5527,17 @@ if ( ! function_exists( 'ur_get_translated_string' ) ) {
 	 *
 	 * @since 4.2.1
 	 *
-	 * @param  string $string String.
+	 * @param  string $domain Domain.
+	 * @param  string $string String Value.
 	 * @param  string $language_code Language Code.
 	 * @param  string $field_key Field Key.
 	 * @param  string $form_id Form ID.
 	 */
-	function ur_get_translated_string( $string, $language_code, $field_key, $form_id = 0 ) {
+	function ur_get_translated_string( $domain, $string, $language_code, $field_key, $form_id = 0 ) {
 		if ( function_exists( 'icl_translate' ) ) {
 			$language_code     = is_array( $language_code ) ? $language_code[0] : $language_code;
-			$translated_string = apply_filters( 'wpml_translate_single_string', $string, 'user-registration', $string, $language_code );
+			$translated_string = apply_filters( 'wpml_translate_single_string', $string, $domain, $field_key, $language_code );
+
 			if ( false === $translated_string || $translated_string === $language_code ) {
 				return $string;
 			} else {

--- a/templates/form-registration.php
+++ b/templates/form-registration.php
@@ -325,7 +325,10 @@ do_action( 'user_registration_before_registration_form', $form_id );
 				<div style="clear:both"></div>
 				<?php if ( $enable_field_icon ) { ?>
 				<input type="hidden" id="ur-form-field-icon" name="ur-field-icon" value="<?php echo esc_attr( $enable_field_icon ); ?>"/>
-				<?php } ?>
+				<?php }
+				$current_language = ur_get_current_language();
+				?>
+				<input type="hidden" name="ur-registration-language" value="<?php echo esc_attr( $current_language ); ?>"/>
 				<input type="hidden" name="ur-user-form-id" value="<?php echo absint( $form_id ); ?>"/>
 				<input type="hidden" name="ur-redirect-url" value="<?php echo esc_url( ur_string_translation( $form_id, 'user_registration_form_setting_redirect_options', $redirect_url ) ); ?>"/>
 				<?php wp_nonce_field( 'ur_frontend_form_id-' . $form_id, 'ur_frontend_form_nonce', false ); ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously we tried to fix email translation from backend current language, which was wrong approach we need to know user while registration which language registration form opened. Also user translate their string in different domain, so handle those domain too. 
In this PR, I have fixed Email Translation issue.

### How to test the changes in this Pull Request:

1. Translate Emails using WPML.
2. In frontend switch the language and register user. 
3. Check user email where translate according to user registered language. 
4. Check by approving and denied user too.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

>  Fix - The email content translation issues with WPML plugin.
