### PR TITLE
UR-2717 Fix - Error message displayed while creating member.

### DIFF
--- a/modules/membership/includes/Admin/Members/Members.php
+++ b/modules/membership/includes/Admin/Members/Members.php
@@ -147,6 +147,7 @@ if ( ! class_exists( 'Members' ) ) {
 		public function get_i18_labels() {
 			return array(
 				'network_error'                                 => esc_html__( 'Network error', 'user-registration' ),
+				'i18n_error'									=> __( 'Error', 'user-registration' ),
 				'i18n_field_is_required'                        => _x( 'field is required.', 'user registration membership', 'user-registration' ),
 				'i18n_field_email_field_validation'             => _x( 'Please enter a valid email address.', 'user registration membership', 'user-registration' ),
 				'i18n_field_password_field_validation'          => _x( 'Password does not match with confirm password.', 'user registration membership', 'user-registration' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

---

### Changes proposed in this Pull Request:

This PR fixes an issue where an undefined error message appears while creating a member. The change ensures that only defined and meaningful messages are displayed to the user.

Closes #<!-- issue number here if any -->

---

### How to test the changes in this Pull Request:

1. Go to the URM > Membership > Members.
2. Attempt to create a member with invalid or incomplete data.
3. Verify that no “undefined” error message is shown, and only valid error messages shown.

---

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

---

### Changelog entry

> Fix – Remove “undefined” error message displayed during member creation.
