### PR TITLE
Fix - Hide Unapproved Users action run for users not from our source

### DIFF
--- a/assets/js/frontend/user-registration.js
+++ b/assets/js/frontend/user-registration.js
@@ -588,11 +588,15 @@
 												? field.val()
 												: "";
 
-											formwise_data.field_name = field
+											privacy_field_name = field
 												.closest(
 													".field-privacy_policy"
 												)
 												.data("ref-id");
+
+											if ( "undefined" !== typeof privacy_field_name ) {
+												formwise_data.field_name = privacy_field_name;
+											}
 										}
 										break;
 									case "radio":

--- a/includes/class-ur-user-approval.php
+++ b/includes/class-ur-user-approval.php
@@ -373,7 +373,9 @@ class UR_User_Approval {
 			return;
 		}
 
-		if ( 'admin_approval' === ur_get_user_login_option( get_current_user_id() ) ) {
+		$form_id = ur_get_form_id_by_userid( get_current_user_id() );
+
+		if ( 'admin_approval' === ur_get_user_login_option( get_current_user_id() ) && $form_id ) {
 
 			// Try to hide the not approved users from any theme or plugin request in frontend.
 			$disable_pre_get = apply_filters( 'user_registration_disable_pre_get_users', 'no' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?


### Changes proposed in this Pull Request:

This was not replicated on our side but only on users side. But when a user registered from woocommerce tried to use a coupon code with one use per user limit, the checkout process was not carried out. Because although the user was not from our side the admin_approval global login_option (deprecated in previous versions) conflicted with the coupon code process and halted the checkout process.

### How to test the changes in this Pull Request:

1. Register a user from woocommerce registration (dont enable our user-registration-woocommerce)
2. Create a coupon code with one use per user limit from Marketting > Coupon.
3. Use the coupon code using one user and again register a user and try using coupon code during the checkout process.
4. Make sure "user_registration_general_setting_login_options" is set to "admin_approval" in options table (Insert this).
5. Further please test whether privacy policy and checkbox work properly when made required during form submission and edit profile.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Fix - Hide Unapproved Users action run for users not from our source