### PR TITLE
UR-2754 Enhance - Restore default email templates option.

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -7303,3 +7303,16 @@ body {
 		}
 	}
 }
+a.button.ur-reset-content-button {
+  border-color: #fa5252;
+  color: #fa5252;
+
+  &:hover,
+  &:focus,
+  &:active,
+  &:visited,
+  &:link {
+    border-color: #fa5252;
+    color: #fa5252;
+  }
+}

--- a/assets/js/admin/form-modal.js
+++ b/assets/js/admin/form-modal.js
@@ -14,6 +14,38 @@
 			$("#ur-modal-backdrop, #ur-modal-wrap").css("display", "block");
 			$(document.body).addClass("modal-open");
 		});
+
+		// Sweetalert modal popup on reset content clicked.
+		$(document).on('click', '.ur-reset-content-button', function (event) {
+			event.preventDefault();
+			Swal.fire({
+				title: 'Reset to Default',
+				text: 'Are you sure you want to reset the email content to the default?',
+				icon: 'warning',
+				showCancelButton: true,
+				cancelButtonColor: '#fafafa',
+				confirmButtonText: 'Yes, Reset',
+				cancelButtonText: 'Cancel',
+			}).then((result) => {
+				if (result.isConfirmed) {
+					var params = new URLSearchParams(window.location.search);
+					var section = params.get('section');
+					if (section) {
+						var selector = section.replace(/^ur_settings_/, 'user_registration_');
+						var editor = typeof tinymce !== "undefined" ? tinymce.get(selector) : null;
+						if (editor) {
+							editor.setContent(user_registration_form_modal_params[section + "_default_content"]);
+						} else {
+							var $textarea = $("textarea#" + selector);
+							if ($textarea.length) {
+								$textarea.val(user_registration_form_modal_params[section + "_default_content"]);
+							}
+						}
+					}
+				}
+			});
+		});
+
 		// Close modal on close or cancel links
 		$(document).on(
 			"click",

--- a/assets/js/admin/form-modal.js
+++ b/assets/js/admin/form-modal.js
@@ -34,11 +34,11 @@
 						var selector = section.replace(/^ur_settings_/, 'user_registration_');
 						var editor = typeof tinymce !== "undefined" ? tinymce.get(selector) : null;
 						if (editor) {
-							editor.setContent(user_registration_form_modal_params[section + "_default_content"]);
+							editor.setContent(user_registration_email_settings[section]);
 						} else {
 							var $textarea = $("textarea#" + selector);
 							if ($textarea.length) {
-								$textarea.val(user_registration_form_modal_params[section + "_default_content"]);
+								$textarea.val(user_registration_email_settings[section]);
 							}
 						}
 					}

--- a/includes/admin/class-ur-admin-assets.php
+++ b/includes/admin/class-ur-admin-assets.php
@@ -462,6 +462,21 @@ class UR_Admin_Assets {
 
 				)
 			);
+
+			// Only run this if we are on the email settings page.
+			if( is_admin() 
+				&& isset( $_GET[ 'tab' ] ) 
+				&& 'email' === $_GET['tab']  
+				&& isset( $_GET['section'] ) 
+				&& ! empty( $_GET['section'] ) 
+			) {
+				wp_localize_script(
+					'user-registration-form-modal-js',
+					'user_registration_form_modal_params',
+					$this->get_i18n_email_content_default_values(),
+				);
+			}
+
 			wp_enqueue_script( 'user-registration-form-modal-js' );
 			wp_enqueue_script( 'ur-enhanced-select' );
 		}
@@ -544,7 +559,22 @@ class UR_Admin_Assets {
 			false
 		);
 	}
