### PR TITLE
UR 2400 - Email notification to user on admin profile update.

### DIFF
--- a/includes/class-ur-emailer.php
+++ b/includes/class-ur-emailer.php
@@ -218,7 +218,7 @@ class UR_Emailer {
 		$username     = $user_data->user_login;
 		$single_field = array();
 
-		if ( ur_option_checked( 'user_registration_ajax_form_submission_on_edit_profile', false ) ) {
+		if ( ur_option_checked( 'user_registration_ajax_form_submission_on_edit_profile', false ) || current_user_can( 'manage_options' ) ) {
 
 			if ( isset( $_POST['form_data'] ) ) { //PHPCS:ignore
 				$form_data = json_decode( stripslashes( $_POST['form_data'] ) ); //PHPCS:ignore


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changes proposed in this Pull Request:

This PR fixes the issue listed in the ticket and sends an email to both the user and the admin when a user's profile is updated via the admin panel through **URM > Users > Edit** .
Email is sent similar to how user updates their profile via my account page.

### How to test the changes in this Pull Request:

1. Go to **URM > Users** in the WordPress admin panel.
2. Edit any user details and save changes.
3. Ensure both the user and the admin receive appropriate email notifications with updated content.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Email notification to user on profile update by admin.
