### PR TITLE
Fix - Avoid the API request to stats for development mode.

### DIFF
--- a/includes/stats/class-ur-stats.php
+++ b/includes/stats/class-ur-stats.php
@@ -123,7 +123,7 @@ if ( ! class_exists( 'UR_Stats' ) ) {
 
 			$base_product = $this->get_base_product();
 
-			$active_plugins   = get_option( 'active_plugins', array() );
+			$active_plugins = get_option( 'active_plugins', array() );
 
 			$base_product_name = $is_premium ? 'User Registration Pro' : 'User Registration';
 
@@ -164,20 +164,19 @@ if ( ! class_exists( 'UR_Stats' ) ) {
 				}
 			}
 
-
 			/**
 			 * Format module data to track in TG Tracking.
 			 *
 			 * @since 4.0
 			 */
-			 $enabled_features = get_option( 'user_registration_enabled_features', array() );
+			$enabled_features = get_option( 'user_registration_enabled_features', array() );
 
-			 $addons_list_moved_into_module = array(
-                'user-registration-payments',
-                'user-registration-content-restriction',
-                'user-registration-frontend-listing',
-                'user-registration-membership',
-             );
+			$addons_list_moved_into_module = array(
+				'user-registration-payments',
+				'user-registration-content-restriction',
+				'user-registration-frontend-listing',
+				'user-registration-membership',
+			);
 
 			if ( ! empty( $enabled_features ) ) {
 				$our_modules     = $this->get_modules();
@@ -185,13 +184,13 @@ if ( ! class_exists( 'UR_Stats' ) ) {
 				foreach ( $enabled_features as $slug ) {
 					if ( isset( $modules_by_slug[ $slug ] ) ) {
 						$module                       = $modules_by_slug[ $slug ];
-						$product_slug 				  = in_array( $slug, $addons_list_moved_into_module ) ? $slug . '/' . $slug . '.php' : $slug;
+						$product_slug                 = in_array( $slug, $addons_list_moved_into_module ) ? $slug . '/' . $slug . '.php' : $slug;
 						$addons_data[ $product_slug ] = array(
 							'product_name'    => $module['name'],
 							'product_version' => UR()->version,
 							'product_type'    => in_array( $slug, $addons_list_moved_into_module ) ? 'plugin' : 'module',
 							'product_slug'    => $product_slug,
-							'is_premium'      => $is_premium
+							'is_premium'      => $is_premium,
 						);
 					}
 				}
@@ -303,12 +302,36 @@ if ( ! class_exists( 'UR_Stats' ) ) {
 		}
 
 		/**
+		 * Get api stats url.
+		 *
+		 * @return string
+		 */
+		private function get_stats_api_url() {
+			$url = '';
+			// Ingore for development mode.
+			if ( defined( 'UR_DEV' ) && UR_DEV ) {
+				if ( defined( 'TG_USERS_TRACKING_VERSION' ) ) {
+					$url = rest_url() . 'tgreporting/v1/process-premium/';
+				}
+			} else {
+				$url = self::REMOTE_URL;
+			}
+
+			return $url;
+		}
+		/**
 		 * Call API.
 		 *
 		 * @return void
 		 */
 		public function call_api() {
 			global $wpdb;
+			$stats_api_url = $this->get_stats_api_url();
+
+			if ( '' === $stats_api_url ) {
+				return;
+			}
+
 			$theme                        = wp_get_theme();
 			$data                         = array();
 			$data['product_data']         = $this->get_plugin_lists();
@@ -331,7 +354,7 @@ if ( ! class_exists( 'UR_Stats' ) ) {
 			$data['base_product']         = $this->get_base_product();
 			$data['global_settings']      = $this->get_global_settings();
 
-			$this->send_request( apply_filters( 'user_registration_tg_tracking_remote_url' , self::REMOTE_URL ), $data );
+			$this->send_request( apply_filters( 'user_registration_tg_tracking_remote_url', $stats_api_url ), $data );
 		}
 
 		/**
@@ -514,8 +537,8 @@ if ( ! class_exists( 'UR_Stats' ) ) {
 		 *
 		 * @since 4.0
 		 */
-		public function get_modules(){
-			$all_modules  = file_get_contents( ur()->plugin_path() . '/assets/extensions-json/all-features.json' );
+		public function get_modules() {
+			$all_modules = file_get_contents( ur()->plugin_path() . '/assets/extensions-json/all-features.json' );
 
 			if ( ur_is_json( $all_modules ) ) {
 				$all_modules = json_decode( $all_modules, true );

--- a/user-registration.php
+++ b/user-registration.php
@@ -170,6 +170,7 @@ if ( ! class_exists( 'UserRegistration' ) ) :
 			$this->define( 'UR_FORM_PATH', UR_ABSPATH . 'includes' . UR_DS . 'form' . UR_DS );
 			$this->define( 'UR_SESSION_CACHE_GROUP', 'ur_session_id' );
 			$this->define( 'UR_PRO_ACTIVE', false );
+			$this->define( 'UR_DEV', false );
 		}
 
 		/**
@@ -304,7 +305,7 @@ if ( ! class_exists( 'UserRegistration' ) ) :
 				include_once UR_ABSPATH . 'includes/3rd-party/oxygen/class-ur-oxygen.php';
 			}
 			// Divi builder compatiblity.
-			if(class_exists('WPEverest\URM\DiviBuilder\Builder')) {
+			if ( class_exists( 'WPEverest\URM\DiviBuilder\Builder' ) ) {
 				WPEverest\URM\DiviBuilder\Builder::init();
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR aims to avoid the stats API request to every activation of modules and addons for development mode.
If we are working in development mode, we must add **define('EFP_DEV', true);** to the config file.

### How to test the changes in this Pull Request:

1.
2.
3.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
