### PR TITLE
UR-2706 Fix - Prevent login form resubmission on reload.

### DIFF
--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -4269,18 +4269,22 @@ if ( ! function_exists( 'ur_process_login' ) ) {
 						)
 					);
 				}
-				/**
-				 * Filters the error messages displayed on the login screen.
-				 *
-				 * @param string $message The original error message displayed on the login screen.
-				 */
-				add_filter( "user_registration_post_login_errors", function( $err_msg ) use ($message) {
-					return apply_filters( 'login_errors', $message );
-				}, 10, 1 );
+
+				// Store error message in session for PRG pattern
+				if ( ! session_id() ) {
+					session_start();
+				}
+				$_SESSION['ur_login_error'] = apply_filters( 'login_errors', $message );
+
 				/**
 				 * Triggered when a user fails to log in during the user registration process.
 				 */
 				do_action( 'user_registration_login_failed' );
+
+				// Redirect to prevent form resubmission
+				$redirect_url = wp_get_raw_referer() ? wp_get_raw_referer() : ur_get_my_account_url();
+				wp_redirect( $redirect_url );
+				exit;
 			}
 		}
 	}

--- a/templates/myaccount/form-login.php
+++ b/templates/myaccount/form-login.php
@@ -83,7 +83,18 @@ do_action( 'user_registration_before_customer_login_form' );
  * @param function Print notice function.
  * @return function.
  */
-ur_add_notice( apply_filters( 'user_registration_post_login_errors', '' ), 'error' );
+
+// Check for session error message (PRG pattern)
+if ( ! session_id() ) {
+	session_start();
+}
+if ( isset( $_SESSION['ur_login_error'] ) ) {
+	ur_add_notice( $_SESSION['ur_login_error'], 'error' );
+	unset( $_SESSION['ur_login_error'] );
+} else {
+	ur_add_notice( apply_filters( 'user_registration_post_login_errors', '' ), 'error' );
+}
+
 if ( ! $is_passwordless_enabled || $is_passwordless_login_default_login_area_enabled ) {
 	ur_add_notice( apply_filters( 'user_registration_passwordless_login_notice', '' ), 'success' );
 }
@@ -144,7 +155,7 @@ apply_filters( 'user_registration_login_form_before_notice', ur_print_notices() 
 						}
 						?>
 						<span class="input-wrapper">
-						<input placeholder="<?php echo esc_attr( $placeholders['username'] ); ?>" type="text" class="user-registration-Input user-registration-Input--text input-text" name="username" id="username" value="<?php echo ( ! empty( $_POST['username'] ) ) ? esc_attr( wp_unslash( sanitize_text_field( $_POST['username'] ) ) ) : ''; // phpcs:ignore ?>" style="<?php echo ($enable_field_icon || $is_login_settings && is_plugin_active( 'user-registration-pro/user-registration.php' )) ? "padding-left: 32px !important" : '' ?>"/>
+						<input placeholder="<?php echo esc_attr( $placeholders['username'] ); ?>" type="text" class="user-registration-Input user-registration-Input--text input-text" name="username" id="username" value="" style="<?php echo ($enable_field_icon || $is_login_settings && is_plugin_active( 'user-registration-pro/user-registration.php' )) ? "padding-left: 32px !important" : '' ?>"/>
 						<?php if ( $enable_field_icon || $is_login_settings && is_plugin_active( 'user-registration-pro/user-registration.php' ) ) { ?>
 							<span class="ur-icon ur-icon-user">
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .
Previously : When a user submits a login form and gets an error (e.g., user is denied access), the browser keeps the form data in memory. If the user reloads the page, the browser shows a warning about resubmitting the form. If the user gets approved between the initial submission and the reload, the resubmitted form will succeed, which is a security issue.
This PR fixes this issue by preventing form resubmission using PHP session.
### How to test the changes in this Pull Request:

To test the fix:

1. Create a user account with "pending approval" status
2. Try to log in with the pending account
3. You should see an error message
4. Reload the page - you should not see a browser warning about form resubmission
5. The form should be empty and require manual re-entry of credentials
6. Approve the user account
7. Try logging in again with fresh credentials - it should work

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

>  Fix - Prevent login form resubmission on reload.
