### PR TITLE
Fix - File size upload in the edit profile according to server size.

### DIFF
--- a/templates/myaccount/form-edit-profile.php
+++ b/templates/myaccount/form-edit-profile.php
@@ -128,7 +128,7 @@ if ( 'vertical' === $layout ) {
 								?>
 									<img class="profile-preview" alt="profile-picture" src="<?php echo esc_url( $image ); ?>" style='max-width:96px; max-height:96px;' >
 
-									<p class="user-registration-tips"><?php echo esc_html__( 'Max size: ', 'user-registration' ) . esc_attr( size_format( $max_upload_size * 1024 ) ); ?></p>
+									<p class="user-registration-tips"><?php echo esc_html__( 'Max size: ', 'user-registration' ) . esc_attr( size_format( $max_upload_size ) ); ?></p>
 									</div>
 									<header>
 										<p><strong>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
Previously, In our User registration profile edit page the size of profile picture upload was the server file upload size multiplied by 1024. This PR fixes this profile picture upload size message in the edit profile page

Closes # .

### How to test the changes in this Pull Request:

1. Go to the Edit profile Page and check the max capacity for the profile picture.
2. Check whether the size is according to the server size or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - File size upload in the edit profile according to server size.