### PR TITLE
Fix - Form save action not working for initial form publish captcha setting

### DIFF
--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -863,7 +863,7 @@ class UR_AJAX {
 			// check captcha configuration before form save action.
 			if ( isset( $_POST['data']['form_setting_data'] ) ) {
 				foreach ( wp_unslash( $_POST['data']['form_setting_data'] )  as $setting_data ) { //phpcs:ignore
-					if ( 'user_registration_form_setting_enable_recaptcha_support' === $setting_data['name'] && ur_string_to_bool( $setting_data['value'] ) && ! ur_check_captch_keys( 'register', $_POST['data']['form_id'] ) ) {
+					if ( 'user_registration_form_setting_enable_recaptcha_support' === $setting_data['name'] && ur_string_to_bool( $setting_data['value'] ) && ! ur_check_captch_keys( 'register', $_POST['data']['form_id'], true ) ) {
 						throw new Exception(
 							sprintf(
 							/* translators: %s - Integration tab url */

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -3658,14 +3658,24 @@ if ( ! function_exists( 'ur_check_captch_keys' ) ) {
 	 *
 	 * @return bool
 	 */
-	function ur_check_captch_keys( $context = 'register', $form_id = 0 ) {
+	function ur_check_captch_keys( $context = 'register', $form_id = 0, $form_save_action = false ) {
 		$recaptcha_type      = get_option( 'user_registration_captcha_setting_recaptcha_version', 'v2' );
 		$invisible_recaptcha = ur_option_checked( 'user_registration_captcha_setting_invisible_recaptcha_v2', false );
 
 		if ( 'login' === $context ) {
 			$recaptcha_type = get_option( 'user_registration_login_options_configured_captcha_type', $recaptcha_type );
 		} elseif ( 'register' === $context && $form_id ) {
-			$recaptcha_type = ur_get_single_post_meta( $form_id, 'user_registration_form_setting_configured_captcha_type', $recaptcha_type );
+			if ( $form_save_action ) {
+				if ( isset( $_POST['data']['form_setting_data'] ) ) {
+					foreach (  $_POST['data']['form_setting_data'] as $value ) {
+						if ( "user_registration_form_setting_configured_captcha_type" === $value["name"] ) {
+							$recaptcha_type = $value["value"];
+						}
+					}
+				}
+			} else {
+				$recaptcha_type = ur_get_single_post_meta( $form_id, 'user_registration_form_setting_configured_captcha_type', $recaptcha_type );
+			}
 		}
 
 		$site_key   = '';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?


### Changes proposed in this Pull Request:

Previously, when a new form was created and tried to enable captcha support and save form, it gave error. This PR fixes the issue.

Closes # .

### How to test the changes in this Pull Request:

1. Create a new form after setting up captcha from User Registration > Settings > Captcha.
2. Enable Captcha Support from Form Settings and try saving form.
3. Check if the form save and other captcha functionality on frontend works properly or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Form save action not working for initial form publish captcha setting
