### PR TITLE
Fix - Error handling when wp_insert_user throws error.

### DIFF
--- a/includes/frontend/class-ur-frontend-form-handler.php
+++ b/includes/frontend/class-ur-frontend-form-handler.php
@@ -120,6 +120,19 @@ class UR_Frontend_Form_Handler {
 
 			$user_id = wp_insert_user( $userdata ); // Insert user data in users table.
 
+			if ( is_wp_error( $user_id ) ) {
+				$err_msg = "";
+				foreach ( $user_id->errors as $error ) {
+					$err_msg .= "<p>" . $error[0] . "</p>";
+				}
+
+				wp_send_json_error(
+					array(
+						'message' => sprintf( __( '%s', 'user-registration' ), $err_msg ),
+					)
+				);
+			}
+
 			$filtered_form_data = apply_filters( 'user_registration_before_user_meta_update', self::$valid_form_data, $user_id, $form_id );
 
 			self::ur_update_user_meta( $user_id, $filtered_form_data, $form_id ); // Insert user data in usermeta table.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

wp_insert_user threw error object when default fields validation from wordpress was not met. This PR fixes this issue.

### How to test the changes in this Pull Request:

1. Drag user_url (website) field.
2. While submitting form, insert more than 100 characters in website field.
3. Please see whether error handling works properly or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Error handling when wp_insert_user throws error.
