### PR TITLE
Fix - Error message styling not changing from style customizer.

### DIFF
--- a/assets/css/user-registration.scss
+++ b/assets/css/user-registration.scss
@@ -150,10 +150,10 @@
 }
 
 .user-registration-error {
-	border-top-color: $red !important;
-	background: rgba($red, 0.1) !important;
-	color: darken($red, 15%) !important;
-	
+	border-top-color: $red;
+	background: rgba($red, 0.1);
+	color: darken($red, 15%);
+
 	&::before {
 		content: "\f534";
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously, while customizing the error message styling from the Style customizer it was not reflecting on the frontent while was working fine in the preview. This PR fixes this issue.

Closes # .

### How to test the changes in this Pull Request:

1. Go to User registration > Settings > Login Forms and click on the Paint brush
2. After that, it will be redirected to the Customizer.
3. Go to Messages > Enable the Show Error Message
4. Now check whether it is working accordingly or not.

[Style customizer PR dependency](https://github.com/wpeverest/user-registration-style-customizer/pull/15)
### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Error message styling not changing from style customizer.
