### PR TITLE
Fix - Issue in saving shipping address different to billing in woocommerce

### DIFF
--- a/assets/js/frontend/user-registration.js
+++ b/assets/js/frontend/user-registration.js
@@ -571,6 +571,9 @@
 													JSON.stringify(
 														checked_value
 													);
+												if ( "separate_shipping" === field.attr("data-id") ) {
+													formwise_data.value = field.val();
+												}
 											} else {
 												formwise_data.value = "";
 											}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?


### Changes proposed in this Pull Request:

On form submission, when we enable separate shipping to that of billing. Shipping address also saved same billing address.

Closes # .

### How to test the changes in this Pull Request:

1. Drag all billing and shipping fields.
2. Register a user enabling "Ship to different address"
3. Login and In Address tab of My Account verify the values.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Issue in saving shipping address different to billing in woocommerce.
