### PR TITLE
Fix - Conflict with Botiga theme.

### DIFF
--- a/assets/js/frontend/user-registration.js
+++ b/assets/js/frontend/user-registration.js
@@ -2904,3 +2904,11 @@ function customPasswordChecks(password) {
 	}
 	return 4;
 }
+
+//Shows the content restriction message if botiga theme is used.
+jQuery(document).ready(function($) {
+	var urcrContentRestrictMsg = $document.find('.urcr-restrict-msg');
+	if (urcrContentRestrictMsg.length > 0) {
+		urcrContentRestrictMsg.first().css('display', 'block');
+	}
+});

--- a/modules/content-restriction/class-urcr-frontend.php
+++ b/modules/content-restriction/class-urcr-frontend.php
@@ -1156,7 +1156,16 @@ class URCR_Frontend {
 
 		$message = apply_filters( 'user_registration_process_smart_tags', $message );
 
-		return '<span class="urcr-restrict-msg">' . $message . '</span>';
+		$active_theme = wp_get_theme();
+
+		$active_theme = wp_get_theme();
+
+		if ( isset( $active_theme ) && 'Botiga' === $active_theme->get( 'Name' ) ) {
+			return '<span class="urcr-restrict-msg" style="display:none">' . $message . '</span>';
+		} else {
+			return '<span class="urcr-restrict-msg">' . $message . '</span>';
+		}
+
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The content restriction message was displayed multiple times while using the Botiga theme. This PR fixes this issue.

Closes # .

### How to test the changes in this Pull Request:

1. Enable content restriction module and add content restriction for specific page
2. Install and activate Botiga theme.
3. Now go to the content restricted page and check how many times the restriction message is displayed.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Conflict with Botiga theme.
