### PR TITLE
UR 2708 - Enhance - Prevent deleting membership plan while users are assigned

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -3216,8 +3216,7 @@ body {
 		}
 
 		.swal2-popup {
-			width: 400px;
-
+			width: 500px;
 			&.user-registration-settings-swal2 {
 				width: auto;
 
@@ -3287,6 +3286,11 @@ body {
 						font-size: 16px;
 						font-weight: 600;
 					}
+				}
+				ul {
+					list-style: disc;
+					font-size: medium;
+					margin-left: 40px;
 				}
 			}
 

--- a/assets/css/modules/membership/user-registration-membership-admin.scss
+++ b/assets/css/modules/membership/user-registration-membership-admin.scss
@@ -472,7 +472,7 @@
 							}
 
 							&#action {
-								width: 160px;
+								width: 180px;
 							}
 						}
 					}

--- a/assets/js/modules/membership/admin/user-registration-membership-admin.js
+++ b/assets/js/modules/membership/admin/user-registration-membership-admin.js
@@ -833,7 +833,15 @@
 	$('.delete-membership').on('click', function (e) {
 		e.preventDefault();
 		e.stopPropagation();
-		var $this = $(this);
+
+		var $this = $(this),
+			$membership_id = $this.data('membership-id'),
+			parent = $this.closest('.delete');
+		if (parent.find('span').hasClass('is-active')) {
+			return;
+		}
+		ur_membership_utils.append_spinner(parent);
+
 		Swal.fire({
 			title:
 				'<img src="' +
@@ -849,7 +857,47 @@
 			allowOutsideClick: false
 		}).then(function (result) {
 			if (result.isConfirmed) {
-				$(location).attr('href', $this.attr('href'));
+				ur_membership_request_utils.send_data(
+					{
+						action: 'user_registration_membership_delete_membership',
+						membership_id: $membership_id
+					},
+					{
+						success: function (response) {
+							if (response.success) {
+								ur_membership_utils.show_success_message(
+									response.data.message
+								);
+								ur_membership_request_utils.remove_deleted_memberships($this, false);
+							} else {
+								Swal.fire({
+									title:
+										'<img src="' +
+										ur_membership_data.delete_icon +
+										'" id="delete-user-icon">' +
+										ur_membership_data.labels.i18n_prompt_title,
+									html: response.data.message,
+									confirmButtonText: ur_membership_data.labels.i18n_prompt_ok,
+									allowOutsideClick: false
+								});
+							}
+						},
+						failure: function (xhr, statusText) {
+							ur_membership_utils.show_failure_message(
+								ur_membership_data.labels.network_error +
+								'(' +
+								statusText +
+								')'
+							);
+						},
+						complete: function () {
+							ur_membership_utils.remove_spinner($this.closest('.delete'));
+							// window.location.reload(); //Todo: Can be removed after fixing checkbox error and adding no content image if empty for all delete on ajax
+						}
+					}
+				);
+			} else {
+				ur_membership_utils.remove_spinner($this.closest('.delete'));
 			}
 		});
 	});

