### PR TITLE
Fix - Strpos deprecated warning.

### DIFF
--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -8062,20 +8062,22 @@ if ( ! function_exists( 'ur_find_my_account_in_custom_template' ) ) {
 
 		$content = ur_file_get_contents( $template_path );
 
-		if ( strpos( $content, '[user_registration_my_account' ) !== false ) {
-			return true;
-		}
-		if ( strpos( $content, '[user_registration_login' ) !== false ) {
-			return true;
-		}
-		if ( strpos( $content, '[woocommerce_my_account' ) !== false ) {
-			return true;
-		}
-		if ( strpos( $content, '<!-- wp:user-registration/myaccount' ) !== false ) {
-			return true;
-		}
-		if ( strpos( $content, '<!-- wp:user-registration/login' ) !== false ) {
-			return true;
+		if ( ! empty( $content ) ) {
+			if ( strpos( $content, '[user_registration_my_account' ) !== false ) {
+				return true;
+			}
+			if ( strpos( $content, '[user_registration_login' ) !== false ) {
+				return true;
+			}
+			if ( strpos( $content, '[woocommerce_my_account' ) !== false ) {
+				return true;
+			}
+			if ( strpos( $content, '<!-- wp:user-registration/myaccount' ) !== false ) {
+				return true;
+			}
+			if ( strpos( $content, '<!-- wp:user-registration/login' ) !== false ) {
+				return true;
+			}
 		}
 
 		return $value;

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -8062,22 +8062,24 @@ if ( ! function_exists( 'ur_find_my_account_in_custom_template' ) ) {
 
 		$content = ur_file_get_contents( $template_path );
 
-		if ( ! empty( $content ) ) {
-			if ( strpos( $content, '[user_registration_my_account' ) !== false ) {
-				return true;
-			}
-			if ( strpos( $content, '[user_registration_login' ) !== false ) {
-				return true;
-			}
-			if ( strpos( $content, '[woocommerce_my_account' ) !== false ) {
-				return true;
-			}
-			if ( strpos( $content, '<!-- wp:user-registration/myaccount' ) !== false ) {
-				return true;
-			}
-			if ( strpos( $content, '<!-- wp:user-registration/login' ) !== false ) {
-				return true;
-			}
+		if ( empty( $content ) || !is_string( $content ) ) {
+			return $value;
+		}
+
+		if ( strpos( $content, '[user_registration_my_account' ) !== false ) {
+			return true;
+		}
+		if ( strpos( $content, '[user_registration_login' ) !== false ) {
+			return true;
+		}
+		if ( strpos( $content, '[woocommerce_my_account' ) !== false ) {
+			return true;
+		}
+		if ( strpos( $content, '<!-- wp:user-registration/myaccount' ) !== false ) {
+			return true;
+		}
+		if ( strpos( $content, '<!-- wp:user-registration/login' ) !== false ) {
+			return true;
 		}
 
 		return $value;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
This PR fixes the issue of having the null value passed in the strpos deprecated.

Closes # .

### How to test the changes in this Pull Request:

1. Go to other pages except the Login, My Account or Woocommerce Page and it might replicate with PHP version PHP 8.1.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Strpos deprecated warning.
