### PR TITLE
Fix - Email content mismatch on Verified Email

### DIFF
--- a/includes/class-ur-preview.php
+++ b/includes/class-ur-preview.php
@@ -184,8 +184,6 @@ class UR_Preview {
 		remove_filter( 'the_content', array( $this, 'form_preview_content' ) );
 
 		wp_enqueue_script( 'ur-my-account' );
-		do_action( 'user_registration_my_account_enqueue_scripts', array(), 0 );
-
 		$recaptcha_enabled = ur_option_checked( 'user_registration_login_options_enable_recaptcha', false );
 		$recaptcha_node    = ur_get_recaptcha_node( 'login', $recaptcha_enabled );
 
@@ -239,7 +237,11 @@ class UR_Preview {
 			if ( 'passwordless_login_email' === $option_name ) {
 				$email_content = get_option( 'user_registration_' . $option_name . '_content', $class_instance->$default_content() );
 			} else {
-				$email_content = get_option( 'user_registration_' . $option_name, $class_instance->$default_content() );
+				if ( "email_verified_admin_email" === $option_name ) {
+					$email_content = get_option( 'user_registration_pro_' . $option_name, $class_instance->$default_content() );
+				} else {
+					$email_content = get_option( 'user_registration_' . $option_name, $class_instance->$default_content() );
+				}
 			}
 			/**
 			 * Filter to process the smart tags.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?


### Changes proposed in this Pull Request:

This PR fixes the issue for admin email mismatch on User Email verified.

### How to test the changes in this Pull Request:

1. Put login option on Admin Approval after Email Confirmation
2. Register a user and verify the email.
3. Check if admin email is sent according to the Email in User Registration Settings > Emails section. (Change the email and verify)
4. Also check on email preview section.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Email content mismatch on Verified Email
