### PR TITLE
Fix - Email settings not display while translating site.

### DIFF
--- a/includes/admin/settings/emails/class-ur-settings-admin-email.php
+++ b/includes/admin/settings/emails/class-ur-settings-admin-email.php
@@ -51,7 +51,7 @@ if ( ! class_exists( 'UR_Settings_Admin_Email', false ) ) :
 			$this->id          = 'admin_email';
 			$this->title       = __( 'New Member Registered', 'user-registration' );
 			$this->description = __( 'Notify admins about a new membership signup, including member details.', 'user-registration' );
-			$this->receiver    = __( 'Admin', 'user-registration' );
+			$this->receiver    = 'Admin';
 		}
 
 		/**

--- a/includes/admin/settings/emails/class-ur-settings-approval-link-email.php
+++ b/includes/admin/settings/emails/class-ur-settings-approval-link-email.php
@@ -51,7 +51,7 @@ if ( ! class_exists( 'UR_Settings_Approval_Link_Email', false ) ) :
 			$this->id          = 'approval_link_email';
 			$this->title       = __( 'Admin Approval Request', 'user-registration' );
 			$this->description = __( 'Requests admin approval for a user registration approval, with a direct link to approve or deny.', 'user-registration' );
-			$this->receiver    = __( 'Admin', 'user-registration' );
+			$this->receiver    = 'Admin';
 		}
 
 		/**

--- a/includes/admin/settings/emails/class-ur-settings-awaiting-admin-approval-email.php
+++ b/includes/admin/settings/emails/class-ur-settings-awaiting-admin-approval-email.php
@@ -51,7 +51,7 @@ if ( ! class_exists( 'UR_Settings_Awaiting_Admin_Approval_Email', false ) ) :
 			$this->id          = 'awaiting_admin_approval_email';
 			$this->title       = __( 'Awaiting Admin Approval', 'user-registration' );
 			$this->description = __( 'Lets the user know their registration is pending and they must wait for admin approval.', 'user-registration' );
-			$this->receiver    = __( 'User', 'user-registration' );
+			$this->receiver    = 'User';
 		}
 
 		/**

--- a/includes/admin/settings/emails/class-ur-settings-confirm-email-address-change-email.php
+++ b/includes/admin/settings/emails/class-ur-settings-confirm-email-address-change-email.php
@@ -51,7 +51,7 @@ if ( ! class_exists( 'UR_Settings_Confirm_Email_Address_Change_Email', false ) )
 			$this->id          = 'confirm_email_address_change_email';
 			$this->title       = __( 'Email Address Change Confirmation', 'user-registration' );
 			$this->description = __( 'Asks the user to verify a newly requested email address change with a confirmation link.', 'user-registration' );
-			$this->receiver    = __( 'User', 'user-registration' );
+			$this->receiver    = 'User';
 		}
 
 		/**

--- a/includes/admin/settings/emails/class-ur-settings-email-confirmation.php
+++ b/includes/admin/settings/emails/class-ur-settings-email-confirmation.php
@@ -51,7 +51,7 @@ if ( ! class_exists( 'UR_Settings_Email_Confirmation', false ) ) :
 			$this->id          = 'email_confirmation';
 			$this->title       = __( 'Email Address Confirmation', 'user-registration' );
 			$this->description = __( 'Requests the user to confirm their email address by clicking a verification link.', 'user-registration' );
-			$this->receiver    = __( 'User', 'user-registration' );
+			$this->receiver    = 'User';
 		}
 
 		/**

--- a/includes/admin/settings/emails/class-ur-settings-payment-success-admin-email.php
+++ b/includes/admin/settings/emails/class-ur-settings-payment-success-admin-email.php
@@ -53,7 +53,7 @@ if ( ! class_exists( 'UR_Settings_Payment_Success_Admin_Email', false ) ) :
 			$this->id          = 'payment_success_admin_email';
 			$this->title       = esc_html__( 'Payment Success', 'user-registration' );
 			$this->description = esc_html__( 'Notifies admins that a user’s payment was successful.', 'user-registration' );
-			$this->receiver    = __( 'Admin', 'user-registration' );
+			$this->receiver    = 'Admin';
 		}
 
 		/**

--- a/includes/admin/settings/emails/class-ur-settings-payment-success-email.php
+++ b/includes/admin/settings/emails/class-ur-settings-payment-success-email.php
@@ -53,7 +53,7 @@ if ( ! class_exists( 'UR_Settings_Payment_Success_Email', false ) ) :
 			$this->id          = 'payment_success_email';
 			$this->title       = esc_html__( 'Payment Success', 'user-registration' );
 			$this->description = esc_html__( 'Confirms successful payment for the user\'s registration', 'user-registration' );
-			$this->receiver    = __( 'User', 'user-registration' );
+			$this->receiver    = 'User';
 		}
 
 		/**

--- a/includes/admin/settings/emails/class-ur-settings-profile-details-changed-email.php
+++ b/includes/admin/settings/emails/class-ur-settings-profile-details-changed-email.php
@@ -51,7 +51,7 @@ if ( ! class_exists( 'UR_Settings_Profile_Details_Changed_Email', false ) ) :
 			$this->id          = 'profile_details_changed_email';
 			$this->title       = __( 'Profile Updated', 'user-registration' );
 			$this->description = __( 'Notifies admin that a user’s profile details have been updated or changed.', 'user-registration' );
-			$this->receiver    = __( 'Admin', 'user-registration' );
+			$this->receiver    = 'Admin';
 		}
 
 		/**

--- a/includes/admin/settings/emails/class-ur-settings-profile-details-updated-email.php
+++ b/includes/admin/settings/emails/class-ur-settings-profile-details-updated-email.php
@@ -50,7 +50,7 @@ if ( ! class_exists( 'UR_Settings_Profile_Details_Updated_Email', false ) ) :
 			$this->id          = 'profile_details_updated_email';
 			$this->title       = __( 'Profile Updated', 'user-registration' );
 			$this->description = __( 'Confirms to the user that their profile details were successfully updated.', 'user-registration' );
-			$this->receiver    = __( 'User', 'user-registration' );
+			$this->receiver    = 'User';
 		}
 
 		/**
@@ -136,7 +136,7 @@ if ( ! class_exists( 'UR_Settings_Profile_Details_Updated_Email', false ) ) :
 				'user_registration_profile_details_updated_email_message',
 				sprintf(
 					__(
-					'Hi {{username}},<br/>
+						'Hi {{username}},<br/>
 					Your profile details have been successfully updated on {{blog_info}}.<br/>
 					{{all_fields}}<br/>
 					Thank You!',

--- a/includes/admin/settings/emails/class-ur-settings-registration-denied-email.php
+++ b/includes/admin/settings/emails/class-ur-settings-registration-denied-email.php
@@ -51,7 +51,7 @@ if ( ! class_exists( 'UR_Settings_Registration_Denied_Email', false ) ) :
 			$this->id          = 'registration_denied_email';
 			$this->title       = __( 'Registration Denied', 'user-registration' );
 			$this->description = __( 'Notifies the user their registration was denied.', 'user-registration' );
-			$this->receiver    = __( 'User', 'user-registration' );
+			$this->receiver    = 'User';
 		}
 
 		/**

--- a/includes/admin/settings/emails/class-ur-settings-registration-pending-email.php
+++ b/includes/admin/settings/emails/class-ur-settings-registration-pending-email.php
@@ -51,7 +51,7 @@ if ( ! class_exists( 'UR_Settings_Registration_Pending_Email', false ) ) :
 			$this->id          = 'registration_pending_email';
 			$this->title       = __( 'Account Status Changed: Pending Approval', 'user-registration' );
 			$this->description = __( 'Notifies the user that their existing registration status has been reverted to pending approval by an administrator.', 'user-registration' );
-			$this->receiver    = __( 'User', 'user-registration' );
+			$this->receiver    = 'User';
 		}
 
 		/**

--- a/includes/admin/settings/emails/class-ur-settings-reset-password-email.php
+++ b/includes/admin/settings/emails/class-ur-settings-reset-password-email.php
@@ -50,7 +50,7 @@ if ( ! class_exists( 'UR_Settings_Reset_Password_Email', false ) ) :
 			$this->id          = 'reset_password_email';
 			$this->title       = __( 'Reset Password', 'user-registration' );
 			$this->description = __( 'Sends a secure password reset link to the user who requested a reset.', 'user-registration' );
-			$this->receiver    = __( 'User', 'user-registration' );
+			$this->receiver    = 'User';
 		}
 
 		/**

--- a/includes/admin/settings/emails/class-ur-settings-successfully-registered-email.php
+++ b/includes/admin/settings/emails/class-ur-settings-successfully-registered-email.php
@@ -51,7 +51,7 @@ if ( ! class_exists( 'UR_Settings_Successfully_Registered_Email', false ) ) :
 			$this->id          = 'successfully_registered_email';
 			$this->title       = __( 'Registration Success', 'user-registration' );
 			$this->description = __( 'Confirms successful registration to the user.', 'user-registration' );
-			$this->receiver    = __( 'User', 'user-registration' );
+			$this->receiver    = 'User';
 		}
 
 		/**

--- a/modules/membership/includes/Emails/Admin/UR_Settings_Membership_Cancellation_Admin_Email.php
+++ b/modules/membership/includes/Emails/Admin/UR_Settings_Membership_Cancellation_Admin_Email.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace WPEverest\URMembership\Emails\Admin;
+
 /**
  * Membership_Cancellation_Email.php
  *
@@ -45,7 +46,7 @@ class UR_Settings_Membership_Cancellation_Admin_Email {
 		$this->id          = 'membership_cancellation_admin_email';
 		$this->title       = __( 'Membership Cancellation Notification', 'user-registration' );
 		$this->description = __( 'Notifies membership cancellation to the admin.', 'user-registration' );
-		$this->receiver    = __( 'Admin', 'user-registration-profile-completeness' );
+		$this->receiver    = 'Admin';
 	}
 
 	/**
@@ -53,7 +54,6 @@ class UR_Settings_Membership_Cancellation_Admin_Email {
 	 *
 	 * @return array
 	 * @since 1.0.0
-	 *
 	 */
 	public function get_settings() {
 
@@ -109,18 +109,19 @@ class UR_Settings_Membership_Cancellation_Admin_Email {
 
 	/**
 	 * Notification sent to admin when member cancel their membership.
-	 *
 	 */
 	public function user_registration_get_membership_cancellation_admin_email() {
 		$message = apply_filters(
 			'user_registration_membership_cancellation_admin_email_message',
 			sprintf(
-				__( '
+				__(
+					'
 					Hi Admin, <br>
 					The user {{username}} has cancelled their membership on {{blog_info}}. <br>
 
 					Thank you!',
-					'user-registration' )
+					'user-registration'
+				)
 			)
 		);
 

--- a/modules/membership/includes/Emails/User/UR_Settings_Membership_Cancellation_User_Email.php
+++ b/modules/membership/includes/Emails/User/UR_Settings_Membership_Cancellation_User_Email.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace WPEverest\URMembership\Emails\User;
+
 /**
  * Membership_Cancellation_Email.php
  *
@@ -45,7 +46,7 @@ class UR_Settings_Membership_Cancellation_User_Email {
 		$this->id          = 'membership_cancellation_user_email';
 		$this->title       = __( 'Membership Cancellation Confirmation', 'user-registration' );
 		$this->description = __( 'Confirms membership cancellation to the user, providing any relevant account status or next steps.', 'user-registration' );
-		$this->receiver    = __( 'User', 'user-registration-profile-completeness' );
+		$this->receiver    = 'User';
 	}
 
 	/**
@@ -53,7 +54,6 @@ class UR_Settings_Membership_Cancellation_User_Email {
 	 *
 	 * @return array
 	 * @since 1.0.0
-	 *
 	 */
 	public function get_settings() {
 
@@ -109,20 +109,21 @@ class UR_Settings_Membership_Cancellation_User_Email {
 
 	/**
 	 * Notification sent to admin when member cancel their membership.
-	 *
 	 */
 	public function user_registration_get_membership_cancellation_user_email() {
 		$message = apply_filters(
 			'user_registration_membership_cancellation_user_email_message',
 			sprintf(
-				__( '
+				__(
+					'
 					Hi {{username}}, <br>
 					We\'re sorry to see you go. Your request to cancel the {{membership_plan_name}} membership has been successfully processed. <br>
 					If you change your mind in the future, we\'ll be here to welcome you back.<br>
 					Thank you for being a part of {{blog_info}}.<br><br>
 
 					Goodbye and take care!',
-					'user-registration' )
+					'user-registration'
+				)
 			)
 		);
 

--- a/modules/membership/includes/Emails/User/UR_Settings_Membership_Renewal_Reminder_User_Email.php
+++ b/modules/membership/includes/Emails/User/UR_Settings_Membership_Renewal_Reminder_User_Email.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace WPEverest\URMembership\Emails\User;
+
 /**
  * Membership_Renewal_Reminder_Email.php
  *
@@ -45,7 +46,7 @@ class UR_Settings_Membership_Renewal_Reminder_User_Email {
 		$this->id          = 'membership_renewal_reminder_user_email';
 		$this->title       = __( 'Membership Renewal Reminder', 'user-registration' );
 		$this->description = __( 'An email sent to notify users about an upcoming subscription renewal', 'user-registration' );
-		$this->receiver    = __( 'User', 'user-registration-profile-completeness' );
+		$this->receiver    = 'User';
 	}
 
 	/**
@@ -53,7 +54,6 @@ class UR_Settings_Membership_Renewal_Reminder_User_Email {
 	 *
 	 * @return array
 	 * @since 1.0.0
-	 *
 	 */
 	public function get_settings() {
 
@@ -90,7 +90,7 @@ class UR_Settings_Membership_Renewal_Reminder_User_Email {
 								'default'  => 7,
 								'css'      => 'min-width: 350px;',
 								'desc_tip' => true,
-							)
+							),
 						),
 					),
 					'renewal_email'    => array(
@@ -130,7 +130,7 @@ class UR_Settings_Membership_Renewal_Reminder_User_Email {
 								'desc_tip' => true,
 							),
 						),
-					)
+					),
 				),
 			)
 		);
