### PR TITLE
UR-2907 Tweak - Made membership toggle html structure same as other options

### DIFF
--- a/assets/js/modules/membership/admin/user-registration-membership-admin.js
+++ b/assets/js/modules/membership/admin/user-registration-membership-admin.js
@@ -565,57 +565,41 @@
 		},
 
 		update_membership_status: function ($this) {
-			ur_membership_utils.prepend_spinner($this.parents('.row-actions'));
-			$this.attr('disabled', true);
-			var status = $this.prop('checked'),
+			ur_membership_utils.prepend_spinner($this.closest('.row-actions'));
+			$this.prop('disabled', true);
+
+			var status = $this.is(':checked'),
 				ID = $this.data('ur-membership-id');
+
 			this.send_data(
 				{
 					action: 'user_registration_membership_update_membership_status',
 					membership_data: JSON.stringify({
-						'status': status,
-						'ID': ID
+						status: status,
+						ID: ID
 					})
 				},
 				{
 					success: function (response) {
 						if (response.success) {
-							ur_membership_utils.show_success_message(
-								response.data.message
-							);
+							ur_membership_utils.show_success_message(response.data.message);
 						} else {
-							ur_membership_utils.show_failure_message(
-								response.data.message
-							);
+							ur_membership_utils.show_failure_message(response.data.message);
+							$this.prop('checked', !status);
 						}
 					},
-					failure: function (xhr, statusText) {
-						ur_membership_utils.show_failure_message(
-							ur_membership_data.labels.network_error +
-							'(' +
-							statusText +
-							')'
-						);
+					failure: function () {
+						ur_membership_utils.show_failure_message(ur_membership_data.labels.network_error);
+						$this.prop('checked', !status);
 					},
 					complete: function () {
-						//update UI after successful update
-						ur_membership_utils.remove_spinner($this.parents('.row-actions'));
-						$this.attr('disabled', false);
-						var state = status ? 'Active' : 'Inactive',
-							status_span = $('#ur-membership-list-status-' + ID);
-						status_span.text(state);
-						if (state === 'Inactive') {
-							status_span.removeClass('user-registration-badge--success-subtle');
-							status_span.addClass('user-registration-badge--secondary-subtle');
-						} else {
-							status_span.removeClass('user-registration-badge--secondary-subtle');
-							status_span.addClass('user-registration-badge--success-subtle');
-						}
-
+						ur_membership_utils.remove_spinner($this.closest('.row-actions'));
+						$this.prop('disabled', false);
 					}
 				}
 			);
 		},
+
 
 		validate_payment_gateway: function ($this) {
 

--- a/modules/membership/includes/Admin/Membership/ListTable.php
+++ b/modules/membership/includes/Admin/Membership/ListTable.php
@@ -186,28 +186,32 @@ class ListTable extends \UR_List_Table {
 		$membership_content = json_decode( $membership->post_content, true );
 		$checked            = ( $membership_content['status'] == 'true' ) ? 'checked' : '';
 		$actions            = '
-				<div class="row-actions ur-d-flex ur-align-items-center visible" style="gap: 5px">
+			<div class="row-actions ur-d-flex ur-align-items-center visible" style="gap: 5px">
 
-					<div class="user-registration-switch">
+				<div class="ur-toggle-section">
+					<span class="user-registration-toggle-form">
 						<input
-						 		type="checkbox"
-						 		' . $checked . '
-							   	class="ur-membership-change-status user-registration-switch__control hide-show-check enabled"
-							   	data-ur-membership-id = ' . $membership->ID . '
+							type="checkbox"
+							name="ur_membership_change_status"
+							' . $checked . '
+							class="ur-membership-change-status hide-show-check enabled"
+							data-ur-membership-id="' . esc_attr( $membership->ID ) . '"
 						>
-					</div>
-					&nbsp | &nbsp
-					<span class="edit">
-						<a href="' . esc_url( $edit_link ) . '">' . __( 'Edit', 'user-registration' ) . '</a>
+						<span class="slider round"></span>
 					</span>
-					&nbsp | &nbsp
-					<span class="delete">
-						<a class="delete-membership" aria-label="' . esc_attr__( 'Delete this item', 'user-registration' ) . '" href="' . $delete_link . '">' . esc_html__( 'Delete', 'user-registration' ) . '</a>
-					</span>
-					</div>
+				</div>
 
-					';
+				&nbsp; | &nbsp;
+				<span class="edit">
+					<a href="' . esc_url( $edit_link ) . '">' . __( 'Edit', 'user-registration' ) . '</a>
+				</span>
+				&nbsp; | &nbsp;
+				<span class="delete">
+					<a class="delete-membership" aria-label="' . esc_attr__( 'Delete this item', 'user-registration' ) . '" href="' . esc_url( $delete_link ) . '">' . esc_html__( 'Delete', 'user-registration' ) . '</a>
+				</span>
 
+			</div>
+		';
 		return $actions;
 	}
 
@@ -224,7 +228,7 @@ class ListTable extends \UR_List_Table {
 						<?php esc_html_e( 'All Membership', 'user-registration' ); ?>
 					</h1>
 					<a href="<?php echo esc_url( admin_url( 'admin.php?page=' . $this->page . '&action=add_new_membership' ) ); ?>"
-					   class="button ur-button-primary">
+						class="button ur-button-primary">
 						+
 						<?php
 						echo __( 'Create new Membership', 'user-registration' )
@@ -266,14 +270,14 @@ class ListTable extends \UR_List_Table {
 			</p>
 			<div>
 				<input type="search" id="<?php echo $search_id; ?>" name="s"
-					   value="<?php echo esc_attr( $_GET['s'] ?? '' ); ?>"
-					   placeholder="<?php echo esc_attr( 'Search Membership', ' user-registration' ); ?> ..."
-					   autocomplete="off">
+						value="<?php echo esc_attr( $_GET['s'] ?? '' ); ?>"
+						placeholder="<?php echo esc_attr( 'Search Membership', ' user-registration' ); ?> ..."
+						autocomplete="off">
 				<button type="submit" id="search-submit">
 					<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
 						<path fill="#000" fill-rule="evenodd"
-							  d="M4 11a7 7 0 1 1 12.042 4.856 1.012 1.012 0 0 0-.186.186A7 7 0 0 1 4 11Zm12.618 7.032a9 9 0 1 1 1.414-1.414l3.675 3.675a1 1 0 0 1-1.414 1.414l-3.675-3.675Z"
-							  clip-rule="evenodd"></path>
+								d="M4 11a7 7 0 1 1 12.042 4.856 1.012 1.012 0 0 0-.186.186A7 7 0 0 1 4 11Zm12.618 7.032a9 9 0 1 1 1.414-1.414l3.675 3.675a1 1 0 0 1-1.414 1.414l-3.675-3.675Z"
+								clip-rule="evenodd"></path>
 					</svg>
 				</button>
 			</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR makes the consistency in the toggle of membership with other options' toggle.

Closes # .

### How to test the changes in this Pull Request:

1. Go to Membership > Check the toggle HTML structure
2. Check if the toggle HTML is same as other or not.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Made membership toggle html structure same as other options.