### PR TITLE
Fix - Textarea validation and character count message typo error.

### DIFF
--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -368,7 +368,7 @@ if ( ! function_exists( 'user_registration_form_field' ) ) {
 			case 'textarea':
 				$field .= '<textarea style="margin-bottom:0px;" data-rules="' . esc_attr( $rules ) . '" data-id="' . esc_attr( $key ) . '" name="' . esc_attr( $key ) . '" class="input-text ' . esc_attr( implode( ' ', $args['input_class'] ) ) . '" id="' . esc_attr( $args['id'] ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '" ' . ( empty( $args['custom_attributes']['rows'] ) ? ' rows="2"' : '' ) . ( empty( $args['custom_attributes']['cols'] ) ? ' cols="5"' : '' ) . implode( ' ', $custom_attributes ) . '>' . esc_textarea( $value ) . '</textarea>';
 				$field .= '<div style="text-align: right; font-size:14px; color:#737373; margin-top:0px;"> <div class="ur-input-count" data-count-type="' . ( isset( $args['max-words'] ) ? 'words' : 'characters' ) . '" style="display: inline-block; margin-right: 1px;">0</div>';
-				$field .= '<div style="display: inline-block;">' . ( isset( $args['max-words'] ) ? '/' . $args['max-words'] . ' ' . __('words', 'user-registration') : ( isset( $args['max-characters'] ) ? '/' . $args['max-characters'] . ' '. __('characters'. 'user-registration') : ' ' . __('characters', 'user-registration') ) );
+				$field .= '<div style="display: inline-block;">' . ( isset( $args['max-words'] ) ? '/' . $args['max-words'] . ' ' . __( 'words', 'user-registration' ) : ( isset( $args['max-characters'] ) ? '/' . $args['max-characters'] . ' ' . __( 'characters', 'user-registration' ) : ' ' . __( 'characters', 'user-registration' ) ) );
 				$field .= '</div></div>';
 				break;
 

--- a/includes/validation/class-ur-validation.php
+++ b/includes/validation/class-ur-validation.php
@@ -141,7 +141,7 @@ class UR_Validation {
 	 * @return boolean or WP_Error.
 	 */
 	public static function validate_length( $value, $size ) {
-		if ( strlen( $value ) > $size ) {
+		if ( mb_strlen( $value ) > $size ) {
 			return new WP_Error(
 				'user_registration_validation_max_size_exceeded',
 				/* translators: %d - Size */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

There was the typo error while the validation was made for the textarea with max character count and even-though the max character count and the textarea character was error the error message was showing. This PR fixes this issue.

Closes # .

### How to test the changes in this Pull Request:

1. Drag and drop the text area field, add the validation of the max count.
2. Now check the frontend of the form whether the character count is adding the additional test user-registration or not
3. Enter exactly 1000 characters suppose you have made the max count 1000 and check whether the validation message is shown or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Textarea validation and character count message typo error.
