### PR TITLE
Fix - Slug translation issue on my account links

### DIFF
--- a/includes/class-ur-smart-tags.php
+++ b/includes/class-ur-smart-tags.php
@@ -501,11 +501,13 @@ class UR_Smart_Tags {
 						$content = str_replace( '{{' . $tag . '}}', esc_html( $full_name ), $content );
 						break;
 					case 'profile_details_link':
-						$profile_details_link = '<a href="' . esc_url( ur_get_endpoint_url( 'edit-profile' ) ) . '">' . esc_html__( 'profile details', 'user-registration' ) . '</a>';
+						$endpoint = ur_string_translation( 0, 'user_registration_edit-profile_slug', 'edit-profile' );
+						$profile_details_link = '<a href="' . esc_url( ur_get_endpoint_url( $endpoint ) ) . '">' . esc_html__( 'profile details', 'user-registration' ) . '</a>';
 						$content              = str_replace( '{{' . $tag . '}}', wp_kses_post( $profile_details_link ), $content );
 						break;
 					case 'edit_password_link':
-						$edit_password_link = '<a href="' . esc_url( ur_get_endpoint_url( 'edit-password' ) ) . '">' . esc_html__( 'edit your password', 'user-registration' ) . '</a>';
+						$endpoint = ur_string_translation( 0, 'user_registration_edit-password_slug', 'edit-password' );
+						$edit_password_link = '<a href="' . esc_url( ur_get_endpoint_url( $endpoint ) ) . '">' . esc_html__( 'edit your password', 'user-registration' ) . '</a>';
 						$content            = str_replace( '{{' . $tag . '}}', wp_kses_post( $edit_password_link ), $content );
 						break;
 					case 'sign_out_link':


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?


### Changes proposed in this Pull Request:

The links and endpoints gave issue for navigation after wpml translation of slugs. This PR fixes this issue.

Zips: https://themegrill.atlassian.net/browse/UR-1945?focusedCommentId=24167 

Closes # .

### How to test the changes in this Pull Request:

1. Translate our plugin using WPML String translation.
2. Translate slugs for my account endpoints and links.
3. In frontend check whether or not everything is working properly or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Slug translation issue on my account links.
