### PR TITLE
Enhance - Warning for field deletion used in Conditional Logic

### DIFF
--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -3248,7 +3248,8 @@
 												)
 												.val(),
 											ele = $this,
-											$ele = $(this);
+											$ele = $(this),
+											delete_item = true;
 
 										// Get fieldKey from data-field-key attribute.
 										var fieldKey = $ele
@@ -3274,88 +3275,101 @@
 											})
 											.text()
 											.trim();
-											var is_auto_generate_pass_enable = $("#user_registration_pro_auto_password_activate").is(
-												":checked"
-											);
-											if ( $.inArray( fieldKey, user_registration_form_builder_data.ur_form_non_deletable_fields ) > -1 ) {
-												if( 'user_pass' === fieldKey &&  ! is_auto_generate_pass_enable  ) {
-													show_feature_notice(fieldKey ,label);
-													return;
-												}
-												if ( 'user_pass' !== fieldKey ) {
-													show_feature_notice(fieldKey, label);
-													return;
-												}
+										var is_auto_generate_pass_enable = $("#user_registration_pro_auto_password_activate").is(
+											":checked"
+										);
+										if ( $.inArray( fieldKey, user_registration_form_builder_data.ur_form_non_deletable_fields ) > -1 ) {
+											if( 'user_pass' === fieldKey &&  ! is_auto_generate_pass_enable  ) {
+												show_feature_notice(fieldKey ,label);
+												return;
+											}
+											if ( 'user_pass' !== fieldKey ) {
+												show_feature_notice(fieldKey, label);
+												return;
+											}
 										}
 
-										ur_confirmation(
-											user_registration_form_builder_data
-												.i18n_admin
-												.i18n_are_you_sure_want_to_delete_field,
-											{
-												title: user_registration_form_builder_data
-													.i18n_admin.i18n_msg_delete,
-												showCancelButton: true,
-												confirmButtonText:
-													user_registration_form_builder_data
-														.i18n_admin
-														.i18n_choice_ok,
-												cancelButtonText:
-													user_registration_form_builder_data
-														.i18n_admin
-														.i18n_choice_cancel,
-												ele: ele,
-												$ele: $ele,
-												removed_item: removed_item,
-												confirm: function () {
-													$ele.closest(
-														".ur-selected-item "
-													).remove();
-													ele.check_grid();
-													builder.manage_empty_grid();
-													builder.manage_draggable_users_fields();
+										var data = {
+											delete_item : delete_item,
+											removed_item : removed_item,
+											label : label,
+										};
 
-													// Remove item from conditional logic options
-													$(
-														'[class*="urcl-settings-rules_field_"] option[value="' +
-															removed_item +
-															'"]'
-													).remove();
-
-													// Remove Field from Form Setting Conditionally Assign User Role.
-													$(
-														'[class*="urcl-field-conditional-field-select"] option[value="' +
-															removed_item +
-															'"]'
-													).remove();
-
-													$(
-														'[id="user_registration_form_setting_default_phone_field"] option[value="' +
-														removed_item +
-															'"]'
-													).remove();
-
-													$(document.body).trigger(
-														"ur_field_removed",
-														[
-															{
-																fieldName:
-																	fieldName,
-																fieldKey:
-																	fieldKey,
-																label: label
-															}
-														]
-													);
-
-													// To prevent click on whole item.
-													return false;
-												},
-												reject: function () {
-													return false;
-												}
-											}
+										$(document).trigger(
+											"user_registration_before_admin_field_remove",
+											[data]
 										);
+
+										if ( data.delete_item ) {
+											ur_confirmation(
+												user_registration_form_builder_data
+													.i18n_admin
+													.i18n_are_you_sure_want_to_delete_field,
+												{
+													title: user_registration_form_builder_data
+														.i18n_admin.i18n_msg_delete,
+													showCancelButton: true,
+													confirmButtonText:
+														user_registration_form_builder_data
+															.i18n_admin
+															.i18n_choice_ok,
+													cancelButtonText:
+														user_registration_form_builder_data
+															.i18n_admin
+															.i18n_choice_cancel,
+													ele: ele,
+													$ele: $ele,
+													removed_item: removed_item,
+													confirm: function () {
+														$ele.closest(
+															".ur-selected-item "
+														).remove();
+														ele.check_grid();
+														builder.manage_empty_grid();
+														builder.manage_draggable_users_fields();
+
+														// Remove item from conditional logic options
+														$(
+															'[class*="urcl-settings-rules_field_"] option[value="' +
+																removed_item +
+																'"]'
+														).remove();
+
+														// Remove Field from Form Setting Conditionally Assign User Role.
+														$(
+															'[class*="urcl-field-conditional-field-select"] option[value="' +
+																removed_item +
+																'"]'
+														).remove();
+
+														$(
+															'[id="user_registration_form_setting_default_phone_field"] option[value="' +
+															removed_item +
+																'"]'
+														).remove();
+
+														$(document.body).trigger(
+															"ur_field_removed",
+															[
+																{
+																	fieldName:
+																		fieldName,
+																	fieldKey:
+																		fieldKey,
+																	label: label
+																}
+															]
+														);
+
+														// To prevent click on whole item.
+														return false;
+													},
+													reject: function () {
+														return false;
+													}
+												}
+											);
+										}
 									}
 								);
 							},