-
+	/**
+	 * Get localized email content default values.
+	 */
+	public function get_i18n_email_content_default_values() {
+		$section = isset( $_GET['section'] ) ? $_GET[ 'section' ] : '';
+		$user_registration_form_modal_params = [];
+		$path = UR()->plugin_path() . '/includes/admin/settings/emails/class-' . strtolower( str_replace( '_', '-', $section ) ) . '.php';
+		if( is_file( $path ) ) {
+			$setting = include_once $path;
+			$method = property_exists( $setting, 'id' ) ? 'ur_get_' . $setting->id : '';
+			if( is_object( $setting ) && method_exists( $setting, $method ) ) {
+				$user_registration_form_modal_params[ $section . '_default_content' ] = $setting->$method();
+			}
+		}
+		return $user_registration_form_modal_params;
+	}
 	/**
 	 * Get Form Required HTML.
 	 *

--- a/includes/admin/class-ur-admin-assets.php
+++ b/includes/admin/class-ur-admin-assets.php
@@ -565,6 +565,7 @@ class UR_Admin_Assets {
 	public function get_i18n_email_content_default_values() {
 		$section = isset( $_GET['section'] ) ? $_GET[ 'section' ] : '';
 		$user_registration_form_modal_params = [];
+
 		$path = UR()->plugin_path() . '/includes/admin/settings/emails/class-' . strtolower( str_replace( '_', '-', $section ) ) . '.php';
 		if( is_file( $path ) ) {
 			$setting = include_once $path;

--- a/includes/admin/class-ur-admin-form-modal.php
+++ b/includes/admin/class-ur-admin-form-modal.php
@@ -69,6 +69,12 @@ if ( ! class_exists( 'UR_Admin_Form_Modal', false ) ) :
 				wp_kses_post( $icon ),
 				esc_html__( 'Add Registration Form', 'user-registration' )
 			);
+			printf(
+				'<a href="#" class="button ur-reset-content-button" data-editor="%s" title="%s">%s</a>',
+				esc_attr( $editor_id ),
+				esc_attr__( 'Reset email content', 'user-registration' ),
+				esc_html__( 'Reset Content', 'user-registration' )
+			);
 
 			/**
 			 * Action Hook for Smart Tags List

--- a/includes/admin/settings/class-ur-settings-email.php
+++ b/includes/admin/settings/class-ur-settings-email.php
@@ -54,6 +54,22 @@ if ( ! class_exists( 'UR_Settings_Email' ) ) :
 				'email_notification_setting'
 			), 10, 2 );
 			$this->initialize_email_classes();
+
+			$email_content_default_values = [];
+			foreach( $this->emails as $key => $email) {
+				$method_name = 'ur_get_' . $email->id;
+				//for membership, the naming convention is different.
+				if( ! method_exists( $email, $method_name ) ) {
+					$method_name = 'user_registration_get_' . $email->id;
+				}
+				$key = strtolower( $key );
+				$email_content_default_values[ $key ] = method_exists($email, $method_name) ? $email->$method_name() : '';
+			}
+			wp_localize_script(
+				'user-registration-settings',
+				'user_registration_email_settings',
+				$email_content_default_values,
+			);
 		}
 
 		/**

--- a/modules/membership/includes/Emails/Admin/UR_Settings_Membership_Cancellation_Admin_Email.php
+++ b/modules/membership/includes/Emails/Admin/UR_Settings_Membership_Cancellation_Admin_Email.php
@@ -92,7 +92,7 @@ class UR_Settings_Membership_Cancellation_Admin_Email {
 							array(
 								'title'    => __( 'Email Content', 'user-registration' ),
 								'desc'     => __( 'Customize the content of the membership cancellation email to admin.', 'user-registration' ),
-								'id'       => 'user_registration_membership_cancellation_admin_email_message',
+								'id'       => 'user_registration_membership_cancellation_admin_email',
 								'type'     => 'tinymce',
 								'default'  => $this->user_registration_get_membership_cancellation_admin_email(),
 								'css'      => 'min-width: 350px;',

--- a/modules/membership/includes/Emails/User/UR_Settings_Membership_Cancellation_User_Email.php
+++ b/modules/membership/includes/Emails/User/UR_Settings_Membership_Cancellation_User_Email.php
@@ -92,7 +92,7 @@ class UR_Settings_Membership_Cancellation_User_Email {
 							array(
 								'title'    => __( 'Email Content', 'user-registration' ),
 								'desc'     => __( 'Customize the content of the membership cancellation email to admin.', 'user-registration' ),
-								'id'       => 'user_registration_membership_cancellation_user_email_message',
+								'id'       => 'user_registration_membership_cancellation_user_email',
 								'type'     => 'tinymce',
 								'default'  => $this->user_registration_get_membership_cancellation_user_email(),
 								'css'      => 'min-width: 350px;',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Added a "Reset Content" button to the email settings WYSIWYG interface, allowing users to revert email content to the default value provided by the URM plugin. This helps users quickly restore default messages without manually copying if needed.

Closes #<!-- issue number here, if applicable -->

### How to test the changes in this Pull Request:

1. Navigate to the **URM > Settings > Emails** section in the plugin.
2. Configure an email option.
3. Change the email content for the email options.
4. Click the **Reset Content** button.
5. Confirm the SweetAlert prompt.
6. Verify that the email content is reverted to the default.
### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Added a reset content button in email settings to reset content to default value.
