### PR TITLE
UR-1658 Fix - Anyone can register option not working due to conflict with Really Simple SSL plugin

### DIFF
--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -5827,3 +5827,33 @@ if ( ! function_exists( 'ur_current_url' ) ) {
 		return esc_url_raw( $url );
 	}
 }
+
+// TODO: Remove this code once Really Simple SSL plugin resolves the conflict from their side.
+if ( ! function_exists( 'ur_rsssl_anyone_can_register_conflict_resolver' ) ) {
+
+	/**
+	 * Resolve anyone can register setting conflict with Really Simple SSL Plugin.
+	 *
+	 * @param bool $value Option value.
+	 */
+	function ur_rsssl_anyone_can_register_conflict_resolver( $value ) {
+		global $wpdb;
+
+		if ( function_exists( 'is_plugin_active' ) && is_plugin_active( 'really-simple-ssl/rlrsssl-really-simple-ssl.php' ) ) {
+
+			$rsssl_options = get_option( 'rsssl_options', '' );
+			$rsssl_options = maybe_unserialize( $rsssl_options );
+
+			if ( isset( $rsssl_options['disable_anyone_can_register'] ) && $rsssl_options['disable_anyone_can_register'] ) {
+				$value = $wpdb->get_var( "SELECT option_value FROM {$wpdb->prefix}options WHERE option_name = 'users_can_register';" ); // phpcs:ignore;
+
+				if ( $value ) {
+					return true;
+				}
+			}
+		}
+
+		return $value;
+	}
+}
+add_filter( 'ur_register_setting_override', 'ur_rsssl_anyone_can_register_conflict_resolver', 10, 1 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously when Anyone can register option is enabled and saved and Really Simple SSL plugin was activated then “Disable ‘anyone can register'” setting is enabled, the “Anyone can register” option is blocked from being enabled in Settings -> General by your plugin code. This is an issue that is to be fixed by Really Simple SSL Plugin. I have raised a thread in their support https://wordpress.org/support/topic/conflict-with-disable-anyone-can-register/#new-topic-0.

Apart from not being able to save the enabled setting of Anyone can register, its previous saved enabled value was not abled to be fetched by our plugin, so even though it was previously enabled, the conflict caused by the Really Simple SSL plugin with WordPress core functionality, always sent the option value to be false irrespective of what was saved in the options table. This PR provides a solution for this from our side, which fetches the saved value from the options table when Really Simple SSL is active and its option “Disable ‘anyone can register'” was enabled, if the fetched value is true then our plugin functionality will not be affected and users will not be displayed `Only administrator can add new users` message in Registration Page.

### How to test the changes in this Pull Request:

1. Without switching to this branch firstly enable the Anyone Can Register option and then enable Really Simple SSL plugin's  “Disable ‘anyone can register'” , Go to our Registration Form Page as guest user, `Only administrator can add new users`  message will be shown.
2. Switch to this branch and check if Registration Form will be displayed in the page, and user will be able to register from our form.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Anyone can register option not working due to conflict with the Really Simple SSL plugin
