### PR TITLE
UR-2277  Bug - Auto enable Payment history when enabling payment addons.

### DIFF
--- a/assets/extensions-json/all-features.json
+++ b/assets/extensions-json/all-features.json
@@ -27,7 +27,7 @@
       ],
       "setting_url": "admin.php?page=member-payment-history",
       "demo_video_url": "DuWX7i7eYsY",
-      "activation_requirements": [ "membership", "pro" ]
+      "activation_requirements": [ "membership", "pro" , "stripe" , "authorize-net" , "payments" ]
     },
     {
       "title": "PayPal Payment",

--- a/includes/RestApi/controllers/version1/class-ur-modules.php
+++ b/includes/RestApi/controllers/version1/class-ur-modules.php
@@ -294,15 +294,15 @@ class UR_Modules {
 		$enabled_features = get_option( 'user_registration_enabled_features', array() );
 
 		if ( 'user-registration-membership' === $slug ) {
-			if ( ! get_option( 'user_registration_membership_installed_flag', false ) ) {
 				array_push( $enabled_features, 'user-registration-payment-history' );
 				array_push( $enabled_features, 'user-registration-content-restriction' );
+			if ( ! get_option( 'user_registration_membership_installed_flag', false ) ) {
 				ur_membership_install_required_pages();
 				\WPEverest\URMembership\Admin\Database\Database::create_tables();
 			}
 		}
 
-		if ( 'user-registration-payments' === $slug && !in_array('user-registration-payment-history', $enabled_features)) {
+		if (  in_array($slug , ['user-registration-payments', 'user-registration-stripe', 'user-registration-authorize-net']) && !in_array('user-registration-payment-history', $enabled_features)) {
 			$enabled_features[] = 'user-registration-payment-history';
 		}
 		array_push( $enabled_features, $slug );

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,8 @@
         "url-loader": "^4.1.1",
         "webpack": "^5.94.0",
         "webpack-cli": "^4.10.0",
-        "webpack-dev-server": "^4.7.2"
+        "webpack-dev-server": "^4.7.2",
+        "webpackbar": "^7.0.0"
       },
       "engines": {
         "node": ">=8.9.3",
@@ -9333,6 +9334,15 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/ansis": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.17.0.tgz",
+      "integrity": "sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -11397,6 +11407,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
       }
     },
     "node_modules/console-browserify": {
@@ -23060,6 +23079,15 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/pretty-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-time/-/pretty-time-1.1.0.tgz",
+      "integrity": "sha512-28iF6xPQrP8Oa6uxE6a1biz+lWeTOAPKggvjB8HAs6nVMKZwf5bG++632Dx614hIWgUPkgivRfG+a8uAXGTIbA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -26008,6 +26036,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/std-env": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.1.tgz",
+      "integrity": "sha512-vj5lIj3Mwf9D79hBkltk5qmkFI+biIKWS2IBxEyEU3AX1tUf7AoL8nSazCOiiqQsGKIq01SClsKEzweu34uwvA==",
+      "dev": true
+    },
     "node_modules/stdout-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
@@ -28586,6 +28620,33 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/webpackbar": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webpackbar/-/webpackbar-7.0.0.tgz",
+      "integrity": "sha512-aS9soqSO2iCHgqHoCrj4LbfGQUboDCYJPSFOAchEK+9psIjNrfSWW4Y0YEz67MKURNvMmfo0ycOg9d/+OOf9/Q==",
+      "dev": true,
+      "dependencies": {
+        "ansis": "^3.2.0",
+        "consola": "^3.2.3",
+        "pretty-time": "^1.1.0",
+        "std-env": "^3.7.0"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "@rspack/core": "*",
+        "webpack": "3 || 4 || 5"
+      },
+      "peerDependenciesMeta": {
+        "@rspack/core": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
       }
     },
     "node_modules/websocket-driver": {
@@ -35796,6 +35857,12 @@
         "color-convert": "^2.0.1"
       }
     },
+    "ansis": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.17.0.tgz",
+      "integrity": "sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==",
+      "dev": true
+    },
     "anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -37365,6 +37432,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
       "integrity": "sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==",
+      "dev": true
+    },
+    "consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
       "dev": true
     },
     "console-browserify": {
@@ -46053,6 +46126,12 @@
         }
       }
     },
+    "pretty-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-time/-/pretty-time-1.1.0.tgz",
+      "integrity": "sha512-28iF6xPQrP8Oa6uxE6a1biz+lWeTOAPKggvjB8HAs6nVMKZwf5bG++632Dx614hIWgUPkgivRfG+a8uAXGTIbA==",
+      "dev": true
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -48301,6 +48380,12 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "dev": true
     },
