### PR TITLE
UR-2663 Dev - Filter to hide my account page selection notice

### DIFF
--- a/includes/admin/notifications/class-ur-admin-notices.php
+++ b/includes/admin/notifications/class-ur-admin-notices.php
@@ -106,12 +106,16 @@ class UR_Admin_Notices {
 		if ( 0 === $matched ) {
 			$my_account_setting_link = admin_url() . 'admin.php?page=user-registration-settings#user_registration_myaccount_page_id';
 
-			$message = sprintf(
-				/* translators: %1$s - My account Link. */
-				__( 'Please choose a <strong title="A page with [user_registration_my_account] shortcode">My Account</strong> page in <a href="%1$s" style="text-decoration:none;">General Settings</a>. <br/><strong>Got Stuck? Read</strong> <a href="https://docs.wpuserregistration.com/docs/how-to-show-account-profile/" style="text-decoration:none;" rel="noreferrer noopener" target="_blank">How to setup My Account page</a>.', 'user-registration' ),
-				$my_account_setting_link
-			);
-			self::add_custom_notice( 'select_my_account', $message );
+			if ( $urm_show_message ) {
+				$message = sprintf(
+					/* translators: %1$s - My account Link. */
+					__( 'Please choose a <strong title="A page with [user_registration_my_account] shortcode">My Account</strong> page in <a href="%1$s" style="text-decoration:none;">General Settings</a>. <br/><strong>Got Stuck? Read</strong> <a href="https://docs.wpuserregistration.com/docs/how-to-show-account-profile/" style="text-decoration:none;" rel="noreferrer noopener" target="_blank">How to setup My Account page</a>.', 'user-registration' ),
+					$my_account_setting_link
+				);
+				self::add_custom_notice( 'select_my_account', $message );
+			} else {
+				self::remove_notice( 'select_my_account' );
+			}
 		} else {
 			self::remove_notice( 'select_my_account' );
 		}

--- a/includes/admin/notifications/class-ur-admin-notices.php
+++ b/includes/admin/notifications/class-ur-admin-notices.php
@@ -105,7 +105,7 @@ class UR_Admin_Notices {
 
 		if ( 0 === $matched ) {
 			$my_account_setting_link = admin_url() . 'admin.php?page=user-registration-settings#user_registration_myaccount_page_id';
-
+			$urm_show_message        = apply_filters( 'user_registration_membership_show_my_account_notice', true );
 			if ( $urm_show_message ) {
 				$message = sprintf(
 					/* translators: %1$s - My account Link. */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

While we don't want to use the URM my account page such as in case of buddy press the my account selection message was displaying. This PR adds the filter to hide this notiifcation conditionally.

### How to test the changes in this Pull Request:

1. Do not select my account page in setting and check whether the my account selection notice is displayed or not after using this filter.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Filter to hide my account page selection notice.
