### PR TITLE
UR-2281 Enhance - Scroll to top on category selection on form template page

### DIFF
--- a/src/form-templates/components/Main.js
+++ b/src/form-templates/components/Main.js
@@ -77,6 +77,9 @@ const Main = ({ filter }) => {
 	}, [selectedCategory, searchTerm, templates, filter]);
 
 	const handleCategorySelect = useCallback((category) => {
+		if (typeof window !== "undefined") {
+			window.scrollTo(0, 0);
+		}
 		setState((prevState) => ({ ...prevState, selectedCategory: category }));
 	}, []);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Previously, when the user selects a new category template in URM Dashboard Templates Page, the scrollbar remains at the previous state. In this PR, the scroll bar is moved to top on category selection each time it changes. 
### How to test the changes in this Pull Request:

1. Go to URM Dashboard > Create a Registration Form
2. Select a category from Template
3. Notice, the scrollbar is moved to top.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?


### Changelog entry
Enhance - Scrollbar move to top on category selection on form template page