### PR TITLE
Fix - Validation on the disabling default WordPress page setting.

### DIFF
--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -439,15 +439,46 @@
 	$(".ur-redirect-to-login-page").ready(function () {
 		var $url = $(".ur-redirect-to-login-page"),
 			$check = $("#user_registration_login_options_prevent_core_login"),
-			$redirect = $(
-				"#user_registration_login_options_login_redirect_url"
-			);
+			$redirect = $("#user_registration_login_options_login_redirect_url");
 
 		if (!$check.prop("checked")) {
 			$url.val("").closest(".single_select_page").css("display", "none");
 		} else {
+			var $selected_page = $check.closest('.ur-login-form-setting-block').find('.ur-redirect-to-login-page').val();
+			var login_form_settings = $check.closest('.user-registration-login-form-container');
+			var wpbody_class = $(login_form_settings).closest('#wpbody-content');
+
+			if ('' === $selected_page) {
+				$(wpbody_class).find('#ur-lists-page-topnav').find('.ur_save_login_form_action_button').prop('disabled', true);
+				$check.closest('.ur-login-form-setting-block')
+					.find('.ur-redirect-to-login-page')
+					.closest('.user-registration-login-form-global-settings--field')
+					.append('<div class="error inline" style="padding:10px;">' + ur_login_form_params.user_registration_membership_redirect_default_page_message + '</div>');
+			} else {
+				$(wpbody_class).find('#ur-lists-page-topnav').find('.ur_save_login_form_action_button').prop('disabled', false);
+				$check.closest('.ur-login-form-setting-block')
+					.find('.ur-redirect-to-login-page')
+					.closest('.user-registration-login-form-global-settings--field')
+					.find('.error.inline').remove();
+			}
+
 			$redirect.prop("required", true);
 		}
+
+		// Handling the "clear" button click event for Select2.
+		$('select[name="user_registration_login_options_login_redirect_url"]').on('select2:unselect', function() {
+			var $selected_page = $check.closest('.ur-login-form-setting-block').find('.ur-redirect-to-login-page').val();
+			var login_form_settings = $check.closest('.user-registration-login-form-container');
+			var wpbody_class = $(login_form_settings).closest('#wpbody-content');
+
+			$(wpbody_class).find('#ur-lists-page-topnav').find('.ur_save_login_form_action_button').prop('disabled', true);
+			$check.closest('.ur-login-form-setting-block')
+				.find('.ur-redirect-to-login-page')
+				.closest('.user-registration-login-form-global-settings--field')
+				.append('<div class="error inline" style="padding:10px;">' + ur_login_form_params.user_registration_membership_redirect_default_page_message + '</div>');
+
+			$redirect.prop("required", true);
+		});
 	});
 
 	$("#user_registration_login_options_prevent_core_login").on(
@@ -464,6 +495,22 @@
 			);
 		}
 	);