@@ -140,13 +140,13 @@ class UR_Settings_Membership_Renewal_Reminder_User_Email {
 
 	/**
 	 * Notification sent to admin when member cancel their membership.
-	 *
 	 */
 	public function user_registration_get_membership_renewal_reminder_user_email() {
 		$message = apply_filters(
 			'user_registration_membership_renewal_reminder_user_email_message',
 			sprintf(
-				__( '
+				__(
+					'
 					Hi {{username}}, <br><br>
 					This is a friendly reminder that your {{membership_plan_name}} membership on {{blog_info}} is due for renewal soon. <br>
 					Don\'t worry – your membership will be automatically renewed, and the payment will be processed shortly. <br>
@@ -154,7 +154,8 @@ class UR_Settings_Membership_Renewal_Reminder_User_Email {
 					Thank you for being a valued member!<br><br>
 					Best regards,<br>
 					{{blog_info}}',
-					'user-registration' )
+					'user-registration'
+				)
 			)
 		);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

While translating the site, the **To Users** email settings were not being displayed due to a mismatch between translated and non-translated values. This PR fixes the issue by ensuring consistent comparison logic.

Closes # .

### How to test the changes in this Pull Request:

1. Use the translation plugins
2. Translate all site using that plugin
3. Go to URM > Global Settings > Emails > To Users

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Email settings not display while translating site.