### PR TITLE
Fix - Email template for reset password from the admin dashboard.

### DIFF
--- a/includes/class-ur-emailer.php
+++ b/includes/class-ur-emailer.php
@@ -54,7 +54,7 @@ class UR_Emailer {
 		global $pagenow;
 
 		// adds the hook if it is for reset password.
-		if ( ( is_admin() && 'users.php' === $pagenow ) || ( is_admin() && 'resetpassword' === isset( $_GET['action'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ( is_admin() && 'users.php' === $pagenow ) || ( is_admin() && isset( $_GET['action'] ) && 'resetpassword' === $_GET['action'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			add_filter( 'retrieve_password_message', array( __CLASS__, 'ur_retrieve_password_message' ), 20, 4 );
 			add_filter( 'retrieve_password_title', array( __CLASS__, 'ur_retrieve_password_title' ), 20, 3 );
 			add_filter( 'wp_mail_content_type', array( __CLASS__, 'ur_get_content_type' ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Previously, in our User registration email template was not working for the password rest email while sending the email from Admin Dashboard from that specific user's detail page.

Closes # .

### How to test the changes in this Pull Request:

1. Register a user from our form and select the email template for that form.
2. Now Go to User Registration > Users > View any user
3. Click on the Send Password Reset Email from the leftmost menu of the User's Detail Page
4. Finally, verify whether the password reset email is send or not accordingly with the expected email template and email contents.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Email template for reset password from the admin dashboard.
