### PR TITLE
UR 2264 Security - Vulnurability fix for auto_login after registration.

### DIFF
--- a/includes/frontend/class-ur-frontend-form-handler.php
+++ b/includes/frontend/class-ur-frontend-form-handler.php
@@ -298,6 +298,10 @@ class UR_Frontend_Form_Handler {
 		$current_language = ur_get_current_language();
 		$current_language = isset( $_POST['registration_language'] ) ? ur_clean( $_POST['registration_language'] ) : $current_language; //phpcs:ignore.
 		update_user_meta( $user_id, 'ur_registered_language', $current_language );
+		$login_option   = ur_get_user_login_option( $user_id );
+		if("auto_login" === $login_option) {
+			update_user_meta( $user_id, 'urm_user_just_created', 'yes' );
+		}
 	}
 }
 

--- a/modules/membership/includes/AJAX.php
+++ b/modules/membership/includes/AJAX.php
@@ -110,9 +110,9 @@ class AJAX {
 		$membership_service      = new MembershipService();
 		$response                = $membership_service->create_membership_order_and_subscription( $data );
 		$member_id               = $response['member_id'];
-		$transaction_id          = $response['transaction_id'] ?? 0;
+		$transaction_id          = isset($response['transaction_id']) ? $response['transaction_id'] : 0;
 		$data['member_id']       = $member_id;
-		$data['subscription_id'] = $response['subscription_id'] ?? 0;
+		$data['subscription_id'] = isset($response['subscription_id']) ? $response['subscription_id'] : 0;
 		$data['email']           = $response['member_email'];
 
 		$pg_data = array();
@@ -152,7 +152,7 @@ class AJAX {
 			}
 			wp_send_json_success( $response );
 		} else {
-			$message = $response['message'] ?? esc_html__( 'Sorry! There was an unexpected error while registering the user . ', 'user-registration' );
+			$message = isset($response['message']) ? $response['message'] : esc_html__( 'Sorry! There was an unexpected error while registering the user . ', 'user-registration' );
 			wp_send_json_error(
 				array(
 					'message' => $message,
@@ -515,7 +515,7 @@ class AJAX {
 				)
 			);
 		} else {
-			$message = $response['message'] ?? esc_html__( 'Sorry! There was an unexpected error while saving the members data . ', 'user-registration' );
+			$message = isset($response['message']) ? $response['message'] : esc_html__( 'Sorry! There was an unexpected error while saving the members data . ', 'user-registration' );
 			wp_send_json_error(
 				array(
 					'message' => $message,
@@ -583,7 +583,7 @@ class AJAX {
 				if ( ! $logged_in ) {
 					wp_send_json_error(
 						array(
-							'message' => $update_stripe_order["message"] ?? __( "Something went wrong when updating users payment status" )
+							'message' => isset($update_stripe_order["message"]) ? $update_stripe_order["message"] :  __( "Something went wrong when updating users payment status" )
 						),
 						500
 					);
@@ -597,7 +597,7 @@ class AJAX {
 		}
 		wp_send_json_error(
 			array(
-				'message' => $update_stripe_order["message"] ?? __( "Something went wrong when updating users payment status" )
+				'message' => isset($update_stripe_order["message"]) ? $update_stripe_order["message"] : __( "Something went wrong when updating users payment status" )
 			),
 			500
 		);
@@ -619,7 +619,7 @@ class AJAX {
 			wp_delete_user( absint( $member_id ) );
 			wp_send_json_error(
 				array(
-					'message' => $message ?? __( "Something went wrong when updating users payment status" )
+					'message' => __( "Something went wrong when updating users payment status" )
 				)
 			);
 		}
@@ -658,7 +658,7 @@ class AJAX {
 				)
 			);
 		} else {
-			$message = $cancel_status['message'] ?? esc_html__( 'Something went wrong while cancelling your subscription. Please contact support', 'user-registration' );
+			$message = isset($cancel_status['message']) ? $cancel_status['message'] : esc_html__( 'Something went wrong while cancelling your subscription. Please contact support', 'user-registration' );
 			wp_send_json_error(
 				array(
 					'message' => $message,

--- a/modules/membership/includes/Admin/Services/MembersService.php
+++ b/modules/membership/includes/Admin/Services/MembersService.php
@@ -106,8 +106,8 @@ class MembersService {
 	public function prepare_members_data( $data ) {
 		$membership_details = $this->membership_repository->get_single_membership_by_ID( absint( $data['membership'] ) );
 		$membership_meta    = json_decode( $membership_details['meta_value'], true );
-		$role      = isset( $membership_meta['role'] ) ? $membership_meta['role'] : 'subscriber';
-		
+		$role               = isset( $membership_meta['role'] ) ? $membership_meta['role'] : 'subscriber';
+
 
 		$coupon_details = array();
 		if ( isset( $data['coupon'] ) && ! empty( $data['coupon'] ) && ur_check_module_activation( 'coupon' ) ) {
@@ -115,13 +115,13 @@ class MembersService {
 		}
 
 		$user_data = array(
-			'user_login'    => !empty( $data['username']) ? sanitize_text_field( $data['username'] ) : '',
-			'user_email'    => !empty($data['email']) ?  sanitize_email( $data['email'] ) : '',
-			'user_pass'     => !empty($data['password']) ? $data['password'] : '',
-			'user_nicename' => (!empty($data['firstname']) && !empty($data['lastname'])) ? sanitize_text_field( $data['firstname'] ) . ' ' . sanitize_text_field( $data['lastname'] ) : '',
-			'display_name'  => !empty($data['username']) ? sanitize_text_field( $data['username'] ) : '',
-			'first_name'    => !empty($data['firstname']) ? sanitize_text_field( $data['firstname'] ) : '',
-			'last_name'     => !empty($data['lastname']) ? sanitize_text_field( $data['lastname'] ) : '',
+			'user_login'    => ! empty( $data['username'] ) ? sanitize_text_field( $data['username'] ) : '',
+			'user_email'    => ! empty( $data['email'] ) ? sanitize_email( $data['email'] ) : '',
+			'user_pass'     => ! empty( $data['password'] ) ? $data['password'] : '',
+			'user_nicename' => ( ! empty( $data['firstname'] ) && ! empty( $data['lastname'] ) ) ? sanitize_text_field( $data['firstname'] ) . ' ' . sanitize_text_field( $data['lastname'] ) : '',
+			'display_name'  => ! empty( $data['username'] ) ? sanitize_text_field( $data['username'] ) : '',
+			'first_name'    => ! empty( $data['firstname'] ) ? sanitize_text_field( $data['firstname'] ) : '',
+			'last_name'     => ! empty( $data['lastname'] ) ? sanitize_text_field( $data['lastname'] ) : '',
 			'user_status'   => isset( $data['member_status'] ) ? absint( $data['member_status'] ) : 1,
 		);
 
@@ -157,12 +157,25 @@ class MembersService {
 	 *
 	 * @param $user_id
 	 *
-	 * @return void
+	 * @return bool
 	 */
-	public function login_member( $user_id ) {
-		wp_clear_auth_cookie();
-		$remember = apply_filters( 'user_registration_autologin_remember_user', false );
-		wp_set_auth_cookie( $user_id, $remember );
+	public function login_member( $user_id, $check_just_created ) {
+		$is_just_created = 'no';
+		if ( $check_just_created ) {
+			$is_just_created = get_user_meta( $user_id, 'urm_user_just_created', true );
+		}
+
+		if ( "yes" === $is_just_created ) {
+			delete_user_meta( $user_id, 'urm_user_just_created');
+			wp_clear_auth_cookie();
+			$remember = apply_filters( 'user_registration_autologin_remember_user', false );
+			wp_set_auth_cookie( $user_id, $remember );
+
+			return true;
+		} else {
+			return false;
+		}
+
 	}
 
 }

--- a/modules/membership/includes/Admin/Services/Paypal/PaypalService.php
+++ b/modules/membership/includes/Admin/Services/Paypal/PaypalService.php
@@ -171,7 +171,7 @@ class PaypalService {
 		$login_option = ur_get_user_login_option( $member_id );
 		if ( "auto_login" === $login_option ) {
 			$member_service = new MembersService();
-			$member_service->login_member( $member_id );
+			$member_service->login_member( $member_id , true);
 		}
 		ur_membership_redirect_to_thank_you_page( $member_id, $member_order );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The vulnerability reported is an authentication bypass which we consider to be a high risk due to unauthenticated users being able to login as any users (including admin) by providing the user ID. We confirmed the issue in the current version, 4.1.1.
This fix fixes the issue by adding a user_meta `urm_user_just_created`  when creating the user and checking it  during the ajax request. The meta gets deleted after the check is completed.
<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Refer to [this comment](https://themegrill.atlassian.net/browse/UR-2264?focusedCommentId=26028) to recreate this issue. 

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Security - Vulnurability fix for auto_login after registration.