### PR TITLE
UR-2617/Fix - Fatal error while sending payment successful email without membership.

### DIFF
--- a/includes/class-ur-smart-tags.php
+++ b/includes/class-ur-smart-tags.php
@@ -19,7 +19,7 @@ class UR_Smart_Tags {
 		add_filter( 'user_registration_process_smart_tags', array( $this, 'process' ), 10, 3 );
 		add_filter( 'ur_smart_tags_list_in_general', array( $this, 'select_smart_tags_in_general' ), 10, 1 );
 		add_filter( 'ur_pattern_validation_list_in_advanced_settings', array(
-			$this,
+				$this,
 			'select_pattern_validation'
 		), 10, 1 );
 	}
@@ -31,8 +31,8 @@ class UR_Smart_Tags {
 	 */
 	public static function smart_tags_list() {
 		if ( isset( $_GET['page'] ) && $_GET['page'] === 'yith_wpv_panel' &&
-		     isset( $_GET['tab'] ) && $_GET['tab'] === 'vendors' &&
-		     isset( $_GET['sub_tab'] ) && $_GET['sub_tab'] === 'vendors-list' ) {
+			isset( $_GET['tab'] ) && $_GET['tab'] === 'vendors' &&
+			isset( $_GET['sub_tab'] ) && $_GET['sub_tab'] === 'vendors-list' ) {
 			$smart_tags = array();
 		} else {
 			$smart_tags = array_merge( self::ur_unauthenticated_parsable_smart_tags_list(), self::ur_authenticated_parsable_smart_tags_list() );
@@ -665,7 +665,7 @@ class UR_Smart_Tags {
 						}
 						$template_file   = locate_template( 'payment-successful-email.php' );
 						if ( ! $template_file ) {
-							$template_file = UR_MEMBERSHIP_DIR . 'includes/Templates/Emails/payment-successful-email.php';
+							$template_file = UR_ABSPATH . 'modules/membership/includes/Templates/Emails/payment-successful-email.php';
 						}
 						ob_start();
 						require $template_file;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

There was fatal error while sending the payment successful email without creating the membership form or simply not activating membership plugin.

Closes # .

### How to test the changes in this Pull Request:

1. Create a subscription plan using subscription plan field.
2. Add stripe payment field.
3. Submit the form and check whether the fatal error is thrown or not.

You can also use this form for reference: 
[teacher-2025-06-27_01_10_50.json](https://github.com/user-attachments/files/20944686/teacher-2025-06-27_01_10_50.json)


### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Fatal error while sending payment successful email without membership.
