### PR TITLE
Fix - Lambda expression not supported in php version less than 7 4.

### DIFF
--- a/includes/admin/class-ur-admin-export-users.php
+++ b/includes/admin/class-ur-admin-export-users.php
@@ -313,12 +313,22 @@ class UR_Admin_Export_Users {
 					if ( isset( $profile[ $profile_key ]['default'] ) ) {
 						$default_value = $profile[ $profile_key ]['default'];
 
-						// Handle array values properly.
-						if ( is_array( $default_value ) ) {
-							$default_value = implode( ', ', array_filter( $default_value, fn( $v ) => ! empty( $v ) ) );
-						} else {
-							$default_value = esc_html( $default_value );
-						}
+					// Handle array values properly.
+					if ( is_array( $default_value ) ) {
+						// Filter out empty values and join the remaining values into a string.
+						$default_value = implode(
+							', ',
+							array_filter(
+								$default_value,
+								function ( $v ) {
+									return ! empty( $v );
+								}
+							)
+						);
+					} else {
+						// If it's not an array, sanitize the value.
+						$default_value = esc_html( $default_value );
+					}
 
 						// Only set non-empty default values.
 						if ( ! empty( $default_value ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The lambda expression was not supported by the PHP version less than 7.4. There was use of one in the export setting. This PR makes it compatible with PHP less than 7.4.

Closes # .

### How to test the changes in this Pull Request:

1. Use the PHP version 7.4
2. Check the export entries setting.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Lambda expression not supported in php version less than 7 4.
