### PR TITLE
UR-2339 : Updated regex for USA zip code validation

### DIFF
--- a/includes/class-ur-smart-tags.php
+++ b/includes/class-ur-smart-tags.php
@@ -655,7 +655,7 @@ class UR_Smart_Tags {
 				'^[a-zA-Z0-9-]+$'                                                                            => __( 'Slug', 'user-registration' ),
 				'(0[0-9]|1[0-9]|2[0-3])(:[0-5][0-9]){2}'                                                     => __( 'Time (hh:mm:ss)', 'user-registration' ),
 				'^(https?|ftp):\/\/[^\s\/$.?#].[^\s]*$'                                                      => __( 'URL', 'user-registration' ),
-				'(\d{5}([\-]\d{4})?)'                                                                        => __( 'Zip Code', 'user-registration' ),
+				'^\d{5}(-\d{4})?$'                                                                        => __( 'Zip Code', 'user-registration' ),
 			)
 		);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### Closes
USA Zip code validation fixed for 5 and 9 digit code

### How to test the changes in this Pull Request:

1. Apply Pattern validation from advanced fields
2. 5 digit and 9 digit zip code is now validated (xxxxx and xxxxx-xxxx)

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