+    "std-env": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.1.tgz",
+      "integrity": "sha512-vj5lIj3Mwf9D79hBkltk5qmkFI+biIKWS2IBxEyEU3AX1tUf7AoL8nSazCOiiqQsGKIq01SClsKEzweu34uwvA==",
+      "dev": true
+    },
     "stdout-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
@@ -50209,6 +50294,18 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
       "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w=="
+    },
+    "webpackbar": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webpackbar/-/webpackbar-7.0.0.tgz",
+      "integrity": "sha512-aS9soqSO2iCHgqHoCrj4LbfGQUboDCYJPSFOAchEK+9psIjNrfSWW4Y0YEz67MKURNvMmfo0ycOg9d/+OOf9/Q==",
+      "dev": true,
+      "requires": {
+        "ansis": "^3.2.0",
+        "consola": "^3.2.3",
+        "pretty-time": "^1.1.0",
+        "std-env": "^3.7.0"
+      }
     },
     "websocket-driver": {
       "version": "0.7.4",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "url-loader": "^4.1.1",
     "webpack": "^5.94.0",
     "webpack-cli": "^4.10.0",
-    "webpack-dev-server": "^4.7.2"
+    "webpack-dev-server": "^4.7.2",
+    "webpackbar": "^7.0.0"
   },
   "engines": {
     "node": ">=8.9.3",

--- a/src/context/dashboardContext.js
+++ b/src/context/dashboardContext.js
@@ -8,7 +8,8 @@ export const initialState = {
 		moduleName: "",
 	},
 	allModules: [],
-	isMembershipActivated: false
+	isMembershipActivated: false,
+	isPaymentAddonActivated: false,
 };
 
 export const actionTypes = {
@@ -16,7 +17,8 @@ export const actionTypes = {
 	GET_THEMES_STATUS: "GET_THEMES_STATUS",
 	GET_UPGRADE_MODAL: "GET_UPGRADE_MODAL",
 	GET_ALL_MODULES: "GET_ALL_MODULES",
-	GET_IS_MEMBERSHIP_ACTIVATED: "GET_IS_MEMBERSHIP_ACTIVATED"
+	GET_IS_MEMBERSHIP_ACTIVATED: "GET_IS_MEMBERSHIP_ACTIVATED",
+	GET_IS_PAYMENT_ADDON_ACTIVATED: "GET_IS_PAYMENT_ADDON_ACTIVATED",
 };
 
 const reducer = (state, action) => {
@@ -45,6 +47,11 @@ const reducer = (state, action) => {
 			return {
 				...state,
 				isMembershipActivated: action.isMembershipActivated
+			};
+		case actionTypes.GET_IS_PAYMENT_ADDON_ACTIVATED:
+			return {
+				...state,
+				isPaymentAddonActivated: action.isPaymentAddonActivated
 			};
 		default:
 			return state;

--- a/src/dashboard/screens/Modules/Modules.js
+++ b/src/dashboard/screens/Modules/Modules.js
@@ -36,7 +36,7 @@ import ModuleBody from "./components/ModuleBody";
 
 const Modules = () => {
 	const toast = useToast();
-	const [{ allModules }, dispatch] = useStateValue();
+	const [{ allModules , isMembershipActivated , isPaymentAddonActivated }, dispatch] = useStateValue();
 	const [state, setState] = useState({
 		modules: [],
 		originalModules: [],
@@ -80,6 +80,9 @@ const Modules = () => {
 		filterModules(state.originalModules, tabIndex);
 	}, [tabIndex]);
 
+	useEffect(() => {
+		fetchModules();
+	}, [isMembershipActivated, isPaymentAddonActivated]);
 	// Filter Modules by Tabs
 	const filterModules = (modules, index) => {
 		let filtered = modules;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
 const isProd = process.env.NODE_ENV === "production";
+const WebpackBar = require("webpackbar");
 
 module.exports = (env, argv) => {
 	return {
@@ -80,7 +81,10 @@ module.exports = (env, argv) => {
 						}
 					}
 				]
-			})
+			}),
+			new WebpackBar({
+				/* options */
+			}),
 		],
 		externals: {
 			"@wordpress/blocks": ["wp", "blocks"],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously when activating Paypal module, the payment history module used to activate but the toggle did not auto enable this PR fixes the issue along with few minor bugs.

Closes # .

### How to test the changes in this Pull Request:

1. Checkout to this branch in pro > enable PayPal from Dashboard > Features
2. See if the payment history module activates too (Also check with stripe and authorize.net)

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry
Bug - Auto enable Payment history when enabling payment
