### PR TITLE
Fix - Partial content restriction message Modification.

### DIFF
--- a/modules/content-restriction/class-urcr-shortcodes.php
+++ b/modules/content-restriction/class-urcr-shortcodes.php
@@ -142,7 +142,9 @@ class URCR_Shortcodes {
 
 			$memberships_roles = isset($memberships_roles) ? explode( ',', $memberships_roles ) : array();
 			$memberships_roles = array_map( function($role) { return trim(str_replace('″', '', $role)) ;}, $memberships_roles );
-			$message = '';
+
+			$message = get_option( 'user_registration_content_restriction_message', '' );
+			
 			if ( $override_global_settings === 'on' ) {
 				$message = ! empty(get_post_meta( $post->ID, 'urcr_meta_content', $single = true )) ? get_post_meta( $post->ID, 'urcr_meta_content', $single = true ) : '';
 			} elseif ( isset( $atts['enable_content_restriction']) && $atts['enable_content_restriction'] === "true" ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

While using the partial content restriction, restriction message was not modified according to the global restriction message. This PR fixes this issue.

Closes # .

### How to test the changes in this Pull Request:

1. Refer to this docs [Partial restriction](https://docs.wpuserregistration.com/docs/content-restriction/#7-toc-title)
2. Change the message in Global restriction setting.
3. Check whether the global restriction message is displayed or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Partial content restriction message Modification.
