### PR TITLE
UR-2896 Tweak - Display membership plan in profile detail for frontend listing

### DIFF
--- a/includes/admin/class-ur-admin-profile.php
+++ b/includes/admin/class-ur-admin-profile.php
@@ -72,9 +72,9 @@ if ( ! class_exists( 'UR_Admin_Profile', false ) ) :
 					if ( isset( $value['field_key'] ) && 'signature' === $value['field_key'] && isset( $_GET['user_id'] ) ) {
 						unset( $form_fields[ $key ] );
 					}
-					if ( isset( $value['field_key'] ) && 'membership' === $value['field_key'] && isset( $_GET['user_id'] ) ) {
-						unset( $form_fields[ $key ] );
-					}
+					// if ( isset( $value['field_key'] ) && 'membership' === $value['field_key'] && isset( $_GET['user_id'] ) ) {
+					// 	unset( $form_fields[ $key ] );
+					// }
 
 					if ( array_key_exists( $key, $all_meta_for_user ) ) {
 						if ( isset( $value['field_key'], $value['choices'] ) && 'checkbox' === $value['field_key'] && empty( $value['choices'] ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

While using the membership field and selecting it in the frontend listing it was not displaying in the profile detail for frontend list. This PR displays the membership plan in profile details page.

Closes # .

### How to test the changes in this Pull Request:

1. Create a form using membership field and create a frontend list select membership field for profile listing and profile detail for frontend listing
2. Check whether the membership is displayed or not.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Display membership plan in profile detail for frontend listing.
