### PR TITLE
Dependency for login block

### DIFF
--- a/includes/blocks/block-types/class-ur-block-login-form.php
+++ b/includes/blocks/block-types/class-ur-block-login-form.php
@@ -36,6 +36,10 @@ class UR_Block_Login_Form extends UR_Block_Abstract {
 			$parameters['logout_redirect'] = $attr['logoutUrl'];
 		}
 
+		if ( ! empty( $attr['userState'] ) ) {
+			$parameters['userState'] = $attr['userState'];
+		}
+		
 		return UR_Shortcodes::login(
 			$parameters
 		);

--- a/includes/blocks/block-types/class-ur-block-myaccount.php
+++ b/includes/blocks/block-types/class-ur-block-myaccount.php
@@ -36,7 +36,18 @@ class UR_Block_Myaccount extends UR_Block_Abstract {
 			$parameters['logout_redirect'] = $attr['logoutUrl'];
 		}
 
-		return UR_Shortcodes::my_account(
+		if ( ! empty( $attr['userState'] ) ) {
+			$parameters['userState'] = $attr['userState'];
+		}
+		
+
+		if ( empty( $parameters )  || ( isset($parameters['userState']) && "logged_in" === $parameters['userState'] )) {
+			return UR_Shortcodes::my_account(
+				$parameters
+			);
+		}
+		
+		return UR_Shortcodes::login(
 			$parameters
 		);
 	}

