### PR TITLE
UR-2547 Fix - Failure of paypal form creation.

### DIFF
--- a/includes/RestApi/controllers/version1/class-ur-plugin-status.php
+++ b/includes/RestApi/controllers/version1/class-ur-plugin-status.php
@@ -112,30 +112,38 @@ class UR_Plugin_Status {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function get_plugin_status() {
-			$extension_data = self::get_addons_data();
+		$extension_data = self::get_addons_data();
+		$addons_lists   = $extension_data->products;
 
-			$addons_lists = $extension_data->products;
 		if ( ! function_exists( 'get_plugins' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
-			$installed_plugin_slugs = array_keys( get_plugins() );
+		$installed_plugin_slugs = array_keys( get_plugins() );
+
+		$plugin_statuses = array();
+
+		if ( ur_check_module_activation( 'payments' ) ) {
+			$plugin_statuses['user-registration-payments'] = 'active';
+		} else {
+			$plugin_statuses['user-registration-payments'] = 'not-installed';
+		}
 
 		foreach ( $addons_lists as $addon ) {
 			$addon_file = $addon->slug . '/' . $addon->slug . '.php';
 			if ( in_array( $addon_file, $installed_plugin_slugs, true ) ) {
 				$plugin_statuses[ $addon->slug ] = is_plugin_active( $addon_file ) ? 'active' : 'inactive';
-			} else {
-				$plugin_statuses[ $addon->slug ] = 'not-installed';
+			} elseif ( ! isset( $plugin_statuses[ $addon->slug ] ) ) {
+					$plugin_statuses[ $addon->slug ] = 'not-installed';
 			}
 		}
 
-			return new WP_REST_Response(
-				array(
-					'success'       => true,
-					'plugin_status' => $plugin_statuses,
-				),
-				200
-			);
+		return new WP_REST_Response(
+			array(
+				'success'       => true,
+				'plugin_status' => $plugin_statuses,
+			),
+			200
+		);
 	}
 
 
@@ -157,7 +165,16 @@ class UR_Plugin_Status {
 	 * @return object
 	 */
 	public static function get_addons_data() {
-		$addons_data = ur_get_json_file_contents( 'assets/extensions-json/sections/all_extensions.json' );
+		$addons_data          = ur_get_json_file_contents( 'assets/extensions-json/sections/all_extensions.json' );
+		$module_features_data = ur_get_json_file_contents( 'assets/extensions-json/all-features.json' );
+
+		$features_data = isset( $module_features_data->features ) ? $module_features_data->features : array();
+
+		$addons_data_array = isset( $addons_data->products ) ? $addons_data->products : array();
+
+		$addons_data_array = array_merge( $addons_data_array, $features_data );
+
+		$addons_data->products = $addons_data_array;
 
 		$new_product = (object) array(
 			'products' => array(
@@ -225,6 +242,10 @@ class UR_Plugin_Status {
 	 */
 	public static function plugin_activate( $request ) {
 		$addon = $request->get_param( 'addonData' );
+
+		if ( isset( $addon['slug'] ) && 'user-registration-payments' === $addon['slug'] ) {
+			$addon['type'] = 'feature';
+		}
 
 		if ( isset( $addon['type'] ) && 'addon' === $addon['type'] ) {
 			$slug        = isset( $addon['name'] ) ? sanitize_key( wp_unslash( $addon['name'] ) ) : '';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When creating a PayPal Event Registration Form, the required add-ons are not properly recognized. After publishing the form, attempting to edit it from the “All Forms” section causes a warning to be encountered.

Closes # .

### How to test the changes in this Pull Request:

1. Go to URM > All Forms > Add New.
2. Go to Payments Form > Select PayPal Event Registration Form and click on Get Started.
3. Check whether the Paypal is installed, activated and the form with Paypal is created or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Failure of Paypal form creation.