+
+	// Checks whether the page is selected or not while changing the select value.
+	$('select[name="user_registration_login_options_login_redirect_url"]').on('change', function(){
+		var selected_page = $(this).val();
+		var login_form_settings = $(this).closest('.user-registration-login-form-container');
+		var wpbody_class = $(login_form_settings).closest('#wpbody-content');
+
+		if ('' !== selected_page) {
+			$(wpbody_class).find('#ur-lists-page-topnav').find('.ur_save_login_form_action_button').prop('disabled', false);
+			$(this).closest('.ur-login-form-setting-block')
+				.find('.ur-redirect-to-login-page')
+				.closest('.user-registration-login-form-global-settings--field')
+				.find('.error.inline').remove();
+		}
+	});
+
 	// Display the sync profile picture settings when the disable profile picture is checked and advanced fields is active.
 	$("#user_registration_disable_profile_picture").on("change", function () {
 		var is_advanced_fields_active = parseInt(

--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -485,6 +485,33 @@
 		"change",
 		function () {
 			var $url = $("#user_registration_login_options_prevent_core_login");
+			var login_form_settings = $url.closest('.user-registration-login-form-container');
+			var wpbody_class = $(login_form_settings).closest('#wpbody-content');
+			var selected_page = $this.closest('.ur-login-form-setting-block').find('.ur-redirect-to-login-page').val();
+
+			if ($(this).is(':checked')) {
+				if ('' === selected_page) {
+					$(wpbody_class).find('#ur-lists-page-topnav').find('.ur_save_login_form_action_button').prop('disabled', true);
+					$this.closest('.ur-login-form-setting-block')
+						.find('.ur-redirect-to-login-page')
+						.closest('.user-registration-login-form-global-settings--field')
+						.append('<div class="error inline" style="padding:10px;">' + ur_login_form_params.user_registration_membership_redirect_default_page_message + '</div>');
+				} else {
+					$(wpbody_class).find('#ur-lists-page-topnav').find('.ur_save_login_form_action_button').prop('disabled', false);
+					$this.closest('.ur-login-form-setting-block')
+						.find('.ur-redirect-to-login-page')
+						.closest('.user-registration-login-form-global-settings--field')
+						.find('.error.inline').remove();
+				}
+			} else {
+				$(wpbody_class).find('#ur-lists-page-topnav').find('.ur_save_login_form_action_button').prop('disabled', false);
+					$this.closest('.ur-login-form-setting-block')
+						.find('.ur-redirect-to-login-page')
+						.closest('.user-registration-login-form-global-settings--field')
+						.find('.error.inline').remove();
+			}
+
+
 
 			$(".single_select_page").toggle();
 			$("#user_registration_login_options_login_redirect_url").prop(

--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -439,79 +439,21 @@
 	$(".ur-redirect-to-login-page").ready(function () {
 		var $url = $(".ur-redirect-to-login-page"),
 			$check = $("#user_registration_login_options_prevent_core_login"),
-			$redirect = $("#user_registration_login_options_login_redirect_url");
+			$redirect = $(
+				"#user_registration_login_options_login_redirect_url"
+			);
 
 		if (!$check.prop("checked")) {
 			$url.val("").closest(".single_select_page").css("display", "none");
 		} else {
-			var $selected_page = $check.closest('.ur-login-form-setting-block').find('.ur-redirect-to-login-page').val();
-			var login_form_settings = $check.closest('.user-registration-login-form-container');
-			var wpbody_class = $(login_form_settings).closest('#wpbody-content');
-
-			if ('' === $selected_page) {
-				$(wpbody_class).find('#ur-lists-page-topnav').find('.ur_save_login_form_action_button').prop('disabled', true);
-				$check.closest('.ur-login-form-setting-block')
-					.find('.ur-redirect-to-login-page')
-					.closest('.user-registration-login-form-global-settings--field')
-					.append('<div class="error inline" style="padding:10px;">' + ur_login_form_params.user_registration_membership_redirect_default_page_message + '</div>');
-			} else {
-				$(wpbody_class).find('#ur-lists-page-topnav').find('.ur_save_login_form_action_button').prop('disabled', false);
-				$check.closest('.ur-login-form-setting-block')
-					.find('.ur-redirect-to-login-page')
-					.closest('.user-registration-login-form-global-settings--field')
-					.find('.error.inline').remove();
-			}
-
 			$redirect.prop("required", true);
 		}
-
-		// Handling the "clear" button click event for Select2.
-		$('select[name="user_registration_login_options_login_redirect_url"]').on('select2:unselect', function() {
-			var $selected_page = $check.closest('.ur-login-form-setting-block').find('.ur-redirect-to-login-page').val();
-			var login_form_settings = $check.closest('.user-registration-login-form-container');
-			var wpbody_class = $(login_form_settings).closest('#wpbody-content');
-
-			$(wpbody_class).find('#ur-lists-page-topnav').find('.ur_save_login_form_action_button').prop('disabled', true);
-			$check.closest('.ur-login-form-setting-block')
-				.find('.ur-redirect-to-login-page')
-				.closest('.user-registration-login-form-global-settings--field')
-				.append('<div class="error inline" style="padding:10px;">' + ur_login_form_params.user_registration_membership_redirect_default_page_message + '</div>');
-
-			$redirect.prop("required", true);
-		});
 	});
 
 	$("#user_registration_login_options_prevent_core_login").on(
 		"change",
 		function () {
 			var $url = $("#user_registration_login_options_prevent_core_login");
-			var login_form_settings = $url.closest('.user-registration-login-form-container');
-			var wpbody_class = $(login_form_settings).closest('#wpbody-content');
-			var selected_page = $this.closest('.ur-login-form-setting-block').find('.ur-redirect-to-login-page').val();
-
-			if ($(this).is(':checked')) {
-				if ('' === selected_page) {
-					$(wpbody_class).find('#ur-lists-page-topnav').find('.ur_save_login_form_action_button').prop('disabled', true);
-					$this.closest('.ur-login-form-setting-block')
-						.find('.ur-redirect-to-login-page')
-						.closest('.user-registration-login-form-global-settings--field')
-						.append('<div class="error inline" style="padding:10px;">' + ur_login_form_params.user_registration_membership_redirect_default_page_message + '</div>');
-				} else {
-					$(wpbody_class).find('#ur-lists-page-topnav').find('.ur_save_login_form_action_button').prop('disabled', false);
-					$this.closest('.ur-login-form-setting-block')
-						.find('.ur-redirect-to-login-page')
-						.closest('.user-registration-login-form-global-settings--field')
-						.find('.error.inline').remove();
-				}
-			} else {
-				$(wpbody_class).find('#ur-lists-page-topnav').find('.ur_save_login_form_action_button').prop('disabled', false);
-					$this.closest('.ur-login-form-setting-block')
-						.find('.ur-redirect-to-login-page')
-						.closest('.user-registration-login-form-global-settings--field')
-						.find('.error.inline').remove();
-			}
-
-
 
 			$(".single_select_page").toggle();
 			$("#user_registration_login_options_login_redirect_url").prop(
@@ -522,22 +464,6 @@
 			);
 		}
 	);
-
-	// Checks whether the page is selected or not while changing the select value.
-	$('select[name="user_registration_login_options_login_redirect_url"]').on('change', function(){
-		var selected_page = $(this).val();
-		var login_form_settings = $(this).closest('.user-registration-login-form-container');
-		var wpbody_class = $(login_form_settings).closest('#wpbody-content');
-
-		if ('' !== selected_page) {
-			$(wpbody_class).find('#ur-lists-page-topnav').find('.ur_save_login_form_action_button').prop('disabled', false);
-			$(this).closest('.ur-login-form-setting-block')
-				.find('.ur-redirect-to-login-page')
-				.closest('.user-registration-login-form-global-settings--field')
-				.find('.error.inline').remove();
-		}
-	});
-
 	// Display the sync profile picture settings when the disable profile picture is checked and advanced fields is active.
 	$("#user_registration_disable_profile_picture").on("change", function () {
 		var is_advanced_fields_active = parseInt(

--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -442,12 +442,39 @@
 			$redirect = $(
 				"#user_registration_login_options_login_redirect_url"
 			);
-
 		if (!$check.prop("checked")) {
 			$url.val("").closest(".single_select_page").css("display", "none");
 		} else {
+			var $selected_page = $check.closest('.ur-login-form-setting-block').find('.ur-redirect-to-login-page').val();
+			var login_form_settings = $check.closest('.user-registration-login-form-container');
+			var wpbody_class = $(login_form_settings).closest('#wpbody-content');
+
+			if ('' === $selected_page) {
+				$check.closest('.ur-login-form-setting-block')
+					.find('.ur-redirect-to-login-page')
+					.closest('.user-registration-login-form-global-settings--field')
+					.append('<div class="error inline" style="padding:10px;">' + ur_login_form_params.user_registration_membership_redirect_default_page_message + '</div>');
+			} else {
+				$(wpbody_class).find('#ur-lists-page-topnav').find('.ur_save_login_form_action_button').prop('disabled', false);
+				$check.closest('.ur-login-form-setting-block')
+					.find('.ur-redirect-to-login-page')
+					.closest('.user-registration-login-form-global-settings--field')
+					.find('.error.inline').remove();
+			}
+
 			$redirect.prop("required", true);
 		}
+
+		// Handling the "clear" button click event for Select2.
+		$('select[name="user_registration_login_options_login_redirect_url"]').on('select2:unselect', function() {
+
+			$check.closest('.ur-login-form-setting-block')
+				.find('.ur-redirect-to-login-page')
+				.closest('.user-registration-login-form-global-settings--field')
+				.append('<div class="error inline" style="padding:10px;">' + ur_login_form_params.user_registration_membership_redirect_default_page_message + '</div>');
+
+			$redirect.prop("required", true);
+		});
 	});
 
 	$("#user_registration_login_options_prevent_core_login").on(

--- a/includes/admin/class-ur-admin-menus.php
+++ b/includes/admin/class-ur-admin-menus.php
@@ -664,6 +664,7 @@ if ( ! class_exists( 'UR_Admin_Menus', false ) ) :
 						'i18n_error'                       => _x( 'Error', 'user registration admin', 'user-registration' ),
 					),
 					'user_registration_lost_password_selection_validator_nonce' => wp_create_nonce( 'user_registration_lost_password_selection_validator' ),
+					'user_registration_membership_redirect_default_page_message' => esc_html__( 'Please select a page for redirection', 'user-registration' ),
 				);
 				wp_localize_script(
 					'user-registration-login-settings',

--- a/includes/admin/class-ur-admin-menus.php
+++ b/includes/admin/class-ur-admin-menus.php
@@ -664,7 +664,6 @@ if ( ! class_exists( 'UR_Admin_Menus', false ) ) :
 						'i18n_error'                       => _x( 'Error', 'user registration admin', 'user-registration' ),
 					),
 					'user_registration_lost_password_selection_validator_nonce' => wp_create_nonce( 'user_registration_lost_password_selection_validator' ),
-					'user_registration_membership_redirect_default_page_message' => esc_html__( 'Please select a page for redirection', 'user-registration' ),
 				);
 				wp_localize_script(
 					'user-registration-login-settings',

--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -1015,7 +1015,8 @@ class UR_AJAX {
 		}
 
 		if ( ur_string_to_bool( $output['user_registration_login_options_prevent_core_login'] ) ) {
-			if ( is_numeric( $output['user_registration_login_options_login_redirect_url'] ) ) {
+
+			if ( ( is_numeric( $output['user_registration_login_options_login_redirect_url'] ) ) && ! empty( $output['user_registration_login_options_login_redirect_url'] ) ) {
 				$is_page_my_account_page = ur_find_my_account_in_page( sanitize_text_field( wp_unslash( $output['user_registration_login_options_login_redirect_url'] ) ) );
 				if ( ! $is_page_my_account_page ) {
 					wp_send_json_error(
@@ -1027,6 +1028,15 @@ class UR_AJAX {
 						)
 					);
 				}
+			} else {
+				wp_send_json_error(
+					array(
+						'message' => esc_html__(
+							'Please select a login redirection page.',
+							'user-registration'
+						),
+					)
+				);
 			}
 		}
 
@@ -1070,8 +1080,8 @@ class UR_AJAX {
 		$page_id = empty( $_POST['page_id'] ) ? 0 : sanitize_text_field( absint( $_POST['page_id'] ) );
 		$form_id = ! empty( $_POST['form_id'] ) ? absint( $_POST['form_id'] ) : 0;
 		if ( empty( $page_id ) ) {
-			$url  = add_query_arg( 'post_type', 'page', admin_url( 'post-new.php' ) );
-			$meta = array(
+			$url             = add_query_arg( 'post_type', 'page', admin_url( 'post-new.php' ) );
+			$meta            = array(
 				'embed_page'       => 0,
 				'embed_page_title' => ! empty( $_POST['page_title'] ) ? sanitize_text_field( wp_unslash( $_POST['page_title'] ) ) : '',
 			);
@@ -1087,15 +1097,17 @@ class UR_AJAX {
 			wp_send_json_success( $page_url );
 		} else {
 			UR_Admin_Embed_Wizard::delete_meta();
-			$url  = get_edit_post_link( $page_id, '' );
-			$post = get_post($page_id);
-			$pattern = '[user_registration_form id="%d"]';
-			$shortcode = sprintf( $pattern, absint( $form_id ) );
+			$url             = get_edit_post_link( $page_id, '' );
+			$post            = get_post( $page_id );
+			$pattern         = '[user_registration_form id="%d"]';
+			$shortcode       = sprintf( $pattern, absint( $form_id ) );
 			$updated_content = $post->post_content . "\n\n" . $shortcode;
-			wp_update_post([
-				'ID'           => $page_id,
-				'post_content' => $updated_content,
-			]);
+			wp_update_post(
+				array(
+					'ID'           => $page_id,
+					'post_content' => $updated_content,
+				)
+			);
 			wp_send_json_success( $url );
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes the issue while no page is selected on enabling the **Disable Default WordPress Login Screen**

Closes # .

### How to test the changes in this Pull Request:

1. Go to URM > Settings > Login Forms > General > Enable **Disable Default WordPress Login Screen**
2. Do not select the page from the **Redirect Default WordPress login To** dropdown.
3. And check whether the validation message is shown or not.
4. Also check whether it is allowing to save the setting while not selecting any page.


### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Validation on the disabling default WordPress page setting.