### PR TITLE
UR-1605 Fix - Disable default wordpress login not working.

### DIFF
--- a/includes/admin/class-ur-admin-settings.php
+++ b/includes/admin/class-ur-admin-settings.php
@@ -119,7 +119,16 @@ class UR_Admin_Settings {
 
 			self::add_error(
 				esc_html__(
-					'Your settings have not been saved. You enabled "Disable Default WordPress Login Screen" but did not select a login page. Please select a page for "Redirect Default WordPress Login To".',
+					'Your settings has not been saved. You enabled "Disable Default WordPress Login Screen" but did not select a login page. Please select a page for "Redirect Default WordPress Login To".',
+					'user-registration'
+				)
+			);
+
+		} elseif ( $flag && 'redirect_login_not_myaccount' === $flag ) {
+
+			self::add_error(
+				esc_html__(
+					'Your settings has not been saved.The selected page for "Redirect Default WordPress Login To" is not an login page. Please select an valid login page.',
 					'user-registration'
 				)
 			);

--- a/includes/admin/class-ur-admin-settings.php
+++ b/includes/admin/class-ur-admin-settings.php
@@ -91,7 +91,6 @@ class UR_Admin_Settings {
 		if ( empty( $_REQUEST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( $_REQUEST['_wpnonce'] ), 'user-registration-settings' ) ) {
 			die( esc_html__( 'Action failed. Please refresh the page and retry.', 'user-registration' ) );
 		}
-
 		/**
 		 * Action to save current tab settings
 		 */
@@ -112,10 +111,20 @@ class UR_Admin_Settings {
 		 */
 		$flag = apply_filters( 'show_user_registration_setting_message', true );
 
-		if ( $flag ) {
-			self::add_message( esc_html__( 'Your settings have been saved.', 'user-registration' ) );
-		}
+		$flag = apply_filters( 'user_registration_settings_prevent_default_login', $_REQUEST );
 
+		if ( $flag && is_bool( $flag ) ) {
+			self::add_message( esc_html__( 'Your settings have been saved.', 'user-registration' ) );
+		} elseif ( $flag && 'redirect_login_error' === $flag ) {
+
+			self::add_error(
+				esc_html__(
+					'Your settings have not been saved. You enabled "Disable Default WordPress Login Screen" but did not select a login page. Please select a page for "Redirect Default WordPress Login To".',
+					'user-registration'
+				)
+			);
+
+		}
 		// Flush rules.
 		wp_schedule_single_event( time(), 'user_registration_flush_rewrite_rules' );
 
@@ -198,7 +207,6 @@ class UR_Admin_Settings {
 		// Get current tab/section.
 		$current_tab     = empty( $_GET['tab'] ) ? 'general' : sanitize_title( wp_unslash( $_GET['tab'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
 		$current_section = empty( $_REQUEST['section'] ) ? '' : sanitize_title( wp_unslash( $_REQUEST['section'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
-
 		/**
 		 * Filter to save settings actions
 		 *
@@ -957,6 +965,11 @@ class UR_Admin_Settings {
 
 		if ( empty( $options ) ) {
 			return false;
+		}
+		// Return if default wp_login is disabled and no redirect url is set.
+		$is_wp_login_disabled_error = apply_filters( 'user_registration_settings_prevent_default_login', $_POST );
+		if ( $is_wp_login_disabled_error && 'redirect_login_error' === $is_wp_login_disabled_error ) {
+			return;
 		}
 
 		// Loop options and get values to save.

--- a/includes/admin/class-ur-admin-settings.php
+++ b/includes/admin/class-ur-admin-settings.php
@@ -128,7 +128,7 @@ class UR_Admin_Settings {
 
 			self::add_error(
 				esc_html__(
-					'Your settings has not been saved.The selected page for "Redirect Default WordPress Login To" is not an login page. Please select an valid login page.',
+					'Your settings has not been saved.The selected page for "Redirect Default WordPress Login To" is not a login page. Please select a valid login page.',
 					'user-registration'
 				)
 			);

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -5833,13 +5833,25 @@ if ( ! function_exists( 'ur_prevent_default_login' ) ) {
 	/**
 	 * Handel error when default login screen is disabled but redirect login poage is not selected.
 	 *
+	 * @since 3.3.1
+	 *
 	 * @return @mixed
 	 */
 	function ur_prevent_default_login( $data ) {
 		// Return if default wp_login is disabled and no redirect url is set.
 		if ( isset( $data['user_registration_login_options_prevent_core_login'] ) && $data['user_registration_login_options_prevent_core_login'] ) {
-			if ( isset( $data['user_registration_login_options_login_redirect_url'] ) && ! $data['user_registration_login_options_login_redirect_url'] ) {
-				return 'redirect_login_error';
+			if ( isset( $data['user_registration_login_options_login_redirect_url'] )  ) {
+				gettype( $data['user_registration_login_options_login_redirect_url'] );
+				if( ! $data['user_registration_login_options_login_redirect_url'] ) {
+					return 'redirect_login_error';
+				}
+				if( is_numeric( $data['user_registration_login_options_login_redirect_url'] ) ) {
+					$is_page_my_account_page = ur_find_my_account_in_page( $data['user_registration_login_options_login_redirect_url'] );
+					if ( ! $is_page_my_account_page ) {
+						return 'redirect_login_not_myaccount';
+					}
+
+				}
 			}
 		}
 		return true;

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -5828,3 +5828,20 @@ if ( ! function_exists( 'ur_current_url' ) ) {
 		return esc_url_raw( $url );
 	}
 }
+add_filter( 'user_registration_settings_prevent_default_login', 'ur_prevent_default_login' );
+if ( ! function_exists( 'ur_prevent_default_login' ) ) {
+	/**
+	 * Handel error when default login screen is disabled but redirect login poage is not selected.
+	 *
+	 * @return @mixed
+	 */
+	function ur_prevent_default_login( $data ) {
+		// Return if default wp_login is disabled and no redirect url is set.
+		if ( isset( $data['user_registration_login_options_prevent_core_login'] ) && $data['user_registration_login_options_prevent_core_login'] ) {
+			if ( isset( $data['user_registration_login_options_login_redirect_url'] ) && ! $data['user_registration_login_options_login_redirect_url'] ) {
+				return 'redirect_login_error';
+			}
+		}
+		return true;
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # Previously when `Disable Default WordPress Login Screen` is enabled but `Redirect Default WordPress Login To` is not selected settings were saved. This PR solves this issue.

### How to test the changes in this Pull Request:

1.Go to `settings`>>`Login Options`
2.Enable `Disable Default WordPress Login Screen` and don't select any page at `Redirect Default WordPress Login To` 
3.Now verify form is not submitted and error message is displayed.
4.Also verify when selected redirection page login page is redirected.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Diable default wordpress login not working.
