### PR TITLE
UR 2622 Fix - Export users page issue in settings.

### DIFF
--- a/includes/admin/views/html-admin-page-export-users.php
+++ b/includes/admin/views/html-admin-page-export-users.php
@@ -23,7 +23,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 						<p>
 							<select name="export_users" id="selected-export-user-form" class="ur-input forms-list ur-enhanced-select">
-								<option value="" ><?php esc_html_e( 'Select Form', 'user-registration' ); ?></option>
+								<option value="" >
+								<?php
+								if ( ! empty( $all_forms ) ) {
+									esc_html_e( 'Select Form', 'user-registration' );
+								} else {
+									esc_html_e( 'No Forms Available, please create one.', 'user-registration' );
+								}
+								?>
+								</option>
 								<?php
 								foreach ( $all_forms as $form_id => $form ) {
 									echo '<option value ="' . esc_attr( $form_id ) . '">' . esc_html( $form ) . '</option>';
@@ -31,7 +39,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 								?>
 							</select>
 						</p>
-						<?php do_action( 'user_registration_custom_export_template', array_keys( $all_forms )[0] ); ?>
+
+						<?php
+						if ( ! empty( $all_forms ) ) {
+							do_action( 'user_registration_custom_export_template', array_keys( $all_forms )[0] );
+						}
+						?>
 
 						<input type="button"  class="button button-primary ur_export_user_action_button " name="user_registration_export_users" value="<?php esc_attr_e( 'Export Users', 'user-registration' ); ?>">
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

If there are no forms and the users, in import users the Select Form option was shown even though  the forms were not available for exporting. This PR fixes this issue.

Closes # .

### How to test the changes in this Pull Request:

1. Delete all users and forms.
2. Go to URM >  Settings > Import/ Export > Export Users
3.  Check whether the Select form option is displayed or not if no forms were there.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Export users page issue in settings.
