### PR TITLE
UR-2375 Fix - Username smart-tag shows logged in user's username in form preview.

### DIFF
--- a/includes/class-ur-smart-tags.php
+++ b/includes/class-ur-smart-tags.php
@@ -212,7 +212,7 @@ class UR_Smart_Tags {
 					case 'username':
 						if ( is_user_logged_in() ) {
 							$user = wp_get_current_user();
-							$name = sanitize_text_field( $user->user_login );
+							$name = isset( $values['username'] ) ? $values['username'] : sanitize_text_field( $user->user_login );
 						} else {
 							$name = isset( $values['username'] ) ? $values['username'] : '';
 						}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #.
Previously when registering from preview the username smarttag used to show logged in user's username this PR fixes that issue.
### How to test the changes in this Pull Request:

1. Preview a form logged in as admin
2. Fill in the form and verify if the email show correct username.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Username smart-tag shows logged in user's username in form preview.
