### PR TITLE
UR - 2560 Enhancement - Auto select membership and pg if only one membership.

### DIFF
--- a/assets/js/modules/membership/frontend/user-registration-membership-frontend.js
+++ b/assets/js/modules/membership/frontend/user-registration-membership-frontend.js
@@ -783,6 +783,35 @@
 			}
 		}
 	};
+
+	//on toggle payment gatewaysw
+	$('input[name="urm_payment_method"]').on('change', function () {
+		var selected_method = $(this).val(),
+			stripe_container = $('.stripe-container'),
+			stripe_error_container = $('#stripe-errors');
+
+		var authorize_container = $('#authorize-net-container');
+		var authorize_error_container = $('#authorize-errors');
+
+		stripe_container.addClass('urm-d-none');
+		stripe_error_container.remove();
+
+		authorize_container.addClass('urm-d-none');
+		authorize_error_container.remove();
+
+		elements = {};
+		if (selected_method === 'stripe') {
+			if (urmf_data.stripe_publishable_key.length == 0) {
+				ur_membership_frontend_utils.show_failure_message(urmf_data.labels.i18n_incomplete_stripe_setup_error);
+				return;
+			}
+			stripe_container.removeClass('urm-d-none');
+			stripe_settings.init();
+		}
+		if (selected_method === 'authorize') {
+			authorize_container.removeClass('urm-d-none');
+		}
+	});
 	//activate payment gateways
 	$('input[name="urm_membership"]').on('change', function () {
 		// clear coupon total notice
@@ -819,15 +848,25 @@
 					input_container.addClass('urm-d-none');
 				}
 			});
+
+			if (urm_pg_container.find('input:visible').length === 1) {
+				var lone_pg = urm_pg_container.find('input:visible');
+				$(lone_pg[0]).prop("checked", true);
+				lone_pg.trigger("change");
+			}
 			ur_membership_ajax_utils.calculate_total($(this));
 		}
 	});
 	// membership input change trigger for page with membership id as params.
-	var searchParams = new URLSearchParams(window.location.search);
+	var searchParams = new URLSearchParams(window.location.search),
+		visible_memberships = $('input[name="urm_membership"]');
+
 	if (searchParams.has('membership_id')) {
 		$('input[name="urm_membership"]:checked').change();
 	}
-
+	if (visible_memberships !== undefined && visible_memberships.length === 1) {
+		$(visible_memberships[0]).prop("checked", true).change();
+	}
 	$('.close_notice').on('click', ur_membership_frontend_utils.toggleNotice);
 
 	$('#ur-membership-password').on('keyup change', function () {
@@ -920,34 +959,6 @@
 
 	});
 
-	//on toggle payment gatewaysw
-	$('input[name="urm_payment_method"]').on('change', function () {
-		var selected_method = $(this).val(),
-			stripe_container = $('.stripe-container'),
-			stripe_error_container = $('#stripe-errors');
-
-		var authorize_container = $('#authorize-net-container');
-		var authorize_error_container = $('#authorize-errors');
-
-		stripe_container.addClass('urm-d-none');
-		stripe_error_container.remove();
-
-		authorize_container.addClass('urm-d-none');
-		authorize_error_container.remove();
-
-		elements = {};
-		if (selected_method === 'stripe') {
-			if (urmf_data.stripe_publishable_key.length == 0) {
-				ur_membership_frontend_utils.show_failure_message(urmf_data.labels.i18n_incomplete_stripe_setup_error);
-				return;
-			}
-			stripe_container.removeClass('urm-d-none');
-			stripe_settings.init();
-		}
-		if (selected_method === 'authorize') {
-			authorize_container.removeClass('urm-d-none');
-		}
-	});
 
 	//cancel membership button
 	$(document).on("click", ".cancel-membership-button", function () {


### PR DESCRIPTION
### All Submissions:

* [ x Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Previously, if there were only one membership in a form, it would have to be selected manually; this PR autoselects a single membership and also automatically select a single payment gateway if there was only one.

Closes # .

### How to test the changes in this Pull Request:

1. Create a form with a single membership with a single plan
2. Go to the page and see if the plan is selected automatically along with the PG.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

>  Enhancement - Auto select membership and pg if only one membership.