--- a/modules/membership/includes/Admin/Membership/ListTable.php
+++ b/modules/membership/includes/Admin/Membership/ListTable.php
@@ -182,7 +182,7 @@ class ListTable extends \UR_List_Table {
 	public function column_action( $membership ) {
 
 		$edit_link          = $this->get_edit_links( $membership );
-		$delete_link        = $this->get_delete_links( $membership );
+//		$delete_link        = $this->get_delete_links( $membership );
 		$membership_content = json_decode( $membership->post_content, true );
 		$checked            = ( $membership_content['status'] == 'true' ) ? 'checked' : '';
 		$actions            = '
@@ -201,8 +201,8 @@ class ListTable extends \UR_List_Table {
 						<a href="' . esc_url( $edit_link ) . '">' . __( 'Edit', 'user-registration' ) . '</a>
 					</span>
 					&nbsp | &nbsp
-					<span class="delete">
-						<a class="delete-membership" aria-label="' . esc_attr__( 'Delete this item', 'user-registration' ) . '" href="' . $delete_link . '">' . esc_html__( 'Delete', 'user-registration' ) . '</a>
+					<span class="delete ur-d-flex ur-align-items-center">
+						<a class="delete-membership" data-membership-id="'.esc_attr($membership->ID).'"  aria-label="' . esc_attr__( 'Delete this item', 'user-registration' ) . '" href="#">' . esc_html__( 'Delete', 'user-registration' ) . '</a>
 					</span>
 					</div>
 
@@ -291,7 +291,7 @@ class ListTable extends \UR_List_Table {
 	 */
 	protected function get_bulk_actions() {
 		$actions = array(
-			'delete' => __( 'Delete permanently' )
+//			'delete' => __( 'Delete permanently' )
 		);
 
 		return $actions;

--- a/modules/membership/includes/Admin/Membership/Membership.php
+++ b/modules/membership/includes/Admin/Membership/Membership.php
@@ -135,13 +135,13 @@ class Membership {
 
 		switch ( $action ) {
 			case 'trash':
-				$this->bulk_trash( $delete_list );
+//				$this->bulk_trash( $delete_list );
 				break;
 			case 'untrash':
-				$this->bulk_untrash( $membership_list );
+//				$this->bulk_untrash( $membership_list );
 				break;
 			case 'delete':
-				$this->bulk_trash( $delete_list, true, $delete_membership );
+//				$this->bulk_trash( $delete_list, true, $delete_membership );
 				break;
 			default:
 				break;
@@ -453,9 +453,10 @@ class Membership {
 			'i18n_valid_trial_period_field_validation'     => _x( 'Trial period must be less than subscription period.', 'user registration membership', 'user-registration' ),
 			'i18n_error'                                   => _x( 'Error', 'user registration membership', 'user-registration' ),
 			'i18n_save'                                    => _x( 'Save', 'user registration membership', 'user-registration' ),
-			'i18n_prompt_title'                            => __( 'Delete Membership', 'user-registration' ),
+			'i18n_prompt_title'                            => __( 'Delete Membership Plan', 'user-registration' ),
 			'i18n_prompt_bulk_subtitle'                    => __( 'Are you sure you want to delete these memberships permanently?', 'user-registration' ),
 			'i18n_prompt_single_subtitle'                  => __( 'Are you sure you want to delete this membership permanently?', 'user-registration' ),
+			'i18n_prompt_ok'                               => __( 'Ok', 'user-registration' ),
 			'i18n_prompt_delete'                           => __( 'Delete', 'user-registration' ),
 			'i18n_prompt_cancel'                           => __( 'Cancel', 'user-registration' ),
 			'i18n_prompt_no_membership_selected'           => __( 'Please select at least one membership.', 'user-registration' ),

--- a/modules/membership/includes/Admin/Services/MembershipService.php
+++ b/modules/membership/includes/Admin/Services/MembershipService.php
@@ -183,7 +183,7 @@ class MembershipService {
 				),
 				'ur_membership_description' => array(
 					'meta_key'   => 'ur_membership_description',
-					'meta_value' => wp_kses_post($data['post_data']['description']),
+					'meta_value' => wp_kses_post( $data['post_data']['description'] ),
 				)
 			),
 
@@ -463,5 +463,36 @@ class MembershipService {
 		}
 
 		return array();
+	}
+
+	public function delete_membership( $membership_id ) {
+		$response                  = array(
+			'status' => true,
+		);
+		$valid_membership_statuses = apply_filters( "urm_valid_membership_statuses", array(
+				__( "active", "user-registration" ),
+				__( "pending", "user-registration" ),
+				__( "trial", "user-registration" )
+			)
+		);
+		$active_members            = $this->membership_repository->check_deletable_membership( $membership_id, $valid_membership_statuses );
+		if ( $active_members['total'] > 0 ) {
+			$html = "<p>" . __( "You cannot delete a membership plan if it has active users assigned to it with any of the following statuses:", "user-registration" ) . "</p>";
+			$html .= "<ul>";
+			foreach ( $valid_membership_statuses as $status ) {
+				$html .= "<li>" . ucfirst($status). "</li>";
+			}
+			$html .= "</ul >";
+			$html .= "<p >" . __( "To proceed, update all memberships to Expired or Cancelled, or assign users to a different plan . Once no active users remain, the plan can be deleted", "user-registration" ) . "</p > ";
+
+			$response = array(
+				'status'  => false,
+				'message' => $html
+			);
+		} else {
+			$this->membership_repository->delete( $membership_id );
+		}
+
+		return $response;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds functionality to prevent deletion of membership when users with pending, active and trial users are assigned to it.
PS: Membership with cancelled and expired members can be deleted.
Closes # .

### How to test the changes in this Pull Request:

1. Memberships > Delete 
2. See if the popup appears for memberships with members.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
