### PR TITLE
UR 2545  Fix - Enable Paypal in form setting triggers override global paypal settings

### DIFF
--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -65,7 +65,7 @@ jQuery(function ($) {
 				message = user_registration_form_builder_data.form_membership_payment_fields_disabled_message;
 			}
 			else if($(this).hasClass("ur-membership-field-disabled")){
-				message = user_registration_form_builder_data.form_membership_field_disabled_message;				
+				message = user_registration_form_builder_data.form_membership_field_disabled_message;
 			}
 			else{
 				message = user_registration_form_builder_data.form_one_time_draggable_fields_locked_message.replace(
@@ -490,7 +490,7 @@ jQuery(function ($) {
 								'" class="form-settings-tab ' +
 								classToAdd +
 								'" ' +
-								dataAttributes + 
+								dataAttributes +
 								style +
 								" >" +
 								appending_text +
@@ -1617,7 +1617,7 @@ jQuery(function ($) {
 
 	$(document.body).on(
 		"click",
-		"#user_registration_enable_paypal_standard , #user_registration_override_paypal_global_settings",
+		"#user_registration_override_paypal_global_settings",
 		function () {
 			update_paypal_settings($(this));
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously the enable toggle was triggering the override global PayPal settings switch; this PR fixes this.

### How to test the changes in this Pull Request:

1. Edit Form
2.  Go to Form Settings > Paypal Settings
3. Toggle Enable paypal switch and see if it is still toggling payapl override switch.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

>  Fix - Enable Paypal in form setting triggers override global paypal settings
