### PR TITLE
UR-2211 Fix - Remove unnecessary lost your password link from error message

### DIFF
--- a/includes/functions-ur-account.php
+++ b/includes/functions-ur-account.php
@@ -12,7 +12,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-add_filter( 'login_errors', 'ur_login_error_message' );
 add_filter( 'get_avatar', 'ur_replace_gravatar_image', 99, 6 );
 add_filter( 'ajax_query_attachments_args', 'ur_show_current_user_attachments' );
 
@@ -33,32 +32,6 @@ function ur_show_current_user_attachments( $query ) {
 	}
 
 	return $query;
-}
-
-/**
- * Modify error message on invalid username or password.
- *
- * @param string $error Error Message.
- */
-function ur_login_error_message( $error ) {
-	// Don't change login error messages on admin site .
-	if ( isset( $_POST['redirect_to'] ) && false !== strpos( wp_unslash( $_POST['redirect_to'] ), network_admin_url() ) ) {  // phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		return $error;
-	}
-
-	$pos  = strpos( $error, 'incorrect' );     // Check if the error contains incorrect string.
-	$pos2 = strpos( $error, 'Invalid' );       // Check if the error contains Invalid string.
-
-	// Its the correct username with incorrect password.
-	if ( is_int( $pos ) && isset( $_POST['username'] ) ) {  // phpcs:ignore WordPress.Security.NonceVerification
-		/* translators: %s - Username */
-		$error = sprintf( '<strong>' . __( 'ERROR:', 'user-registration' ) . '</strong>' . __( 'The password you entered for username %1$1s is incorrect. %2$2s', 'user-registration' ), sanitize_text_field( wp_unslash( $_POST['username'] ) ), "<a href='" . esc_url( wp_lostpassword_url() ) . "'>" . __( 'Lost Your Password?', 'user-registration' ) . '</a>' ); // phpcs:ignore WordPress.Security.NonceVerification
-	} elseif ( is_int( $pos2 ) && isset( $_POST['username'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-		/* translators: %s - Lost password URL */
-		$error = sprintf( '<strong>' . __( 'ERROR:', 'user-registration' ) . '</strong>' . __( 'Invalid username. %1s', 'user-registration' ), "<a href='" . esc_url( wp_lostpassword_url() ) . "'>" . __( 'Lost Your Password?', 'user-registration' ) . '</a>' ); // phpcs:ignore WordPress.Security.NonceVerification
-	}
-
-	return $error;
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #

### How to test the changes in this Pull Request:

1. Go to URM > All Form > Login
2. Add a custom message for invalid username "Invalid username"
3. Go to login page, try logging in with non existing username, the error doesn't show the lost your password?

Before Fix:
![before_fix](https://github.com/user-attachments/assets/df0369ad-3bbe-471f-b213-78074de3009a)
After Fix:
![afterfix](https://github.com/user-attachments/assets/235f18e1-49e9-4504-b66a-d070da189d7d)

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fix - Remove lost your password link from login error messages
