### PR TITLE
UR-2661 Feature - Manually add payment.

### DIFF
--- a/assets/css/modules/payment-history/user-registration-payment-history.css
+++ b/assets/css/modules/payment-history/user-registration-payment-history.css
@@ -17,6 +17,11 @@
   justify-content: center;
   align-items: center;
 }
+.payment-status-btn.refunded {
+	border: 1px solid #6C8CA1;
+	border-radius: 3px;
+	background-color: #f4f4ff;
+}
 
 .modal-content {
   background-color: #fefefe;

--- a/assets/css/modules/payment-history/user-registration-payment-history.scss
+++ b/assets/css/modules/payment-history/user-registration-payment-history.scss
@@ -83,6 +83,11 @@ $background-color_2: #fefefe;
 	border-radius: 3px;
 	background: #fff4f4;
 }
+.payment-status-btn.refunded {
+	border: 1px solid #6C8CA1;
+	border-radius: 3px;
+	background-color: #f4f4ff;
+}
 .no-items {
 	td {
 		background: white;

--- a/assets/js/modules/membership/admin/payment-history.js
+++ b/assets/js/modules/membership/admin/payment-history.js
@@ -470,9 +470,8 @@
 				const $submitButton = $('.ur-add-new-payment');
 				$submitButton.prop('disabled', true).prepend('<span class="ur-spinner"></span>');
 
-				// Prepare form data
 				const formData = {
-					ur_member: $('#ur-input-type-member').val(),
+					ur_member_id: $('#ur-input-type-member').val(),
 					ur_membership_plan: $('#ur-input-type-membership-plan').val(),
 					ur_membership_amount: $('#ur-input-type-membership-amount').val(),
 					ur_payment_date: $('#ur-input-type-payment-date').val(),
@@ -489,15 +488,19 @@
 					},
 					success: function(response) {
 						if (response.success) {
-							// Show success message
+							$submitButton.prop('disabled', false).find('.ur-spinner').remove();
+
 							handle_orders_utils.show_success_message(response.data.message || 'Payment created successfully');
-							window.location.href = urmo_data.payment_history_url;
+							setTimeout(
+								function() {
+								window.location.href = urmo_data.payment_history_url;
+							}, 1000);
 						} else {
 							handle_orders_utils.show_failure_message(response.data.message || 'Error creating payment', 'error');
 							$submitButton.prop('disabled', false).find('.ur-spinner').remove();
 						}
 					},
-					error: function(xhr, status, error) {
+					error: function() {
 						handle_orders_utils.show_failure_message('Server error occurred. Please try again.', 'error');
 						$submitButton.prop('disabled', false).find('.ur-spinner').remove();
 					}
@@ -507,7 +510,7 @@
 			$('#ur-input-type-membership-plan').on('change', function() {
 				const selectedOption = $(this).find('option:selected');
 				const amount = selectedOption.data('amount');
-				
+
 				if (amount) {
 					$('#ur-input-type-membership-amount').val(amount);
 					$('#ur-input-type-membership-amount').prop('disabled', false);

--- a/modules/membership/includes/AJAX.php
+++ b/modules/membership/includes/AJAX.php
@@ -16,6 +16,7 @@ use WPEverest\URMembership\Admin\Controllers\MembersController;
 use WPEverest\URMembership\Admin\Repositories\MembershipRepository;
 use WPEverest\URMembership\Admin\Repositories\MembersOrderRepository;
 use WPEverest\URMembership\Admin\Repositories\MembersRepository;
+use WPEverest\URMembership\Admin\Repositories\MembersSubscriptionRepository;
 use WPEverest\URMembership\Admin\Repositories\OrdersRepository;
 use WPEverest\URMembership\Admin\Repositories\SubscriptionRepository;
 use WPEverest\URMembership\Admin\Services\CouponService;
@@ -26,6 +27,7 @@ use WPEverest\URMembership\Admin\Services\MembersService;
 use WPEverest\URMembership\Admin\Services\PaymentService;
 use WPEverest\URMembership\Admin\Services\Stripe\StripeService;
 use WPEverest\URMembership\Admin\Services\SubscriptionService;
+use WPEverest\URMembership\Admin\Services\OrderService;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -69,6 +71,7 @@ class AJAX {
 			'verify_pages'                 => false,
 			'validate_pg'                  => false,
 			'upgrade_membership'           => false,
+			'create_membership_order'      => false,
 		);
 		foreach ( $ajax_events as $ajax_event => $nopriv ) {
 			add_action( 'wp_ajax_user_registration_membership_' . $ajax_event, array( __CLASS__, $ajax_event ) );
@@ -190,6 +193,68 @@ class AJAX {
 			);
 		}
 	}
+
+	/**
+	 * Create membership orders from backend.
+	 */
+	public static function create_membership_order() {
+		if( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error(
+				array(
+					'message' => __( 'Sorry, you do not have permission to create membership order', 'user-registration' ),
+				)
+			);
+		}
+
+		ur_membership_verify_nonce( 'ur_membership_order' );
+
+		$order_data = isset( $_POST['order_data'] ) ? (array) json_decode( wp_unslash( $_POST['order_data'] ), true ) : array();
+
+		$order_data = array(
+			'user_id' => absint( $order_data[ 'ur_member_id' ] ),
+			'item_id' => absint( $order_data[ 'ur_membership_plan' ] ),
+			'total_amount'  => floatval( $order_data[ 'ur_membership_amount' ] ),
+			'status'  => sanitize_text_field( $order_data[ 'ur_transaction_status' ] ),
+			'payment_method' => 'manual',
+			'created_by' => get_current_user_id(),
+			'created_at' => date( 'Y-m-d H:i:s', strtotime( $order_data[ 'ur_payment_date' ] ) ),
+		);
+		$subscription_data = array(
+
+		);
+		$members_order_repository = new OrdersRepository();
+		$subscription_repository = new SubscriptionRepository();
+		try {
+			$subscription = $subscription_repository->create(
+				$subscription_data
+			);
+			$order = $members_order_repository->create( array(
+				'orders_data' => $order_data
+			) );
+		} catch( \Exception $e ) {
+			wp_send_json_error(
+				array(
+					'message' => __( sprintf( '%s', $e->getMessage() ), 'user-registration' ),
+				)
+			);
+		}
+
+		if( false === $order ) {
+			wp_send_json_error(
+				array(
+					'message' => __( 'Failed to create order.', 'user-registration' ),
+				)
+			);
+		} else {
+			wp_send_json_success(
+				array(
+					'data' => $order,
+					'message' => __( 'Order created succcessfully.', 'user-registration' ),
+				)
+			);
+		}
+	}
+
 
 	/**
 	 * Create membership from backend

--- a/modules/membership/includes/Admin/Members/Members.php
+++ b/modules/membership/includes/Admin/Members/Members.php
@@ -285,7 +285,6 @@ if ( ! class_exists( 'Members' ) ) {
 			$members_list_table = new MembersListTable();
 			$roles              = $members_list_table->get_roles();
 			$memberships        = $members_list_table->get_all_memberships();
-			include __DIR__ . '/../Views/member-create.php';
 		}
 
 		/**

--- a/modules/membership/includes/Admin/Repositories/MembersOrderRepository.php
+++ b/modules/membership/includes/Admin/Repositories/MembersOrderRepository.php
@@ -2,6 +2,7 @@
 
 namespace WPEverest\URMembership\Admin\Repositories;
 
+use DateTime;
 use WPEverest\URMembership\Admin\Interfaces\MembersInterface;
 use WPEverest\URMembership\Admin\Interfaces\MembersOrderInterface;
 use WPEverest\URMembership\TableList;
@@ -70,6 +71,29 @@ class MembersOrderRepository extends BaseRepository implements MembersOrderInter
 		}
 
 		return $deleted !== false && $deleted > 0;
+	}
+
+	public function create_member_order( $order_data ) {
+		$data = array(
+			'user_id' => absint( $order_data[ 'ur_member_id' ] ),
+			'item_id' => absint( $order_data[ 'ur_membership_plan' ] ),
+			'total_amount'  => floatval( $order_data[ 'ur_membership_amount' ] ),
+			'status'  => sanitize_text_field( $order_data[ 'ur_transaction_status' ] ),
+			'payment_method' => 'manual',
+			'created_by' => get_current_user_id(),
+			'created_at' => date( 'Y-m-d H:i:s', strtotime( $order_data[ 'ur_payment_date' ] ) ),
+		);
+
+		$inserted = $this->wpdb()->insert(
+			$this->table,
+			$data,
+			array('%d', '%d', '%f', '%s', '%s', '%d', '%s'),
+		);
+		if( $inserted ) {
+			$order_id = $this->wpdb()->insert_id;
+			return $order_id;
+		}
+		return false;
 	}
 
 }

--- a/modules/membership/includes/Admin/Repositories/OrdersRepository.php
+++ b/modules/membership/includes/Admin/Repositories/OrdersRepository.php
@@ -143,6 +143,19 @@ class OrdersRepository extends BaseRepository implements OrdersInterface {
 			ARRAY_A
 		);
 
+		$orders_meta_table = TableList::order_meta_table();
+		$payment_date = $this->wpdb()->get_var(
+			$this->wpdb()->prepare(
+				"SELECT meta_value FROM {$orders_meta_table} WHERE meta_key=%s AND order_id=%d LIMIT 1",
+				'payment_date',
+				$order_id
+			)
+		);
+
+		if( ! empty( $payment_date ) ) {
+			$result[ 'created_at' ] = $payment_date;
+		}
+
 		return ! $result ? array() : $result;
 	}
 

--- a/modules/membership/includes/Admin/Views/member-create.php
+++ b/modules/membership/includes/Admin/Views/member-create.php
@@ -61,7 +61,7 @@ $return_url = admin_url( 'admin.php?page=user-registration-members' );
 								</div>
 							</div>
 						</div>
-						<!--						username-->
+						<!--username-->
 						<div class="ur-membership-input-container ur-d-flex ur-p-3" style="gap:20px;">
 							<div class="ur-label" style="width: 30%">
 								<label
@@ -101,7 +101,7 @@ $return_url = admin_url( 'admin.php?page=user-registration-members' );
 								</div>
 							</div>
 						</div>
-						<!--						password-->
+						<!-- password -->
 						<div class="ur-membership-input-container ur-d-flex ur-p-3" style="gap:20px;">
 							<div class="ur-label" style="width: 30%">
 								<label
@@ -169,24 +169,6 @@ $return_url = admin_url( 'admin.php?page=user-registration-members' );
 								</div>
 							</div>
 						</div>
-						<!--						status-->
-<!--						<div class="ur-membership-input-container ur-d-flex ur-p-3" style="gap:20px">-->
-<!--							<div class="ur-label" style="width: 30%">-->
-<!--								<label class="ur-membership-enable-status"-->
-<!--									   for="ur-membership-status">--><?php //esc_html_e( 'Member Status', 'user-registration' ); ?><!--</label>-->
-<!--							</div>-->
-<!--							<div class="user-registration-switch ur-ml-auto" style="width: 100%">-->
-<!---->
-<!--								<input-->
-<!--									data-key-name="--><?php //echo esc_html__( 'member_status', 'user-registration' ); ?><!--"-->
-<!--									id="ur-membership-status" type="checkbox"-->
-<!--									class="user-registration-switch__control hide-show-check enabled ur-membership-members-input"-->
-<!--									--><?php //echo esc_attr( isset( $membership_content ) && $membership_content['status'] == 'true' ? 'checked' : '' ); ?>
-<!--									name="ur_membership_status"-->
-<!--									style="width: 100%; text-align: left">-->
-<!--							</div>-->
-<!---->
-<!--						</div>-->
 					</div>
 				</div>
 				<div id="ur-member-form-right" class="ur-p-4">

--- a/modules/payment-history/AJAX.php
+++ b/modules/payment-history/AJAX.php
@@ -39,10 +39,11 @@ class AJAX {
 	public static function add_ajax_events() {
 
 		$ajax_events = array(
-			'delete_orders'     => false,
-			'delete_order'      => false,
-			'show_order_detail' => false,
-			'approve_payment'   => false,
+			'delete_orders'             => false,
+			'delete_order'              => false,
+			'show_order_detail'         => false,
+			'approve_payment'           => false,
+			'create_membership_order'   => false,
 		);
 		foreach ( $ajax_events as $ajax_event => $nopriv ) {
 			add_action( 'wp_ajax_user_registration_membership_' . $ajax_event, array( __CLASS__, $ajax_event ) );
@@ -214,4 +215,68 @@ class AJAX {
 			wp_json_encode( $response )
 		);
 	}
+	/**
+	 * Create membership orders from backend.
+	 */
+	public static function create_membership_order() {
+		if( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error(
+				array(
+					'message' => __( 'Sorry, you do not have permission to create membership order', 'user-registration' ),
+				)
+			);
+		}
+
+		ur_membership_verify_nonce( 'ur_membership_order' );
+
+		$order_data = isset( $_POST['order_data'] ) ? (array) json_decode( wp_unslash( $_POST['order_data'] ), true ) : array();
+
+		$order_data = array(
+			'user_id' => absint( $order_data[ 'ur_member_id' ] ),
+			'item_id' => absint( $order_data[ 'ur_membership_plan' ] ),
+			'total_amount'  => floatval( $order_data[ 'ur_membership_amount' ] ),
+			'status'  => sanitize_text_field( $order_data[ 'ur_transaction_status' ] ),
+			'payment_method' => 'manual',
+			'created_by' => get_current_user_id(),
+			'created_at' => date( 'Y-m-d H:i:s', strtotime( $order_data[ 'ur_payment_date' ] ) ),
+		);
+		$subscription_data = array(
+			'user_id' => absint( $order_data[ 'ur_member_id' ] ),
+			'item_id' => absint( $order_data[ 'ur_membership_plan' ] ),
+			'start_date' => date( 'Y-m-d H:i:s', strtotime( $order_data[ 'ur_payment_date' ] ) ),
+			'billing_amount' => floatval( $order_data[ 'ur_membership_amount' ] ),
+		);
+		$members_order_repository = new OrdersRepository();
+		$subscription_repository = new SubscriptionRepository();
+		try {
+			$subscription = $subscription_repository->create(
+				$subscription_data
+			);
+			$order = $members_order_repository->create( array(
+				'orders_data' => $order_data
+			) );
+		} catch( \Exception $e ) {
+			wp_send_json_error(
+				array(
+					'message' => __( sprintf( '%s', $e->getMessage() ), 'user-registration' ),
+				)
+			);
+		}
+
+		if( false === $order ) {
+			wp_send_json_error(
+				array(
+					'message' => __( 'Failed to create order.', 'user-registration' ),
+				)
+			);
+		} else {
+			wp_send_json_success(
+				array(
+					'data' => $order,
+					'message' => __( 'Order created succcessfully.', 'user-registration' ),
+				)
+			);
+		}
+	}
+
 }

--- a/modules/payment-history/Admin/OrderService.php
+++ b/modules/payment-history/Admin/OrderService.php
@@ -103,6 +103,7 @@ class OrderService {
 				'message' => __( 'Order detail not found', 'user-registration' ),
 			);
 		}
+		
 
 		include __DIR__ . '/../Views/payment-details.php';
 		$html = ob_get_clean();

--- a/modules/payment-history/Admin/OrdersListTable.php
+++ b/modules/payment-history/Admin/OrdersListTable.php
@@ -311,6 +311,20 @@ class OrdersListTable extends \UR_List_Table {
 					';
 	}
 
+	public function column_created_at( $item ) {
+		global $wpdb;
+		$orders_meta_table = TableList::order_meta_table();
+		$payment_date = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT meta_value FROM {$orders_meta_table} WHERE meta_key=%s AND order_id=%d LIMIT 1",
+				'payment_date',
+				$item[ 'order_id' ]
+			)
+		);
+		$payment_date = ! empty( $payment_date ) ? $payment_date : $item[ 'created_at' ];
+		return (new \DateTime( $payment_date ) )->format( 'F j, Y' );
+	}
+
 	/**
 	 * Render the list table page, including header, notices, status filters and table.
 	 */

--- a/modules/payment-history/Orders.php
+++ b/modules/payment-history/Orders.php
@@ -202,14 +202,19 @@ class Orders {
 		<?php
 	}
 	public function render_add_new_payment_history() {
-		$roles = ur_get_all_roles();
-		$memberships = new MembershipService();
-		$membership_plans = $memberships->list_active_memberships();
-		
-		include __DIR__ . '/Views/orders-create.php';
-	}
-	public function get_all_membership_plan() {
+		global $wpdb;
+		$subscription_table = \WPEverest\URMembership\TableList::subscriptions_table();
+		$users = $wpdb->get_results(
+			"
+						SELECT s.user_id, u.user_login, u.user_email
+						FROM $subscription_table AS s
+						INNER JOIN {$wpdb->users} AS u
+							ON s.user_id = u.ID
+						",
+			ARRAY_A
+		);
 
+		include __DIR__ . '/Views/orders-create.php';
 	}
 	/**
 	 * render_payment_history_list
@@ -328,6 +333,7 @@ class Orders {
 				'memberships'         => $memberships,
 				'delete_icon'         => plugins_url( 'assets/images/users/delete-user-red.svg', UR_PLUGIN_FILE ),
 				'add_manual_payment_url' => admin_url( 'admin.php?page=member-payment-history&action=add_new_payment' ),
+				'payment_history_url' => admin_url( 'admin.php?page=member-payment-history' ),
 			)
 		);
 	}

--- a/modules/payment-history/Orders.php
+++ b/modules/payment-history/Orders.php
@@ -3,6 +3,8 @@
 namespace WPEverest\URMembership\Payment;
 
 use WPEverest\URMembership\Payment\Admin\OrdersListTable;
+use WPEverest\URMembership\Admin\Services\MembershipService;
+
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -137,6 +139,7 @@ class Orders {
 
 		switch ( $action ) {
 			case 'add_new_payment':
+				$this->render_add_new_payment_history();
 				break;
 			default:
 				$this->render_payment_history_list();
@@ -144,6 +147,70 @@ class Orders {
 		}
 	}
 
+	/**
+	 * Renders add new payment history form.
+	 * @return void
+	 */
+	public function render_add_new_payment_history_scratch() {
+		global $orders_list_table;
+
+		if ( ! $orders_list_table ) {
+		return;
+		}
+		$enable_members_button = true;
+		?>
+		<style>
+			.navigator{
+				padding: 8px 14px;
+				background-color: #f0f0f0;
+				border-radius: 4px;
+				cursor: pointer;
+			}
+		</style>
+		<div class="ur-membership-header ur-d-flex ur-mr-0 ur-p-3 ur-align-items-center" id=""
+			 style="margin-left: -20px; background:white; gap: 20px; position: sticky; top: 32px; z-index: 700">
+			<img style="max-width: 30px"
+				 src="<?php echo UR()->plugin_url() . '/assets/images/logo.svg'; ?>" alt="">
+			<a href="<?php echo esc_url( admin_url( 'admin.php?page=' . $this->page ) ); ?>"
+			   class="<?php echo esc_attr( ( $_GET['page'] == $this->page ) ? 'row-title' : '' ); ?>"
+			   style="text-decoration: none"
+			>
+				<?php esc_html_e( 'Payment History', 'user-registration' ); ?>
+			</a>
+		</div>
+
+		<div id="user-registration-list-table-page">
+			<div class="user-registration-list-table-heading" id="ur-users-page-topnav" style="gap: 14px;">
+				<div class="navigator navigator-prev" onclick="window.history.back();"><span class="dashicons dashicons-arrow-left-alt2"></span></div>
+				<div class="ur-page-title__wrapper">
+					<h1>
+						<?php esc_html_e( 'Add Manual Payment', 'user-registration' ); ?>
+					</h1>
+				</div>
+			</div>
+			<hr>
+			<form method="get" id="ur-membership-payment-history-form">
+				<input type="hidden" name="page" value="<?php echo $this->page; ?>"/>
+				<input type="hidden" name="action" value="<?php echo $_GET['action']; ?>" />
+				<div>
+					<strong>Important Note:</strong>
+					This form is intended only to record missed payments for tracking purposes. Adding a payment here does not renew the next billing cycle or assign any new plan to the user.
+				</div>
+
+			</form>
+		</div>
+		<?php
+	}
+	public function render_add_new_payment_history() {
+		$roles = ur_get_all_roles();
+		$memberships = new MembershipService();
+		$membership_plans = $memberships->list_active_memberships();
+		
+		include __DIR__ . '/Views/orders-create.php';
+	}
+	public function get_all_membership_plan() {
+
+	}
 	/**
 	 * render_payment_history_list
 	 *
@@ -186,6 +253,12 @@ class Orders {
 					<h1>
 						<?php esc_html_e( 'Payment History', 'user-registration' ); ?>
 					</h1>
+				</div>
+				<div class="button manual-payment-button button-primary" style="display:flex;align-items:end;padding: 6px 14px;">
+					<i class="dashicons dashicons-plus-alt2" style="font-size:0.9rem;"></i>
+					<span>
+						Add Manual Payment
+					</span>
 				</div>
 			</div>
 			<div id="user-registration-pro-filters-row" style="align-items: center;">
@@ -254,6 +327,7 @@ class Orders {
 				'ur_forms'            => ur_get_all_user_registration_form(),
 				'memberships'         => $memberships,
 				'delete_icon'         => plugins_url( 'assets/images/users/delete-user-red.svg', UR_PLUGIN_FILE ),
+				'add_manual_payment_url' => admin_url( 'admin.php?page=member-payment-history&action=add_new_payment' ),
 			)
 		);
 	}

--- a/modules/payment-history/Views/footer-actions.php
+++ b/modules/payment-history/Views/footer-actions.php
@@ -1,0 +1,10 @@
+<div class="submit ur-d-flex ur-justify-content-end ur-p-3" style="gap: 10px">
+	<button class="button-secondary" type="button">
+		<a style="text-decoration:none;color:#0b0b0b;" href="<?php echo $return_url; ?>">
+			<?php echo esc_html__( 'Cancel', 'user-registration' ); ?>
+		</a>
+	</button>
+	<button class="button-primary <?php echo esc_attr( $save_btn_class ); ?>">
+		<?php echo esc_html__( $create_btn_text ); ?>
+	</button>
+</div>

--- a/modules/payment-history/Views/orders-create.php
+++ b/modules/payment-history/Views/orders-create.php
@@ -1,0 +1,209 @@
+<?php
+require __DIR__ . '/header.php';
+$return_url = admin_url( 'admin.php?page=member-payment-history' );
+?>
+
+<form method="post" id="ur-membership-order-create-form" style="width: 80%">
+<div class="user-registration-card">
+	<div class="user-registration-card__header ur-d-flex ur-align-items-center">
+		<a class="ur-text-muted ur-d-flex"
+			href="<?php echo $return_url ?>">
+			<svg viewBox="0 0 24 24" widths="24" height="24" stroke="currentColor" stroke-width="2"
+					fill="none"
+					stroke-linecap="round" stroke-linejoin="round" class="css-i6dzq1">
+				<line x1="19" y1="12" x2="5" y2="12"></line>
+				<polyline points="12 19 5 12 12 5"></polyline>
+			</svg>
+		</a>
+		<h3>
+			<?php echo esc_html_e( 'Add Manual Payment', 'user-registration' ) ?>
+		</h3>
+	</div>
+	<div class="user_registration-card__body" style="margin: 14px 22px;">
+		<div id="ur-membership-orders-create-form" class="user-registration-card">
+			<div class="user-registration-card__body">
+				<div style="font-size:0.75rem;background-color: #f7fbff; border: 1px solid #475bb2; padding: 12px 16px; border-radius: 4px; font-size: 14px; line-height: 150%; display: flex; flex-direction: row; gap: 12px; align-items: start;">
+					<strong>Important Note:</strong>
+					This form is intended only to record missed payments for tracking purposes. Adding a payment here does not renew the next billing cycle or assign any new plan to the user.
+				</div>
+
+				<?php
+				// Ensure we have a list of users to populate the select field.
+				if ( ! isset( $users ) || empty( $users ) ) {
+					$users = get_users(
+						array(
+							'number' => -1,
+							'orderby' => 'display_name',
+							'order'   => 'ASC',
+						)
+					);
+				}
+
+				?>
+
+				<!-- Member -->
+				<div class="ur-membership-input-container ur-d-flex ur-p-3" style="gap:20px;">
+					<div class="ur-label" style="width: 30%">
+						<label for="ur-input-type-membership-plan"><?php esc_html_e( 'Member', 'user-registration' ); ?>
+							<span style="color:red">*</span>
+							<span class="user-registration-help-tip tooltipstered"
+								  data-tip="<?php echo esc_attr__( "Select the user to assign the order to." ) ?>"></span>
+						</label>
+					</div>
+					<div class="ur-input-type-membership-group-name ur-admin-template" style="width: 100%">
+						<div class="ur-field">
+							<select
+								data-key-name="<?php echo esc_html__( 'Membership Plan', 'user-registration' ); ?>"
+								id="ur-input-type-member"
+								name="ur_member"
+								class="user-membership-member-enhanced-select2"
+								style="width: 100%"
+								required>
+								<option value="" disabled selected><?php esc_html_e( 'Select a member', 'user-registration' ); ?></option>
+								<?php
+								if ( ! empty( $users ) ) {
+									foreach ( $users as $user ) :
+										?>
+										<option
+											value="<?php echo esc_attr( $user->ID ) ?>">
+											<?php echo esc_html( $user->user_login ) ?> (<?php echo esc_html( $user->user_email) ?>)
+										</option>
+										<?php
+									endforeach;
+								}
+								?>
+							</select>
+						</div>
+					</div>
+				</div>
+
+
+				<!-- Membership Plan -->
+				<div class="ur-membership-input-container ur-d-flex ur-p-3" style="gap:20px;">
+					<div class="ur-label" style="width: 30%">
+						<label for="ur-input-type-membership-plan"><?php esc_html_e( 'Select Membership Plan', 'user-registration' ); ?>
+							<span style="color:red">*</span>
+							<span class="user-registration-help-tip tooltipstered"
+								  data-tip="<?php echo esc_attr__( "Select the membership plan to assign the user to." ) ?>"></span>
+						</label>
+					</div>
+					<div class="ur-input-type-membership-group-name ur-admin-template" style="width: 100%">
+						<div class="ur-field">
+							<select
+								data-key-name="<?php echo esc_html__( 'Membership Plan', 'user-registration' ); ?>"
+								id="ur-input-type-membership-plan"
+								name="ur_membership_plan"
+								class="user-membership-group-enhanced-select2 urmg-input"
+								style="width: 100%"
+								required>
+								<option value="" disabled selected><?php esc_html_e( 'Select a membership plan', 'user-registration' ); ?></option>
+								<?php
+								if ( ! empty( $membership_plans ) ) {
+									foreach ( $membership_plans as $plan ) :
+										?>
+										<option
+											value="<?php echo esc_attr( $plan['ID'] ); ?>"
+											data-amount="<?php echo esc_attr( $plan['amount'] ); ?>">
+											<?php echo esc_html( $plan['title'] ); ?>
+										</option>
+										<?php
+									endforeach;
+								}
+								?>
+							</select>
+						</div>
+					</div>
+				</div>
+
+				<!-- Amount -->
+				<div class="ur-membership-input-container ur-d-flex ur-p-3" style="gap:20px;">
+					<div class="ur-label" style="width: 30%">
+						<label for="ur-input-type-membership-amount"><?php esc_html_e( 'Amount', 'user-registration' ); ?>
+							<span style="color:red">*</span>
+							<span class="user-registration-help-tip tooltipstered"
+								  data-tip="<?php echo esc_attr__( "Payment amount. Automatically fetched from membership plan but can be edited." ) ?>"></span>
+						</label>
+					</div>
+					<div class="ur-input-type-membership-name ur-admin-template" style="width: 100%">
+						<div class="ur-field">
+							<input type="text"
+								   autocomplete="off"
+								   class="ur-membership-amount-input urmg-input"
+								   data-key-name="<?php echo esc_html__( 'Amount', 'user-registration' ); ?>"
+								   id="ur-input-type-membership-amount"
+								   name="ur_membership_amount"
+								   style="width: 100%"
+								   required>
+						</div>
+					</div>
+				</div>
+
+				<!-- Payment Date -->
+				<div class="ur-membership-input-container ur-d-flex ur-p-3" style="gap:20px;">
+					<div class="ur-label" style="width: 30%">
+						<label for="ur-input-type-payment-date"><?php esc_html_e( 'Payment Date', 'user-registration' ); ?>
+							<span style="color:red">*</span>
+							<span class="user-registration-help-tip tooltipstered"
+								  data-tip="<?php echo esc_attr__( "Select the payment date." ) ?>"></span>
+						</label>
+					</div>
+					<div class="ur-input-type-membership-name ur-admin-template" style="width: 100%">
+						<div class="ur-field">
+							<input type="date"
+								   autocomplete="off"
+								   class="ur-payment-date-input ur-date urmg-input"
+								   data-key-name="<?php echo esc_html__( 'Payment Date', 'user-registration' ); ?>"
+								   id="ur-input-type-payment-date"
+								   name="ur_payment_date"
+								   style="width: 100%"
+								   required>
+						</div>
+					</div>
+				</div>
+
+				<!-- Transaction Status -->
+				<div class="ur-membership-input-container ur-d-flex ur-p-3" style="gap:20px;">
+					<div class="ur-label" style="width: 30%">
+						<label for="ur-input-type-transaction-status"><?php esc_html_e( 'Transaction Status', 'user-registration' ); ?>
+							<span style="color:red">*</span>
+							<span class="user-registration-help-tip tooltipstered"
+								  data-tip="<?php echo esc_attr__( "Select the transaction status." ) ?>"></span>
+						</label>
+					</div>
+					<div class="ur-input-type-membership-name ur-admin-template" style="width: 100%">
+						<div class="ur-field">
+							<select
+								data-key-name="<?php echo esc_html__( 'Transaction Status', 'user-registration' ); ?>"
+								id="ur-input-type-transaction-status"
+								name="ur_transaction_status"
+								class="urmg-input"
+								style="width: 100%"
+								required>
+								<option value=""><?php esc_html_e( 'Select status', 'user-registration' ); ?></option>
+								<option
+									value=""><?php echo esc_html__( 'All Status', 'user-registration' ); ?></option>
+								<?php
+								foreach ( array( 'completed', 'pending', 'failed', 'refunded' ) as $id => $status ) {
+									$selected = isset( $_REQUEST['status'] ) && $status == $_REQUEST['status'] ? 'selected=selected' : '';
+									?>
+									<option
+										value='<?php echo esc_attr( $status ); ?>' <?php echo esc_attr( $selected ); ?>><?php echo esc_html( ucfirst( $status ) ); ?></option>
+									<?php
+								}
+								?>
+							</select>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+	<hr>
+	<?php
+	$save_btn_class  = 'ur-add-new-payment';
+	$create_btn_text = esc_html__( 'Add Payment', 'user-registration' );
+	require __DIR__ . '/footer-actions.php';
+	?>
+	<?php wp_nonce_field( 'ur_membership_order', 'ur_membership_order_nonce' ); ?>
+</div>
+</form>

--- a/modules/payment-history/Views/orders-create.php
+++ b/modules/payment-history/Views/orders-create.php
@@ -30,16 +30,16 @@ $return_url = admin_url( 'admin.php?page=member-payment-history' );
 				<!-- Member -->
 				<div class="ur-membership-input-container ur-d-flex ur-p-3" style="gap:20px;">
 					<div class="ur-label" style="width: 30%">
-						<label for="ur-input-type-membership-plan"><?php esc_html_e( 'Member', 'user-registration' ); ?>
+						<label for="ur-input-type-member"><?php esc_html_e( 'Member', 'user-registration' ); ?>
 							<span style="color:red">*</span>
 							<span class="user-registration-help-tip tooltipstered"
 								  data-tip="<?php echo esc_attr__( "Select the user to assign the order to." ) ?>"></span>
 						</label>
 					</div>
-					<div class="ur-input-type-membership-group-name ur-admin-template" style="width: 100%">
+					<div class="ur-input-type-member-name ur-admin-template" style="width: 100%">
 						<div class="ur-field">
 							<select
-								data-key-name="<?php echo esc_html__( 'Membership Plan', 'user-registration' ); ?>"
+								data-key-name="<?php echo esc_html__( 'Member', 'user-registration' ); ?>"
 								id="ur-input-type-member"
 								name="ur_member"
 								class="user-membership-member-enhanced-select2"
@@ -51,10 +51,11 @@ $return_url = admin_url( 'admin.php?page=member-payment-history' );
 									foreach ( $users as $user ) :
 										?>
 										<option
+											data-membership-plan-id="<?php echo esc_attr( $user[ 'item_id' ] ) ?>"
 											value="<?php echo esc_attr( $user[ 'user_id' ] ) ?>">
 											<?php echo esc_html( $user[ 'user_login' ] ) ?> (<?php echo esc_html( $user[ 'user_email' ] ) ?>)
 										</option>
-										<?php
+									<?php
 									endforeach;
 								}
 								?>
@@ -63,42 +64,43 @@ $return_url = admin_url( 'admin.php?page=member-payment-history' );
 					</div>
 				</div>
 
-
 				<!-- Membership Plan -->
 				<div class="ur-membership-input-container ur-d-flex ur-p-3" style="gap:20px;">
 					<div class="ur-label" style="width: 30%">
-						<label for="ur-input-type-membership-plan"><?php esc_html_e( 'Select Membership Plan', 'user-registration' ); ?>
-							<span style="color:red">*</span>
-							<span class="user-registration-help-tip tooltipstered"
-								  data-tip="<?php echo esc_attr__( "Select the membership plan to assign the user to." ) ?>"></span>
+						<label for="ur-input-type-membership-plan"><?php esc_html_e( 'Membership Plan', 'user-registration' ); ?>
 						</label>
 					</div>
-					<div class="ur-input-type-membership-group-name ur-admin-template" style="width: 100%">
-						<div class="ur-field">
-							<select
-								data-key-name="<?php echo esc_html__( 'Membership Plan', 'user-registration' ); ?>"
-								id="ur-input-type-membership-plan"
-								name="ur_membership_plan"
-								class="user-membership-group-enhanced-select2 urmg-input"
-								style="width: 100%"
-								required>
-								<option value="" disabled selected><?php esc_html_e( 'Select a membership plan', 'user-registration' ); ?></option>
-								<?php
-								if ( ! empty( $membership_plans ) ) {
-									foreach ( $membership_plans as $plan ) :
-										?>
-										<option
-											value="<?php echo esc_attr( $plan['ID'] ); ?>"
-											data-amount="<?php echo esc_attr( $plan['amount'] ); ?>">
-											<?php echo esc_html( $plan['title'] ); ?>
-										</option>
-										<?php
-									endforeach;
-								}
-								?>
-							</select>
-						</div>
+					<div class="ur-text-muted ur-membership-plan-name ur-admin-template" style="width: 100%">
+						Select a member to view their membership plan.
+						<style>
+							.ur-text-muted {
+								width: 100%;
+								color: #383838;
+							}
+						</style>
 					</div>
+					<select
+						data-key-name="<?php echo esc_html__( 'Membership Plan', 'user-registration' ); ?>"
+						id="ur-input-type-membership-plan"
+						name="ur_membership_plan"
+						class="user-membership-group-enhanced-select2 urmg-input"
+						style="width: 100%;"
+						hidden
+						required>
+						<option value="" disabled selected><?php esc_html_e( 'Select a membership plan', 'user-registration' ); ?></option>
+						<?php
+						if ( ! empty( $membership_plans ) ) {
+							foreach ( $membership_plans as $plan ) :
+								?>
+								<option
+									value="<?php echo esc_attr( $plan['ID'] ); ?>"
+									data-amount="<?php echo esc_attr( $plan['amount'] ); ?>">
+									<?php echo esc_html( $plan['title'] ); ?>
+								</option>
+							<?php
+							endforeach;
+						} ?>
+					</select>
 				</div>
 
 				<!-- Amount -->
@@ -118,8 +120,34 @@ $return_url = admin_url( 'admin.php?page=member-payment-history' );
 								   data-key-name="<?php echo esc_html__( 'Amount', 'user-registration' ); ?>"
 								   id="ur-input-type-membership-amount"
 								   name="ur_membership_amount"
-								   style="width: 100%"
+								   style="width: 100%; padding: 8px; border: 1px solid #e1e1e1; border-radius: 4px; height: 38px;"
 								   required>
+						</div>
+					</div>
+				</div>
+				<!-- Payment Method -->
+				<div class="ur-membership-input-container ur-d-flex ur-p-3" style="gap:20px;">
+					<div class="ur-label" style="width: 30%">
+						<label for="ur-input-type-transaction-status"><?php esc_html_e( 'Payment Method', 'user-registration' ); ?>
+							<span style="color:red">*</span>
+							<span class="user-registration-help-tip tooltipstered"
+								  data-tip="<?php echo esc_attr__( "Select the payment method." ) ?>"></span>
+						</label>
+					</div>
+					<div class="ur-input-type-membership-name ur-admin-template" style="width: 100%">
+						<div class="ur-field">
+							<select
+								data-key-name="<?php echo esc_html__( 'Payment Method', 'user-registration' ); ?>"
+								id="ur-input-type-payment-method"
+								name="ur_payment_method"
+								class="urmg-input"
+								style="width: 100%"
+								required>
+								<option value=""><?php esc_html_e( 'Select Payment Method', 'user-registration' ); ?></option>
+								<?php foreach( $payment_methods as $payment_method): ?>
+									<option value="<?php echo $payment_method ?>"><?php echo ucfirst($payment_method) ?></option>
+								<?php endforeach; ?>
+							</select>
 						</div>
 					</div>
 				</div>
@@ -141,7 +169,7 @@ $return_url = admin_url( 'admin.php?page=member-payment-history' );
 								   data-key-name="<?php echo esc_html__( 'Payment Date', 'user-registration' ); ?>"
 								   id="ur-input-type-payment-date"
 								   name="ur_payment_date"
-								   style="width: 100%"
+								   style="width: 100%; padding: 8px; border: 1px solid #e1e1e1; border-radius: 4px; height: 38px;"
 								   required>
 						</div>
 					</div>
@@ -165,19 +193,36 @@ $return_url = admin_url( 'admin.php?page=member-payment-history' );
 								class="urmg-input"
 								style="width: 100%"
 								required>
-								<option value=""><?php esc_html_e( 'Select status', 'user-registration' ); ?></option>
-								<option
-									value=""><?php echo esc_html__( 'All Status', 'user-registration' ); ?></option>
+								<option value="" disabled selected><?php esc_html_e( 'Select status', 'user-registration' ); ?></option>
 								<?php
 								foreach ( array( 'completed', 'pending', 'failed', 'refunded' ) as $id => $status ) {
-									$selected = isset( $_REQUEST['status'] ) && $status == $_REQUEST['status'] ? 'selected=selected' : '';
 									?>
 									<option
-										value='<?php echo esc_attr( $status ); ?>' <?php echo esc_attr( $selected ); ?>><?php echo esc_html( ucfirst( $status ) ); ?></option>
+										value='<?php echo esc_attr( $status ); ?>' ><?php echo esc_html( ucfirst( $status ) ); ?></option>
 									<?php
 								}
 								?>
 							</select>
+						</div>
+					</div>
+				</div>
+				<!-- Payment Notes -->
+				<div class="ur-membership-input-container ur-d-flex ur-p-3" style="gap:20px;">
+					<div class="ur-label" style="width: 30%">
+						<label for="ur-input-type-payment-notes"><?php esc_html_e( 'Payment Notes', 'user-registration' ); ?>
+							<span class="user-registration-help-tip tooltipstered"
+								data-tip="<?php echo esc_attr__( "Add any additional notes about this payment." ) ?>"></span>
+						</label>
+					</div>
+					<div class="ur-input-type-membership-name ur-admin-template" style="width: 100%">
+						<div class="ur-field">
+							<textarea
+								class="ur-payment-notes"
+								data-key-name="<?php echo esc_html__( 'Payment Notes', 'user-registration' ); ?>"
+								id="ur-input-type-payment-notes"
+								name="ur_payment_notes"
+								style="width: 100%; min-height: 100px; padding: 8px;border: 1px solid #e1e1e1;resize:none;"
+							></textarea>
 						</div>
 					</div>
 				</div>

--- a/modules/payment-history/Views/orders-create.php
+++ b/modules/payment-history/Views/orders-create.php
@@ -59,7 +59,7 @@ $return_url = admin_url( 'admin.php?page=member-payment-history' );
 								class="user-membership-member-enhanced-select2"
 								style="width: 100%"
 								required>
-								<option value="" disabled selected><?php esc_html_e( 'Select a member', 'user-registration' ); ?></option>
+								<option value="" disabled selected><?php esc_html_e( 'Search by username or email...', 'user-registration' ); ?></option>
 								<?php
 								if ( ! empty( $users ) ) {
 									foreach ( $users as $user ) :

--- a/modules/payment-history/Views/orders-create.php
+++ b/modules/payment-history/Views/orders-create.php
@@ -5,8 +5,8 @@ $return_url = admin_url( 'admin.php?page=member-payment-history' );
 
 <form method="post" id="ur-membership-order-create-form" style="width: 80%">
 <div class="user-registration-card">
-	<div class="user-registration-card__header ur-d-flex ur-align-items-center">
-		<a class="ur-text-muted ur-d-flex"
+	<div class="user-registration-card__header ur-d-flex ur-align-items-center" style="gap: 8px;">
+		<a style="margin-right: 0; padding-right: 0; border-right: 0; width: 40px; height: 40px; background: #f4f4f4; display: flex; align-items: center; justify-content: center; border-radius: 6px;" class="ur-text-muted ur-d-flex"
 			href="<?php echo $return_url ?>">
 			<svg viewBox="0 0 24 24" widths="24" height="24" stroke="currentColor" stroke-width="2"
 					fill="none"
@@ -22,24 +22,10 @@ $return_url = admin_url( 'admin.php?page=member-payment-history' );
 	<div class="user_registration-card__body" style="margin: 14px 22px;">
 		<div id="ur-membership-orders-create-form" class="user-registration-card">
 			<div class="user-registration-card__body">
-				<div style="font-size:0.75rem;background-color: #f7fbff; border: 1px solid #475bb2; padding: 12px 16px; border-radius: 4px; font-size: 14px; line-height: 150%; display: flex; flex-direction: row; gap: 12px; align-items: start;">
-					<strong>Important Note:</strong>
-					This form is intended only to record missed payments for tracking purposes. Adding a payment here does not renew the next billing cycle or assign any new plan to the user.
+				<div style="font-size:0.8rem;background-color: #f7fbff; border: 1px solid #475bb2; padding: 12px 16px; border-radius: 4px; line-height: 150%; display: flex; flex-direction: row; gap: 12px; align-items: start;">
+					<strong> <?php _e('Important Note:', 'user-registration' ) ?></strong>
+					<?php _e('This form is intended only to record missed payments for tracking purposes. Adding a payment here does not renew the next billing cycle or assign any new plan to the user.' , 'user-registration' ) ?>
 				</div>
-
-				<?php
-				// Ensure we have a list of users to populate the select field.
-				if ( ! isset( $users ) || empty( $users ) ) {
-					$users = get_users(
-						array(
-							'number' => -1,
-							'orderby' => 'display_name',
-							'order'   => 'ASC',
-						)
-					);
-				}
-
-				?>
 
 				<!-- Member -->
 				<div class="ur-membership-input-container ur-d-flex ur-p-3" style="gap:20px;">
@@ -65,8 +51,8 @@ $return_url = admin_url( 'admin.php?page=member-payment-history' );
 									foreach ( $users as $user ) :
 										?>
 										<option
-											value="<?php echo esc_attr( $user->ID ) ?>">
-											<?php echo esc_html( $user->user_login ) ?> (<?php echo esc_html( $user->user_email) ?>)
+											value="<?php echo esc_attr( $user[ 'user_id' ] ) ?>">
+											<?php echo esc_html( $user[ 'user_login' ] ) ?> (<?php echo esc_html( $user[ 'user_email' ] ) ?>)
 										</option>
 										<?php
 									endforeach;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?  
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?  
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?  

---

### Changes proposed in this Pull Request:
This PR introduces the ability to manually add missing payment orders for memberships. Previously, if a payment order was missed by the system, there was no way to create it manually.

**Highlights:**
* New form under **URM > Payment History > Add Manual Payment** for creating payment orders manually.  
* Supports order-related fields and updates the UI dynamically.  
* Fully backward-compatible with existing payment history functionality.

Closes # (insert relevant issue number).  

---

### How to test the changes:

1. Go to **URM > Payment History > Add Manual Payment**.  
2. Fill out the form with order details.  
3. Submit the form and verify the payment order is created.  
4. Confirm that the payment history UI updates correctly.  
5. Ensure existing payment history features still work as expected.

---

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)  
* [ ] Enhancement (modification of the currently available functionality)  
* [x] New feature (non-breaking change which adds functionality)  
* [ ] Breaking change (fix or feature that would cause existing functionality to change)  

---

### Other information:

* [x] Have you added a clear explanation of what your changes do and why they are needed?  
* [x] Have you successfully run tests locally with your changes?  
* [ ] Have you updated the documentation accordingly?  

---

### Changelog entry

> Feature - Manually add missing payment orders for membership.