### PR TITLE
UR-2818 Fix - Inconsistent gaping in registration form fields advanced options

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -3736,7 +3736,7 @@ a.button.ur-smart-tags-list-button {
 		.ur-tab-contents {
 			#ur-setting-form {
 				.ur-general-setting-block {
-					margin-bottom: $spacing_36px;
+					// margin-bottom: $spacing_36px;
 
 					&:has(.closed) {
 						margin-bottom: 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

There was more gap in fields's advanced option. This PR fixes this gaping issue.

Closes # .

### How to test the changes in this Pull Request:

1. Create or go to form
2. Click on Form field and check the gapping between General Settings and Advanced Setting whether there is additional gap or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry
> Fix - Inconsistent gaping in registration form fields advanced options.