### PR TITLE
Fix - Password label not changing dynamically in Login form setting.

### DIFF
--- a/assets/js/admin/login-settings.js
+++ b/assets/js/admin/login-settings.js
@@ -505,7 +505,7 @@
 				);
 
 			form.find(
-				".user-registration-form-row[data-field='password'] label"
+				".user-registration-form-row label[for='password']"
 			).html(value + '<span class="required">*</span>');
 		});
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The password label was not changing dynamically in Login Form Settings. This PR fixes this issue.

Closes # .

### How to test the changes in this Pull Request:

1. Go to URM > Global Settings > Login Options > Labels
2. Change the Label for Password field and check whether is it changing dynamically or not in the corresponding login form.
3. Click on Update Form Button.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Password label not changing dynamically in Login form setting.