### PR TITLE
Fix- Row settings conditional logic not working on profile edit.

### DIFF
--- a/templates/myaccount/form-edit-profile.php
+++ b/templates/myaccount/form-edit-profile.php
@@ -221,7 +221,7 @@ if ( 'vertical' === $layout ) {
 								}
 
 								ob_start();
-								echo '<div class="ur-form-row">';
+								echo '<div class="ur-form-row" data-row-id=' . $row_id . ' ' . $row_cl_props . '>';
 								user_registration_edit_profile_row_template( $data, $profile );
 								echo '</div>';
 								$row_template = ob_get_clean();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
Previously, while using row conditional logic setting, it was not working accordingly on the Profile page. This PR fixes the conditional logic issue.

Closes # .

### How to test the changes in this Pull Request:

1. Enable the Conditional logic addon.
2. Use the row setting conditional logic and perform the entry.
3. Now login as the recent entries user and check if the conditional logic is working accordingly or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix- Row settings conditional logic not working on profile edit.
