### PR TITLE
Enhance - Option to select lost password page.

### DIFF
--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -714,6 +714,27 @@ jQuery(function ($) {
 			});
 	});
 
+	/**
+	 * Enables disables the lost password page
+	 *
+	 */
+	$(document).ready(function() {
+		function ur_enable_lost_password_page() {
+			if ($('#user_registration_login_options_lost_password').prop('checked')) {
+				$('#user_registration_general_setting_lost_password_page').closest('.user-registration-login-form-global-settings').show();
+			} else {
+				$('#user_registration_general_setting_lost_password_page').closest('.user-registration-login-form-global-settings').hide();
+			}
+		}
+
+		ur_enable_lost_password_page();
+
+		$('#user_registration_login_options_lost_password').on('change click', function() {
+			ur_enable_lost_password_page();
+		});
+	});
+
+
 	$(document).on(
 		"click",
 		'.ur-tab-lists li[role="tab"] a.nav-tab',

--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -721,9 +721,9 @@ jQuery(function ($) {
 	$(document).ready(function() {
 		function ur_enable_lost_password_page() {
 			if ($('#user_registration_login_options_lost_password').prop('checked')) {
-				$('#user_registration_general_setting_lost_password_page').closest('.user-registration-login-form-global-settings').show();
+				$('#user_registration_lost_password_page_id').closest('.user-registration-login-form-global-settings').show();
 			} else {
-				$('#user_registration_general_setting_lost_password_page').closest('.user-registration-login-form-global-settings').hide();
+				$('#user_registration_lost_password_page_id').closest('.user-registration-login-form-global-settings').hide();
 			}
 		}
 

--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -1,4 +1,4 @@
-/* global user_registration_settings_params */
+/* global user_registration_settings_params, ur_login_form_params */
 (function ($) {
 	// Allowed Screens
 	$("select#user_registration_allowed_screens")
@@ -681,6 +681,9 @@
 						.closest("form")
 						.find("input[name='save']")
 						.prop("disabled", false);
+						$this
+						.closest(".user-registration-global-settings").$find('.error inline')
+						.remove();
 				}
 				$this.prop("disabled", false);
 
@@ -691,6 +694,49 @@
 			}
 		});
 	});
+
+	// Display error when page with our lost password shortcode is not selected.
+	$("#user_registration_lost_password_page_id").on("change", function () {
+		var $this = $(this),
+			data = {
+				action: "user_registration_lost_password_selection_validator",
+				security: ur_login_form_params.user_registration_lost_password_selection_validator_nonce
+			};
+
+		data.user_registration_selected_lost_password_page = $this.val();
+
+		$this.prop("disabled", true);
+		$this.css("border", "1px solid #e1e1e1");
+
+		$this.closest(".user-registration-global-settings--field").find(".error.inline").remove();
+
+		$.ajax({
+			url: ur_login_form_params.ajax_url,
+			data: data,
+			type: "POST",
+			complete: function (response) {
+				if (response.responseJSON.success === false) {
+					if ($this.closest(".user-registration-login-form-global-settings").find(".error.inline").length === 0) {
+						$this.closest(".user-registration-login-form-global-settings").append(
+							"<div id='message' class='error inline' style='padding:10px;'>" +
+							response.responseJSON.data.message +
+							"</div>"
+						);
+					}
+					$this.css("border", "1px solid red");
+					var login_form = $this.closest('.user-registration-login-form-container');
+					$(login_form).closest('#wpbody-content').find('#ur-lists-page-topnav').find('button[name="save_login_form"]').prop("disabled", true);
+				} else {
+					var login_form = $this.closest('.user-registration-login-form-container');
+					$(login_form).closest('#wpbody-content').find('#ur-lists-page-topnav').find('button[name="save_login_form"]').prop("disabled", false);
+					$this.closest(".user-registration-login-form-global-settings").find(".error.inline").remove();
+				}
+
+				$this.prop("disabled", false);
+			}
+		});
+	});
+
 
 	// Set localStorage with expiry
 	function setStorageValue(key, value) {

--- a/includes/admin/class-ur-admin-menus.php
+++ b/includes/admin/class-ur-admin-menus.php
@@ -663,6 +663,7 @@ if ( ! class_exists( 'UR_Admin_Menus', false ) ) :
 						'i18n_success'                     => _x( 'Success', 'user registration admin', 'user-registration' ),
 						'i18n_error'                       => _x( 'Error', 'user registration admin', 'user-registration' ),
 					),
+					'user_registration_lost_password_selection_validator_nonce' => wp_create_nonce( 'user_registration_lost_password_selection_validator' ),
 				);
 				wp_localize_script(
 					'user-registration-login-settings',

--- a/includes/admin/class-ur-admin-settings.php
+++ b/includes/admin/class-ur-admin-settings.php
@@ -215,6 +215,7 @@ class UR_Admin_Settings {
 				'user_registration_search_global_settings_nonce' => wp_create_nonce( 'user_registration_search_global_settings' ),
 				'user_registration_captcha_test_nonce' => wp_create_nonce( 'user_registration_captcha_test_nonce' ),
 				'user_registration_my_account_selection_validator_nonce' => wp_create_nonce( 'user_registration_my_account_selection_validator' ),
+				'user_registration_lost_password_selection_validator_nonce' => wp_create_nonce( 'user_registration_lost_password_selection_validator' ),
 				'user_registration_membership_pages_selection_validator_nonce' => wp_create_nonce( 'user_registration_validate_page_none' ),
 				'i18n_nav_warning'                     => esc_html__( 'The changes you made will be lost if you navigate away from this page.', 'user-registration' ),
 				'i18n'                                 => array(

--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -49,36 +49,37 @@ class UR_AJAX {
 	 */
 	public static function add_ajax_events() {
 		$ajax_events = array(
-			'user_input_dropped'             => true,
-			'user_form_submit'               => true,
-			'update_profile_details'         => true,
-			'profile_pic_upload'             => true,
-			'ajax_login_submit'              => true,
-			'send_test_email'                => false,
-			'create_form'                    => false,
-			'rated'                          => false,
-			'dashboard_widget'               => false,
-			'dismiss_notice'                 => false,
-			'import_form_action'             => false,
-			'template_licence_check'         => false,
-			'captcha_setup_check'            => false,
-			'install_extension'              => false,
-			'profile_pic_remove'             => false,
-			'form_save_action'               => false,
-			'login_settings_save_action'     => false,
-			'embed_form_action'              => false,
-			'embed_page_list'                => false,
-			'allow_usage_dismiss'            => false,
-			'cancel_email_change'            => false,
-			'email_setting_status'           => false,
-			'locked_form_fields_notice'      => false,
-			'search_global_settings'         => false,
-			'php_notice_dismiss'             => false,
-			'locate_form_action'             => false,
-			'form_preview_save'              => false,
-			'captcha_test'                   => false,
-			'generate_row_settings'          => false,
-			'my_account_selection_validator' => false,
+			'user_input_dropped'                => true,
+			'user_form_submit'                  => true,
+			'update_profile_details'            => true,
+			'profile_pic_upload'                => true,
+			'ajax_login_submit'                 => true,
+			'send_test_email'                   => false,
+			'create_form'                       => false,
+			'rated'                             => false,
+			'dashboard_widget'                  => false,
+			'dismiss_notice'                    => false,
+			'import_form_action'                => false,
+			'template_licence_check'            => false,
+			'captcha_setup_check'               => false,
+			'install_extension'                 => false,
+			'profile_pic_remove'                => false,
+			'form_save_action'                  => false,
+			'login_settings_save_action'        => false,
+			'embed_form_action'                 => false,
+			'embed_page_list'                   => false,
+			'allow_usage_dismiss'               => false,
+			'cancel_email_change'               => false,
+			'email_setting_status'              => false,
+			'locked_form_fields_notice'         => false,
+			'search_global_settings'            => false,
+			'php_notice_dismiss'                => false,
+			'locate_form_action'                => false,
+			'form_preview_save'                 => false,
+			'captcha_test'                      => false,
+			'generate_row_settings'             => false,
+			'my_account_selection_validator'    => false,
+			'lost_password_selection_validator' => false,
 		);
 
 		foreach ( $ajax_events as $ajax_event => $nopriv ) {
@@ -1878,6 +1879,38 @@ class UR_AJAX {
 						array(
 							'message' => esc_html__(
 								'The selected page is not a User Registration & Membership Login or My Account page.',
+								'user-registration'
+							),
+						)
+					);
+				}
+			}
+		}
+
+		wp_send_json_success();
+	}
+
+	/**
+	 * AJAX validate selected lost password page.
+	 */
+	public static function lost_password_selection_validator() {
+		check_ajax_referer( 'user_registration_lost_password_selection_validator', 'security' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'You do not have permission to edit settings form.', 'user-registration' ) ) );
+			wp_die( -1 );
+		}
+
+		// Return if default wp_login is disabled and no redirect url is set.
+		if ( isset( $_POST['user_registration_selected_lost_password_page'] ) ) {
+			if ( is_numeric( $_POST['user_registration_selected_lost_password_page'] ) ) {
+				$is_page_lost_password_page = ur_find_lost_password_in_page( sanitize_text_field( wp_unslash( $_POST['user_registration_selected_lost_password_page'] ) ) );
+
+				if ( ! $is_page_lost_password_page ) {
+					wp_send_json_error(
+						array(
+							'message' => esc_html__(
+								'The selected page is not a User Registration & Membership Lost Password page.',
 								'user-registration'
 							),
 						)

--- a/includes/functions-ur-account.php
+++ b/includes/functions-ur-account.php
@@ -80,9 +80,10 @@ function ur_lostpassword_url( $default_url = '' ) {
 		return $default_url;
 	}
 
-	$lost_password_page = get_option( 'user_registration_lost_password_page_id', false );
+	$lost_password_page     = get_option( 'user_registration_lost_password_page_id', false );
+	$lost_password_page_url = get_option( 'user_registration_general_setting_lost_password_page', '' );
 
-	if ( $lost_password_page ) {
+	if ( $lost_password_page && ! empty( $lost_password_page ) ) {
 		return get_permalink( $lost_password_page );
 	} else {
 
@@ -90,6 +91,7 @@ function ur_lostpassword_url( $default_url = '' ) {
 
 		$ur_account_page_exists = ur_get_page_id( 'myaccount' ) > 0;
 		$lost_password_endpoint = get_option( 'user_registration_myaccount_lost_password_endpoint', 'lost-password' );
+		$lost_password_page     = get_option( 'user_registration_general_setting_lost_password_page', '' );
 
 		$ur_login_page_exists = ur_get_page_id( 'login' ) > 0;
 
@@ -97,7 +99,11 @@ function ur_lostpassword_url( $default_url = '' ) {
 			update_option( 'user_registration_login_page_id', ur_get_page_id( 'login' ) );
 		}
 
-		if ( $ur_account_page_exists && ! empty( $lost_password_endpoint ) ) {
+		$selected_lost_password_page = get_permalink( $lost_password_page_url );
+
+		if ( $ur_account_page_exists && ! empty( $lost_password_endpoint ) && ! empty( $lost_password_page_url ) ) {
+			return get_permalink( $lost_password_page_url );
+		} elseif ( $ur_account_page_exists && ! empty( $lost_password_endpoint ) ) {
 			return ur_get_endpoint_url( $lost_password_endpoint, '', $ur_account_page_url );
 		} elseif ( $ur_login_page_exists && ! empty( $lost_password_endpoint ) ) {
 			return ur_get_endpoint_url( $lost_password_endpoint, '', get_permalink( ur_get_page_id( 'login' ) ) );

--- a/includes/functions-ur-account.php
+++ b/includes/functions-ur-account.php
@@ -80,13 +80,11 @@ function ur_lostpassword_url( $default_url = '' ) {
 		return $default_url;
 	}
 
-	$lost_password_page     = get_option( 'user_registration_lost_password_page_id', false );
-	$lost_password_page_url = get_option( 'user_registration_general_setting_lost_password_page', '' );
+	$lost_password_page = get_option( 'user_registration_lost_password_page_id', false );
 
-	if ( $lost_password_page && ! empty( $lost_password_page ) ) {
+	if ( $lost_password_page && ! empty( get_post( $lost_password_page ) ) ) {
 		return get_permalink( $lost_password_page );
 	} else {
-
 		$ur_account_page_url = ur_get_page_permalink( 'myaccount' );
 
 		$ur_account_page_exists = ur_get_page_id( 'myaccount' ) > 0;
@@ -99,11 +97,7 @@ function ur_lostpassword_url( $default_url = '' ) {
 			update_option( 'user_registration_login_page_id', ur_get_page_id( 'login' ) );
 		}
 
-		$selected_lost_password_page = get_permalink( $lost_password_page_url );
-
-		if ( $ur_account_page_exists && ! empty( $lost_password_endpoint ) && ! empty( $lost_password_page_url ) ) {
-			return get_permalink( $lost_password_page_url );
-		} elseif ( $ur_account_page_exists && ! empty( $lost_password_endpoint ) ) {
+		if ( $ur_account_page_exists && ! empty( $lost_password_endpoint ) ) {
 			return ur_get_endpoint_url( $lost_password_endpoint, '', $ur_account_page_url );
 		} elseif ( $ur_login_page_exists && ! empty( $lost_password_endpoint ) ) {
 			return ur_get_endpoint_url( $lost_password_endpoint, '', get_permalink( ur_get_page_id( 'login' ) ) );

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -132,35 +132,6 @@ if ( ! function_exists( 'is_ur_lost_password_page' ) ) {
 	}
 }
 
-if ( ! function_exists( 'ur_pages_selection_options' ) ) {
-
-	/**
-	 * Get pages for selection options.
-	 *
-	 * @since xx.xx.xx
-	 *
-	 * @return array List of pages with ID as the key and title as the value.
-	 */
-	function ur_pages_selection_options() {
-		$pages     = get_pages();
-		$page_list = array();
-
-		foreach ( $pages as $page ) {
-			$page_list[ $page->ID ] = $page->post_title;
-		}
-
-		/**
-		 * Filter to modify the settings selection pages.
-		 *
-		 * @since xx.xx.xx
-		 *
-		 * @return array $page_list List of pages.
-		 */
-		return apply_filters( 'user_registration_settings_page_selection_options', $page_list );
-	}
-}
-
-
 /**
  * Clean variables using sanitize_text_field. Arrays are cleaned recursively.
  * Non-scalar values are ignored.
@@ -7362,15 +7333,14 @@ if ( ! function_exists( 'get_login_options_settings' ) ) {
 								'default'  => 'yes',
 							),
 							array(
-								'title'    => __( 'Select the Lost password page', 'user-registration' ),
-								'desc'     => __( 'Select the lost password page with the shortcode [user_registration_lost_password]', 'user-registration' ),
-								'id'       => 'user_registration_general_setting_lost_password_page',
-								'default'  => 'default',
-								'type'     => 'select',
-								'class'    => 'ur-enhanced-select',
-								'css'      => 'min-width: 350px;',
+								'title'    => __( 'Lost Password Page', 'user-registration' ),
+								'desc'     => sprintf( __( 'Select the page which contains your login form: [%s]', 'user-registration' ), apply_filters( 'user_registration_lost_password_shortcode_tag', 'user_registration_lost_password' ) ), //phpcs:ignore
+								'id'       => 'user_registration_lost_password_page_id',
+								'type'     => 'single_select_page',
+								'default'  => '',
+								'class'    => 'ur-enhanced-select-nostd',
+								'css'      => 'min-width:350px;',
 								'desc_tip' => true,
-								'options'  => ur_pages_selection_options(),
 							),
 							array(
 								'title'    => __( 'Hide Field Labels', 'user-registration' ),

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -132,6 +132,35 @@ if ( ! function_exists( 'is_ur_lost_password_page' ) ) {
 	}
 }
 
+if ( ! function_exists( 'ur_pages_selection_options' ) ) {
+
+	/**
+	 * Get pages for selection options.
+	 *
+	 * @since xx.xx.xx
+	 *
+	 * @return array List of pages with ID as the key and title as the value.
+	 */
+	function ur_pages_selection_options() {
+		$pages     = get_pages();
+		$page_list = array();
+
+		foreach ( $pages as $page ) {
+			$page_list[ $page->ID ] = $page->post_title;
+		}
+
+		/**
+		 * Filter to modify the settings selection pages.
+		 *
+		 * @since xx.xx.xx
+		 *
+		 * @return array $page_list List of pages.
+		 */
+		return apply_filters( 'user_registration_settings_page_selection_options', $page_list );
+	}
+}
+
+
 /**
  * Clean variables using sanitize_text_field. Arrays are cleaned recursively.
  * Non-scalar values are ignored.
@@ -7332,7 +7361,17 @@ if ( ! function_exists( 'get_login_options_settings' ) ) {
 								'css'      => 'min-width: 350px;',
 								'default'  => 'yes',
 							),
-
+							array(
+								'title'    => __( 'Select the Lost password page', 'user-registration' ),
+								'desc'     => __( 'Select the lost password page with the shortcode [user_registration_lost_password]', 'user-registration' ),
+								'id'       => 'user_registration_general_setting_lost_password_page',
+								'default'  => 'default',
+								'type'     => 'select',
+								'class'    => 'ur-enhanced-select',
+								'css'      => 'min-width: 350px;',
+								'desc_tip' => true,
+								'options'  => ur_pages_selection_options(),
+							),
 							array(
 								'title'    => __( 'Hide Field Labels', 'user-registration' ),
 								'desc'     => '',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds the option to select the lost password page  from the login options settings.

Closes # .

### How to test the changes in this Pull Request:

1. Create a Lost Password page using [user_registration_lost_password] shortcode.
2. Go to URM > Login Form
3. Click on **General > Enable Lost Password >  Select the Lost Password page from the dropdown**
4. Click on the **Update Form**
5. Check this in the backward compatibility and in the woocommerce whether the **Lost Password Page** is working or not.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhance - Option to select lost password page.
