### PR TITLE
Fix - Submit button label and html content not translatable in WPML.

### DIFF
--- a/includes/abstracts/abstract-ur-form-field.php
+++ b/includes/abstracts/abstract-ur-form-field.php
@@ -306,6 +306,10 @@ abstract class UR_Form_Field {
 			}
 		}
 
+		if ( 'html' === $field_key ) {
+			$form_data['html'] = isset( $data['general_setting']->html ) ? ur_string_translation( $form_id, 'user_registration_' . $data['general_setting']->field_name, $data['general_setting']->html ) : '';
+		}
+
 		if ( 'radio' === $field_key ) {
 
 			if ( isset( $data['general_setting']->image_choice ) && ur_string_to_bool( $data['general_setting']->image_choice ) ) {

--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -65,6 +65,6 @@
 		<key name="user_registration_pro_auto_password_generation_message" />
 		<key name="user_registration_pro_email_verified_admin_approval_await_message" />
 		<key name="user_registration_form_submission_error_message_disallow_username_character" />
-		<key name="user_registration_form_submission_email_suggestion" />
+		<key name="user_registration_form_setting_form_submit_label" />
 	</admin-texts>
 </wpml-config>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Submit button label and html content was not translatable in WPML. This PR fixes this issue.

Closes # .

### How to test the changes in this Pull Request:

1. Create a form using the html content.
2. Make the submit button text and HTML content translatable in WPML.
3. Check whether it is translated or not in multiple language site.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Submit button label and html content not translatable in WPML.