--- a/includes/blocks/block-types/class-ur-block-registration-form.php
+++ b/includes/blocks/block-types/class-ur-block-registration-form.php
@@ -26,12 +26,15 @@ class UR_Block_Regstration_Form extends UR_Block_Abstract {
 	 */
 	protected function build_html( $content ) {
 		$form_id = isset( $this->attributes['formId'] ) ? $this->attributes['formId'] : '';
+		$user_state = isset( $this->attributes['userState'] ) ? $this->attributes['userState'] : 'logged_out';
 		if ( empty( $form_id ) ) {
 			return $content;
 		}
+	
 		return UR_Shortcodes::form(
 			array(
 				'id' => $form_id,
+				'userState' => $user_state
 			)
 		);
 	}

--- a/includes/class-ur-shortcodes.php
+++ b/includes/class-ur-shortcodes.php
@@ -254,7 +254,12 @@ class UR_Shortcodes {
 		 * @param bool $default_value Default value retrieved from the 'users_can_register' setting.
 		 */
 		$users_can_register = apply_filters( 'ur_register_setting_override', get_option( 'users_can_register' ) );
-
+		$check_user_state 		= isset( $atts['userState'] ) && 'logged_in' === $atts['userState'];
+		
+		if( $check_user_state ) {
+			return wp_kses_post( apply_filters( 'user_registration_logged_in_message', sprintf( __( 'You are already logged in. <a href="%s">Log out?</a>', 'user-registration' ), ur_logout_url() ) ) );
+		}
+		
 		if ( ! is_user_logged_in() ) {
 			if ( ! $users_can_register ) {
 				/**

--- a/includes/shortcodes/class-ur-shortcode-login.php
+++ b/includes/shortcodes/class-ur-shortcode-login.php
@@ -38,8 +38,9 @@ class UR_Shortcode_Login {
 
 		$redirect_url = isset( $atts['redirect_url'] ) ? trim( $atts['redirect_url'] ) : '';
 		$redirect_url = UR_Shortcodes::check_is_valid_redirect_url( $redirect_url );
+		$check_state = isset( $atts['userState'] ) && 'logged_out' === $atts['userState'];
 
-		if ( ! is_user_logged_in() ) {
+		if ( ! is_user_logged_in() || $check_state  ) {
 			// After password reset, add confirmation message.
 			$is_password_resetted = get_transient( 'ur_password_resetted_flag' );
 			if ( ! empty( $is_password_resetted ) ) {

--- a/includes/shortcodes/class-ur-shortcode-login.php
+++ b/includes/shortcodes/class-ur-shortcode-login.php
@@ -38,8 +38,11 @@ class UR_Shortcode_Login {
 
 		$redirect_url = isset( $atts['redirect_url'] ) ? trim( $atts['redirect_url'] ) : '';
 		$redirect_url = UR_Shortcodes::check_is_valid_redirect_url( $redirect_url );
-		$check_state = isset( $atts['userState'] ) && 'logged_out' === $atts['userState'];
 
+		$check_state = true;
+		if ( isset( $atts['userState'] ) ) {
+			$check_state = 'logged_out' === $atts['userState'];
+		}
 		if ( ! is_user_logged_in() || $check_state  ) {
 			// After password reset, add confirmation message.
 			$is_password_resetted = get_transient( 'ur_password_resetted_flag' );

--- a/src/blocks/blocks/login-form/Edit.js
+++ b/src/blocks/blocks/login-form/Edit.js
@@ -3,7 +3,7 @@ import { __ } from "@wordpress/i18n";
 import { Box } from "@chakra-ui/react";
 import metadata from "./block.json";
 
-import { TextControl, PanelBody } from "@wordpress/components";
+import { TextControl, SelectControl, PanelBody } from "@wordpress/components";
 import { InspectorControls, useBlockProps } from "@wordpress/block-editor";
 const ServerSideRender = wp.serverSideRender
 	? wp.serverSideRender
@@ -14,7 +14,7 @@ const Edit = (props) => {
 	const blockName = metadata.name;
 
 	const {
-		attributes: { redirectUrl, logoutUrl },
+		attributes: { redirectUrl, logoutUrl, userState },
 		setAttributes,
 	} = props;
 
@@ -23,6 +23,9 @@ const Edit = (props) => {
 	};
 	const setLogoutUrl = (url) => {
 		setAttributes({ logoutUrl: url });
+	};
+	const setUserState = (state) => {
+		setAttributes({ userState: state });
 	};
 
 	return (
@@ -42,6 +45,16 @@ const Edit = (props) => {
 						label={__("Logout URL", "user-registration")}
 						value={logoutUrl}
 						onChange={setLogoutUrl}
+					/>
+					<SelectControl
+						key="ur-gutenberg-login-user-login-state"
+						label={__("User State", "user-registration")}
+						value={userState}
+						options={[
+							{ label: "Logged In", value: "logged_in" },
+							{ label: "Logged Out", value: "logged_out" },
+						]}
+						onChange={setUserState}
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/src/blocks/blocks/login-form/Edit.js
+++ b/src/blocks/blocks/login-form/Edit.js
@@ -51,8 +51,8 @@ const Edit = (props) => {
 						label={__("User State", "user-registration")}
 						value={userState}
 						options={[
-							{ label: "Logged In", value: "logged_in" },
 							{ label: "Logged Out", value: "logged_out" },
+							{ label: "Logged In", value: "logged_in" },
 						]}
 						onChange={setUserState}
 					/>

--- a/src/blocks/blocks/login-form/Edit.js
+++ b/src/blocks/blocks/login-form/Edit.js
@@ -3,7 +3,7 @@ import { __ } from "@wordpress/i18n";
 import { Box } from "@chakra-ui/react";
 import metadata from "./block.json";
 
-import { TextControl, SelectControl, PanelBody } from "@wordpress/components";
+import {TextControl, SelectControl, PanelBody, Disabled} from "@wordpress/components";
 import { InspectorControls, useBlockProps } from "@wordpress/block-editor";
 const ServerSideRender = wp.serverSideRender
 	? wp.serverSideRender
@@ -59,11 +59,13 @@ const Edit = (props) => {
 				</PanelBody>
 			</InspectorControls>
 			<Box {...useProps}>
-				<ServerSideRender
-					key="ur-gutenberg-login-form-server-side-renderer"
-					block={blockName}
-					attributes={props.attributes}
-				/>
+				<Disabled>
+					<ServerSideRender
+						key="ur-gutenberg-login-form-server-side-renderer"
+						block={blockName}
+						attributes={props.attributes}
+					/>
+				</Disabled>
 			</Box>
 		</>
 	);

--- a/src/blocks/blocks/login-form/block.json
+++ b/src/blocks/blocks/login-form/block.json
@@ -22,6 +22,9 @@
     },
     "logoutUrl": {
       "type": "string"
+    },
+    "userState": {
+      "type": "string"
     }
   },
   "editorScript": "user-registration-blocks-editor",

--- a/src/blocks/blocks/myaccount/Edit.js
+++ b/src/blocks/blocks/myaccount/Edit.js
@@ -2,7 +2,7 @@ import React from "react";
 import { __ } from "@wordpress/i18n";
 import { Box } from "@chakra-ui/react";
 
-import { TextControl, SelectControl, PanelBody } from "@wordpress/components";
+import {TextControl, SelectControl, PanelBody, Disabled} from "@wordpress/components";
 import { InspectorControls, useBlockProps } from "@wordpress/block-editor";
 import metadata from "./block.json";
 
@@ -63,11 +63,13 @@ const Edit = (props) => {
 				</PanelBody>
 			</InspectorControls>
 			<Box {...useProps}>
-				<ServerSideRender
-					key="ur-gutenberg-myaccount-server-side-renderer"
-					block={blockName}
-					attributes={props.attributes}
-				/>
+				<Disabled>
+					<ServerSideRender
+						key="ur-gutenberg-myaccount-server-side-renderer"
+						block={blockName}
+						attributes={props.attributes}
+					/>
+				</Disabled>
 			</Box>
 		</>
 	);

--- a/src/blocks/blocks/myaccount/Edit.js
+++ b/src/blocks/blocks/myaccount/Edit.js
@@ -2,7 +2,7 @@ import React from "react";
 import { __ } from "@wordpress/i18n";
 import { Box } from "@chakra-ui/react";
 
-import { TextControl, PanelBody } from "@wordpress/components";
+import { TextControl, SelectControl, PanelBody } from "@wordpress/components";
 import { InspectorControls, useBlockProps } from "@wordpress/block-editor";
 import metadata from "./block.json";
 
@@ -15,7 +15,7 @@ const Edit = (props) => {
 	const blockName = metadata.name;
 
 	const {
-		attributes: { redirectUrl, logoutUrl },
+		attributes: { redirectUrl, logoutUrl, userState },
 		setAttributes,
 	} = props;
 
@@ -24,6 +24,9 @@ const Edit = (props) => {
 	};
 	const setLogoutUrl = (url) => {
 		setAttributes({ logoutUrl: url });
+	};
+	const setUserState = (state) => {
+		setAttributes({ userState: state });
 	};
 
 	return (
@@ -46,6 +49,16 @@ const Edit = (props) => {
 						label={__("Logout URL", "user-registration")}
 						value={logoutUrl}
 						onChange={setLogoutUrl}
+					/>
+					<SelectControl
+						key="ur-gutenberg-myaccount-user-login-state"
+						label={__("User State", "user-registration")}
+						value={userState}
+						options={[
+							{ label: "Logged In", value: "logged_in" },
+							{ label: "Logged Out", value: "logged_out" },
+						]}
+						onChange={setUserState}
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/src/blocks/blocks/myaccount/block.json
+++ b/src/blocks/blocks/myaccount/block.json
@@ -25,6 +25,9 @@
     },
     "logoutUrl": {
       "type": "string"
+    },
+    "userState": {
+      "type": "string"
     }
   },
   "editorScript": "user-registration-blocks-editor",

--- a/src/blocks/blocks/registration-form/Edit.js
+++ b/src/blocks/blocks/registration-form/Edit.js
@@ -12,7 +12,7 @@ import {
 	Stack
 } from "@chakra-ui/react";
 
-import { SelectControl, PanelBody } from "@wordpress/components";
+import { SelectControl, PanelBody, Disabled } from "@wordpress/components";
 
 import { InspectorControls, useBlockProps } from "@wordpress/block-editor";
 import { ChakraProvider } from "@chakra-ui/react";
@@ -161,11 +161,13 @@ const Edit = (props) => {
 						</CardBody>
 					</Card>
 				) : (
-					<ServerSideRender
-						key="ur-gutenberg-registration-form-server-side-renderer"
-						block={blockName}
-						attributes={{ ...props.attributes, userState }}
-					/>
+					<Disabled>
+						<ServerSideRender
+							key="ur-gutenberg-registration-form-server-side-renderer"
+							block={blockName}
+							attributes={{ ...props.attributes, userState }}
+						/>
+					</Disabled>
 				)}
 			</Box>
 		</ChakraProvider>

--- a/src/blocks/blocks/registration-form/Edit.js
+++ b/src/blocks/blocks/registration-form/Edit.js
@@ -9,13 +9,18 @@ import {
 	Card,
 	CardBody,
 	Text,
-	Stack,
+	Stack
 } from "@chakra-ui/react";
 
 import { SelectControl, PanelBody } from "@wordpress/components";
 
 import { InspectorControls, useBlockProps } from "@wordpress/block-editor";
 import { ChakraProvider } from "@chakra-ui/react";
+import metadata from "./block.json";
+
+const ServerSideRender = wp.serverSideRender
+	? wp.serverSideRender
+	: wp.components.ServerSideRender;
 
 /* global _UR_BLOCKS_ */
 const { urRestApiNonce, restURL, logoUrl } =
@@ -25,10 +30,13 @@ const Edit = (props) => {
 	const useProps = useBlockProps();
 	const {
 		attributes: { formId },
-		setAttributes,
+		setAttributes
 	} = props;
 
+	const blockName = metadata.name;
 	const [formList, setFormList] = useState("");
+	const [formState, setFormState] = useState(!!formId);
+	const [userState, setUserState] = useState("logged_out");
 
 	useEffect(() => {
 		const fetchData = async () => {
@@ -40,8 +48,8 @@ const Edit = (props) => {
 							"user-registration/v1/gutenberg-blocks/form-list",
 						method: "GET",
 						headers: {
-							"X-WP-Nonce": urRestApiNonce,
-						},
+							"X-WP-Nonce": urRestApiNonce
+						}
 					});
 					if (res.success) {
 						setFormList(res.form_lists);
@@ -57,11 +65,12 @@ const Edit = (props) => {
 
 	const formOptions = Object.keys(formList).map((index) => ({
 		value: Number(index),
-		label: formList[index],
+		label: formList[index]
 	}));
 
 	const selectRegistrationForm = (id) => {
 		setAttributes({ formId: id });
+		setFormState(id);
 	};
 
 	return (
@@ -71,7 +80,7 @@ const Edit = (props) => {
 					<PanelBody
 						title={__(
 							"User Registration Forms",
-							"user-registration",
+							"user-registration"
 						)}
 					>
 						<SelectControl
@@ -81,60 +90,83 @@ const Edit = (props) => {
 								{
 									label: __(
 										"Select a Form",
-										"user-registration",
+										"user-registration"
 									),
-									value: "",
+									value: ""
 								},
-								...formOptions,
+								...formOptions
 							]}
 							onChange={selectRegistrationForm}
 						/>
+						{formState && (
+							<SelectControl
+								key="ur-gutenberg-registration-form-user-login-state"
+								label={__("User State", "user-registration")}
+								value={userState}
+								options={[
+									{ label: "Logged In", value: "logged_in" },
+									{
+										label: "Logged Out",
+										value: "logged_out"
+									}
+								]}
+								onChange={setUserState}
+							/>
+						)}
 					</PanelBody>
 				</InspectorControls>
-				<Card>
-					<CardBody>
-						<Center>
-							<Image src={logoUrl} />
-						</Center>
-						<Center>
-							<Heading as="h3" ml={5}>
-								{__(
-									"User Registration Forms",
-									"user-registration",
-								)}
-							</Heading>
-						</Center>
-						<Center>
-							<Stack spacing="3">
-								<Text fontSize="sm" as="i">
+				{!formState ? (
+					<Card>
+						<CardBody>
+							<Center>
+								<Image src={logoUrl} />
+							</Center>
+							<Center>
+								<Heading as="h3" ml={5}>
 									{__(
-										"Select a registration form name to display one of your form.",
-										"user-registration",
+										"User Registration Forms",
+										"user-registration"
 									)}
-								</Text>
-							</Stack>
-						</Center>
-						<Center>
-							<Box w="sm" m="4">
-								<SelectControl
-									key="ur-gutenberg-registration-form-select-control"
-									value={formId}
-									options={[
-										{
-											label: __(
-												"Select a Form",
-												"user-registration",
-											),
-											value: "",
-										},
-										...formOptions,
-									]}
-									onChange={selectRegistrationForm}
-								/>
-							</Box>
-						</Center>
-					</CardBody>
-				</Card>
+								</Heading>
+							</Center>
+							<Center>
+								<Stack spacing="3">
+									<Text fontSize="sm" as="i">
+										{__(
+											"Select a registration form name to display one of your form.",
+											"user-registration"
+										)}
+									</Text>
+								</Stack>
+							</Center>
+							<Center>
+								<Box w="sm" m="4">
+									<SelectControl
+										key="ur-gutenberg-registration-form-select-control"
+										value={formId}
+										options={[
+											{
+												label: __(
+													"Select a Form",
+													"user-registration"
+												),
+												value: ""
+											},
+											...formOptions
+										]}
+										onChange={selectRegistrationForm}
+									/>
+								</Box>
+							</Center>
+						</CardBody>
+					</Card>
+				) : (
+					<ServerSideRender
+						key="ur-gutenberg-registration-form-server-side-renderer"
+						block={blockName}
+						attributes={{ ...props.attributes, userState }}
+					/>
+				)}
 			</Box>
 		</ChakraProvider>
 	);

--- a/src/blocks/blocks/registration-form/block.json
+++ b/src/blocks/blocks/registration-form/block.json
@@ -20,6 +20,9 @@
     "formId": {
       "type": "string",
       "default": ""
+    },
+    "userState": {
+      "type": "string"
     }
   },
   "editorScript": "user-registration-blocks-editor",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
Previously when admin viewed the login form block it showed already logged In now it should show according to the state.
Added user-logged In state feature, on blocks such as user login and user registration , also added access or restrict state for content restrictions as well.
Closes # .

### How to test the changes in this Pull Request:

1. Go to any page editor and add Blocks user-registration-form, user login, content restriction and my account
2. Change the newly added state settings on the block settings section.
3. Everything should work fine.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Login block should show login form.
