### PR TITLE
Fix - Datetime field conflict with hello elementor theme.

### DIFF
--- a/assets/js/frontend/user-registration.js
+++ b/assets/js/frontend/user-registration.js
@@ -2934,3 +2934,25 @@ jQuery(document).ready(function($) {
 		urcrContentRestrictMsg.first().css('display', 'block');
 	}
 });
+
+/**
+ * Check if hello elementor theme is active or not teo resolve flatpickr design issue.
+ *
+ */
+jQuery(document).ready(function($) {
+
+	//Check the hello elemtor theme is active or not through its stylesheet.
+	$isHelloElementorActive = $('link#hello-elementor-css[href*="themes/hello-elementor"]').length > 0;
+
+	if(!$isHelloElementorActive) {
+		return;
+	}
+
+	$(document).on('focus', '.ur-flatpickr-field', function () {
+		var $input = $(this);
+
+		setTimeout(function () {
+			$('.flatpickr-calendar:visible .flatpickr-current-month').css('display', 'flex');
+		}, 50);
+	});
+});


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

While using Hello Elementor theme, Year dropdown is not displayed in the date time picker field. This PR fixes this issue.

Closes # .

### How to test the changes in this Pull Request:

1. Drag and drop date time picker field.
2. Install and activate Hello Elementor theme.
3. In the frontend section, check whether the year drop down is displayed or not in date picker field.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Datetime field conflict with hello elementor theme.
