### PR TITLE
Ur 2628 Fix - Display country after countires list customization.

### DIFF
--- a/includes/admin/class-ur-admin-profile.php
+++ b/includes/admin/class-ur-admin-profile.php
@@ -247,6 +247,7 @@ if ( ! class_exists( 'UR_Admin_Profile', false ) ) :
 												} else {
 													$selected = esc_attr( get_user_meta( $user->ID, $key, true ) );
 												}
+												$field['options'] = apply_filters( 'override_options_for_select_field', $field['options'], $key );
 												foreach ( $field['options'] as $option_key => $option_value ) :
 													?>
 													<option


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

After customizing the listing of counties select field using **user_registration_countries_list** and **override_options_for_select_field** the countires value was not displayed in WP users edit page. This PR fixes this issue.

Closes # .

### How to test the changes in this Pull Request:

1. Create a code snippet to modify the counties listing in form and the user edit  profile section using above hook now check in the WP users profile page if the data is displayed or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Display country after countires list customization.