### PR TITLE
UR-2822 Fix - Override global setting retain in page reload

### DIFF
--- a/assets/js/modules/content-restriction/admin/urcr-custom.js
+++ b/assets/js/modules/content-restriction/admin/urcr-custom.js
@@ -46,7 +46,8 @@ jQuery(document).ready(function () {
 	$allowTo.on('change', toggleFieldsBasedOnAllowTo);
 
 	// Initial Setup on Page Load
-	jQuery(window).on('load', toggleGlobalOverride);
+	// jQuery(window).on('load', toggleGlobalOverride);
+	toggleGlobalOverride();
 
 	// Content Restriction Section
 	var $allowAccessTo = jQuery('#user_registration_content_restriction_allow_access_to');


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In the page if override global setting is enabled then in the page reload the setting under override global setting is not displayed. This PR fixes this issue.

Closes # .

### How to test the changes in this Pull Request:

1. Go to page
2. Enable override global setting and save the page
3. Reload the page and check if the settings under override global settings is displayed or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Override global setting retain in page reload.
