### PR TITLE
Tweak -  Consistent drop-down for login and registration form builder setting.

### DIFF
--- a/includes/abstracts/abstract-ur-form-field.php
+++ b/includes/abstracts/abstract-ur-form-field.php
@@ -1032,7 +1032,7 @@ abstract class UR_Form_Field {
 		$class        = 'ur-general-setting-' . $strip_prefix;
 
 		$settings  = "<div class='ur-general-setting-block " . esc_attr( $class ) . "'>";
-		$settings .= '<h2 class="ur-toggle-heading">' . esc_html__( 'General Settings', 'user-registration' ) . '</h2><hr>';
+		$settings .= '<h2 class="ur-toggle-heading closed">' . esc_html__( 'General Settings', 'user-registration' ) . '</h2><hr>';
 		$settings .= '<div class="ur-toggle-content">';
 		$settings .= $this->get_field_general_settings();
 		$settings .= '</div>';

--- a/includes/admin/class-ur-admin-menus.php
+++ b/includes/admin/class-ur-admin-menus.php
@@ -407,7 +407,7 @@ if ( ! class_exists( 'UR_Admin_Menus', false ) ) :
 						$fields[ $i ]['name'] = $name;
 					}
 
-					echo '<h2 class="ur-toggle-heading">' . esc_html( $section['section_title'] ) . '</h2><hr/>';
+					echo '<h2 class="ur-toggle-heading closed">' . esc_html( $section['section_title'] ) . '</h2><hr/>';
 					echo '<ul id = "ur-upgradables" class="ur-registered-list" > ';
 					$this->render_upgradable_fields( $fields );
 					echo '</ul >';

--- a/includes/admin/views/html-admin-page-forms.php
+++ b/includes/admin/views/html-admin-page-forms.php
@@ -96,10 +96,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 											<h3 class="ur-fields-not-found-title"><?php esc_html_e( 'Whoops!', 'user-registration' ); ?></h3>
 											<span><?php esc_html_e( 'There is not any field that you were searching for.', 'user-registration' ); ?></span>
 										</div>
-										<h2 class='ur-toggle-heading'><?php esc_html_e( 'Default User Fields', 'user-registration' ); ?></h2>
+										<h2 class='ur-toggle-heading closed'><?php esc_html_e( 'Default User Fields', 'user-registration' ); ?></h2>
 										<hr/>
 										<?php $this->get_registered_user_form_fields(); ?>
-										<h2 class='ur-toggle-heading'><?php esc_html_e( 'Extra Fields', 'user-registration' ); ?></h2>
+										<h2 class='ur-toggle-heading closed'><?php esc_html_e( 'Extra Fields', 'user-registration' ); ?></h2>
 										<hr/>
 										<?php $this->get_registered_other_form_fields(); ?>
 										<?php do_action( 'user_registration_extra_fields' ); ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

There was inconsitency in the drop-down icon for login and registration form field settings. This PR makes this drop-down icon consistency.

Closes # .

### How to test the changes in this Pull Request:

1. Go to Global Settings > Login Settings
2. Open Registration Form edit or create a new form
3. Check the drop-down icon while opening and closing the fields setting in Registration Form and Settings in Login Form.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak -  Consistent drop-down for login and registration form builder setting.