### PR TITLE
Fix - Auto login not working for stripe paid membership.

### DIFF
--- a/modules/membership/includes/AJAX.php
+++ b/modules/membership/includes/AJAX.php
@@ -649,7 +649,6 @@ class AJAX {
 		$customer_id       = isset( $_POST['customer_id'] ) ? $_POST['customer_id'] : '';
 		$payment_method_id = isset( $_POST['payment_method_id'] ) ? sanitize_text_field( $_POST['payment_method_id'] ) : '';
 		$member_id         = absint( wp_unslash( $_POST['member_id'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
-		$payment_status    = sanitize_text_field( $_POST['payment_status'] );
 
 		$is_user_created = get_user_meta( $member_id, 'urm_user_just_created' );
 		if ( ! $is_user_created ) {
@@ -671,7 +670,7 @@ class AJAX {
 		$stripe_subscription = $stripe_service->create_subscription( $customer_id, $payment_method_id, $member_id );
 
 		if ( $stripe_subscription['status'] ) {
-			if ( ! empty( $form_response ) && isset( $form_response['auto_login'] ) && $form_response['auto_login'] && $payment_status !== 'failed' ) {
+			if ( ! empty( $form_response ) && isset( $form_response['auto_login'] ) && $form_response['auto_login'] ) {
 				$members_service = new MembersService();
 				$logged_in       = $members_service->login_member( $member_id, true );
 				if ( ! $logged_in ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Auto login after paid subscription using stripe was not working. This PR fixes this issue.

Closes # .

### How to test the changes in this Pull Request:

1. Create a subscription based membership using Stripe.
2. Create a form using that membership field making Auto Approval and Auto Login feature.
3. Check whether it is redirecting to my account after stripe paid membership subscription.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Auto login not working for stripe paid membership.