### PR TITLE
UR 2889 Fix - Registration successful email sent in before admin approval in membership form

### DIFF
--- a/modules/membership/includes/Admin/Services/EmailService.php
+++ b/modules/membership/includes/Admin/Services/EmailService.php
@@ -122,9 +122,11 @@ class EmailService
 		$subject     = \UR_Emailer::parse_smart_tags( $subject, $values );
 		$template_id = ur_get_single_post_meta( $form_id, 'user_registration_select_email_template' );
 
-		$headers = \UR_Emailer::ur_get_header();
+		$headers      = \UR_Emailer::ur_get_header();
+		$login_option = ur_get_user_login_option( $user_id );
+		$email_status = get_user_meta( $user_id, 'ur_confirm_email', true );
 
-		if ( ( ( 'default' === $login_option || 'auto_login' === $login_option || ur_string_to_bool( $email_status ) ) && ! $is_membership_form ) && ur_string_to_bool( get_option( 'user_registration_enable_successfully_registered_email', true ) ) ) {
+		if ( ( ( 'default' === $login_option || 'auto_login' === $login_option || ur_string_to_bool( $email_status ) ) && ur_string_to_bool( get_option( 'user_registration_enable_successfully_registered_email', true ) ) ) ) {
 			return \UR_Emailer::user_registration_process_and_send_email( sanitize_email( $data['email'] ), $subject, $message, $headers, array(), $template_id );
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

While enabling admin approval email for membership form, right after the user registration email successful email is sent even though user is not approved. This PR fixes this issue.

Closes # .

### How to test the changes in this Pull Request:

1. Create a membership Form
2. Make Admin approval as email option
3. Register the user and check the email received by user right after registration.

**Note:** Email approval and denial email is sent only if it is done from the admin panel this needs to be reviewed and capability is checked before sending the email.


### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Registration successful email sent in before admin approval in membership form.
