### PR TITLE
Fix membership field locked even when payment method is not enabled.

### DIFF
--- a/assets/js/admin/form-builder.js
+++ b/assets/js/admin/form-builder.js
@@ -2861,7 +2861,7 @@
 								});
 								// Disable membership field from dragging when payment setting is enabled already.
 								var $checkboxes = $(
-									"input[name^='user_registration_enable_']"
+									"[data-field-group='payments'] input[name^='user_registration_enable_']"
 								);
 								if ($checkboxes.is(":checked")) {
 									// disable membership field.

--- a/assets/js/modules/membership/admin/membership-groups.js
+++ b/assets/js/modules/membership/admin/membership-groups.js
@@ -213,7 +213,7 @@
 				}
 			});
 			$(document).on('change', '[data-field-group="payments"] input[name^="user_registration_enable_"]', function () {
-				var $checkboxes = $("input[name^='user_registration_enable_']");
+				var $checkboxes = $("[data-field-group='payments'] input[name^='user_registration_enable_']");
 				if( $checkboxes.is(':checked')) {
 					// disable membership field.
 					$membershipField = $(".ur-registered-list").find("li[data-field-id='user_registration_membership']");


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixes the bug which is replicated as follows:
* Enable form title and description from **Form settings > General** while disabling all the payment methods, notice the membership field is locked saying it cannot be used alongside the payment fields.
Closes # .
### How to test the changes in this Pull Request:

1. Confirm the bug mentioned above is not replicated with this changes.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Membership locked even when payment method is not enabled.