--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -2768,10 +2768,19 @@
 									function () {
 										var $this_row = $(this).closest(".ur-single-row");
         								var fieldKeys = [];
+        								var fieldNames = [];
         								$this_row.find(".ur-selected-item .ur-field").each(function () {
             							var fieldKey = $(this).data("field-key");
+            							var fieldName = $(this).closest('.ur-selected-item').find('.ur-general-setting-field-name input[data-field="field_name"]').val();
+            							var fieldLabel = $(this).closest('.ur-selected-item').find('.ur-general-setting-label input[data-field="label"]').val();
            							 	fieldKeys.push(fieldKey);
+           							 	var field_data = {
+											fieldName: fieldName,
+											fieldLabel: fieldLabel
+										};
+										fieldNames.push(field_data);
        								 	});
+
 										if( fieldKeys.includes("user_pass") && fieldKeys.includes("user_email") ) {
 											show_feature_notice('','');
 											return;
@@ -2783,162 +2792,170 @@
 											return;
 										}
 
+										var data ={
+											delete_item : true,
+											fields : fieldNames,
+										};
+
+										$(document).trigger('user_registration_before_admin_row_remove',[data]);
+
 										if (
 											$(".ur-input-grids").find(
 												".ur-single-row:visible"
 											).length > 1
 										) {
 
-
-											ur_confirmation(
-												user_registration_form_builder_data
-													.i18n_admin
-													.i18n_are_you_sure_want_to_delete_row,
-												{
-													title: user_registration_form_builder_data
+											if ( data.delete_item ) {
+												ur_confirmation(
+													user_registration_form_builder_data
 														.i18n_admin
-														.i18n_msg_delete,
-													confirm: function () {
-														var btn =
-															$this_row.prev();
-														var new_btn;
-														if (
-															btn.hasClass(
-																"ur-add-new-row"
-															)
-														) {
-															new_btn =
-																btn.clone();
-														} else {
-															new_btn = $this_row
-																.clone()
-																.attr(
-																	"class",
-																	"dashicons-minus ur-remove-row"
-																);
-														}
-														if (
-															new_btn.hasClass(
-																"ur-add-new-row"
-															)
-														) {
-															$this_row
-																.closest(
-																	".ur-single-row"
+														.i18n_are_you_sure_want_to_delete_row,
+													{
+														title: user_registration_form_builder_data
+															.i18n_admin
+															.i18n_msg_delete,
+														confirm: function () {
+															var btn =
+																$this_row.prev();
+															var new_btn;
+															if (
+																btn.hasClass(
+																	"ur-add-new-row"
 																)
-																.prev()
-																.find(
-																	".ur-remove-row"
-																)
-																.before(
-																	new_btn
-																);
-														}
-														var single_row =
-															$this_row.closest(
-																".ur-single-row"
-															);
-														$(document).trigger(
-															"user_registration_row_deleted",
-															[single_row]
-														);
-
-														// Remove Row Fields from Conditional Select Dropdown.
-														var row_fields =
-															single_row.find(
-																".ur-grid-lists .ur-selected-item .ur-general-setting"
-															);
-														$(row_fields).each(
-															function () {
-																var field_label =
-																	$(this)
-																		.closest(
-																			".ur-selected-item"
-																		)
-																		.find(
-																			" .ur-admin-template .ur-label label"
-																		)
-																		.text();
-																var field_key =
-																	$(this)
-																		.closest(
-																			".ur-selected-item"
-																		)
-																		.find(
-																			" .ur-admin-template .ur-field"
-																		)
-																		.data(
-																			"field-key"
-																		);
-
-																//strip certain fields
-																if (
-																	"section_title" ==
-																		field_key ||
-																	"html" ==
-																		field_key ||
-																	"wysiwyg" ==
-																		field_key ||
-																	"billing_address_title" ==
-																		field_key ||
-																	"shipping_address_title" ==
-																		field_key
-																) {
-																	return;
-																}
-
-																var field_name =
-																	$(this)
-																		.find(
-																			"[data-field='field_name']"
-																		)
-																		.val();
-
-																if (
-																	typeof field_name !==
-																	"undefined"
-																) {
-																	// Remove item from conditional logic options
-																	$(
-																		'[class*="urcl-settings-rules_field_"] option[value="' +
-																			field_name +
-																			'"]'
-																	).remove();
-
-																	// Remove Field from Form Setting Conditionally Assign User Role.
-																	$(
-																		'[class*="urcl-field-conditional-field-select"] option[value="' +
-																			field_name +
-																			'"]'
-																	).remove();
-
-																	// Remove Field from Form Setting Default Phone field for SMS Verification.
-																	$(
-																		'[id="user_registration_form_setting_default_phone_field"] option[value="' +
-																			field_name +
-																			'"]'
-																	).remove();
-																}
+															) {
+																new_btn =
+																	btn.clone();
+															} else {
+																new_btn = $this_row
+																	.clone()
+																	.attr(
+																		"class",
+																		"dashicons-minus ur-remove-row"
+																	);
 															}
-														);
-														single_row.remove();
-														$this.check_grid();
-														builder.manage_draggable_users_fields();
+															if (
+																new_btn.hasClass(
+																	"ur-add-new-row"
+																)
+															) {
+																$this_row
+																	.closest(
+																		".ur-single-row"
+																	)
+																	.prev()
+																	.find(
+																		".ur-remove-row"
+																	)
+																	.before(
+																		new_btn
+																	);
+															}
+															var single_row =
+																$this_row.closest(
+																	".ur-single-row"
+																);
+															$(document).trigger(
+																"user_registration_row_deleted",
+																[single_row]
+															);
 
-														Swal.fire({
-															icon: "success",
-															title: "Successfully deleted!",
-															customClass:
-																"user-registration-swal2-modal user-registration-swal2-modal--center user-registration-swal2-no-button",
-															showConfirmButton: false,
-															timer: 1000
-														});
-													},
-													reject: function () {
-														// Do Nothing.
+															// Remove Row Fields from Conditional Select Dropdown.
+															var row_fields =
+																single_row.find(
+																	".ur-grid-lists .ur-selected-item .ur-general-setting"
+																);
+															$(row_fields).each(
+																function () {
+																	var field_label =
+																		$(this)
+																			.closest(
+																				".ur-selected-item"
+																			)
+																			.find(
+																				" .ur-admin-template .ur-label label"
+																			)
+																			.text();
+																	var field_key =
+																		$(this)
+																			.closest(
+																				".ur-selected-item"
+																			)
+																			.find(
+																				" .ur-admin-template .ur-field"
+																			)
+																			.data(
+																				"field-key"
+																			);
+
+																	//strip certain fields
+																	if (
+																		"section_title" ==
+																			field_key ||
+																		"html" ==
+																			field_key ||
+																		"wysiwyg" ==
+																			field_key ||
+																		"billing_address_title" ==
+																			field_key ||
+																		"shipping_address_title" ==
+																			field_key
+																	) {
+																		return;
+																	}
+
+																	var field_name =
+																		$(this)
+																			.find(
+																				"[data-field='field_name']"
+																			)
+																			.val();
+
+																	if (
+																		typeof field_name !==
+																		"undefined"
+																	) {
+																		// Remove item from conditional logic options
+																		$(
+																			'[class*="urcl-settings-rules_field_"] option[value="' +
+																				field_name +
+																				'"]'
+																		).remove();
+
+																		// Remove Field from Form Setting Conditionally Assign User Role.
+																		$(
+																			'[class*="urcl-field-conditional-field-select"] option[value="' +
+																				field_name +
+																				'"]'
+																		).remove();
+
+																		// Remove Field from Form Setting Default Phone field for SMS Verification.
+																		$(
+																			'[id="user_registration_form_setting_default_phone_field"] option[value="' +
+																				field_name +
+																				'"]'
+																		).remove();
+																	}
+																}
+															);
+															single_row.remove();
+															$this.check_grid();
+															builder.manage_draggable_users_fields();
+
+															Swal.fire({
+																icon: "success",
+																title: "Successfully deleted!",
+																customClass:
+																	"user-registration-swal2-modal user-registration-swal2-modal--center user-registration-swal2-no-button",
+																showConfirmButton: false,
+																timer: 1000
+															});
+														},
+														reject: function () {
+															// Do Nothing.
+														}
 													}
-												}
-											);
+												);
+											}
 										} else {
 											URFormBuilder.ur_alert(
 												user_registration_form_builder_data

--- a/includes/admin/class-ur-admin-assets.php
+++ b/includes/admin/class-ur-admin-assets.php
@@ -584,7 +584,7 @@ class UR_Admin_Assets {
 			'i18n_embed_to_new_page'                      => esc_html__( 'Create New Page', 'user-registration' ),
 			'i18n_embed_existing_page_description'        => esc_html__( 'Select the page to embed your form in.', 'user-registration' ),
 			'i18n_embed_go_back_btn'                      => esc_html__( 'Go Back', 'user-registration' ),
-			'i18n_embed_lets_go_btn'                      => esc_html__( 'Lets Go!', 'user-registration' ),
+			'i18n_embed_lets_go_btn'                      => esc_html__( "Let's Go!", 'user-registration' ),
 			'i18n_embed_new_page_description'             => esc_html__( 'What would you like to call the new page?', 'user-registration' ),
 			'i18n_at_least_one_field_need_to_select'      => _x( 'At least one field needs to be selected.', 'user registration admin', 'user-registration' ),
 			'i18n_total_required_on_coupon'               => _x( 'Total field is required with coupon.', 'user registration admin', 'user-registration' ),

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -4040,7 +4040,7 @@ if ( ! function_exists( 'ur_process_login' ) ) {
 				if ( ur_is_ajax_login_enabled() ) {
 					wp_send_json_error(
 						array(
-							'message' => $message,
+							'message' => apply_filters( 'login_errors', $message ),
 						)
 					);
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?


### Changes proposed in this Pull Request:

Previously, the field used within Conditional Settings of some fields and on Form Settings could have been deleted easily without user knowing they have been used. This PR warns the user about the use of such fields on Conditional Logic.

Please test this on Pro using this branch: **UR-816-fix/urcl-field-delete-warning**

### How to test the changes in this Pull Request:

1. Drag a few fields and enable conditional logic addon.
2. Apply conditional settings for some fields and also in form settings (conditional redirection, assign role).
3. Try to delete the field used in those logics and Verify.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x]Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhance - Warning for field deletion used in Conditional Logic
