### PR TITLE
UR-2934 Fix - Field Label translation in polylang

### DIFF
--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -2324,14 +2324,36 @@ add_action( 'user_registration_installed', 'ur_delete_expired_transients' );
  * @param mixed  $variable To be translated for WPML compatibility.
  */
 function ur_string_translation( $form_id, $field_id, $variable ) {
-	if ( function_exists( 'icl_register_string' ) ) {
-		icl_register_string( isset( $form_id ) && 0 !== $form_id ? 'user_registration_' . absint( $form_id ) : 'user-registration', isset( $field_id ) ? $field_id : '', $variable );
-	}
-	if ( function_exists( 'icl_t' ) ) {
-		$variable = icl_t( isset( $form_id ) && 0 !== $form_id ? 'user_registration_' . absint( $form_id ) : 'user-registration', isset( $field_id ) ? $field_id : '', $variable );
-	}
-	return $variable;
+    $context = ( isset( $form_id ) && 0 !== $form_id )
+        ? 'user_registration_' . absint( $form_id )
+        : 'user-registration';
+    $name    = isset( $field_id ) ? $field_id : '';
+
+    // For handling translation in WPML.
+    if ( defined( 'ICL_SITEPRESS_VERSION' ) ) {
+		if ( function_exists( 'icl_register_string' ) ) {
+			icl_register_string( $context, $name, $variable );
+			if ( function_exists( 'icl_t' ) ) {
+				ur_get_logger()->debug(print_r('icl_t', true));
+				$variable = icl_t( $context, $name, $variable );
+			}
+
+		}
+    }
+
+    // For handling translation in Polylang.
+    elseif ( defined( 'POLYLANG_VERSION' ) ) {
+		if ( function_exists( 'pll_register_string' ) ) {
+			pll_register_string( $name, $variable, $context );
+			if ( function_exists( 'pll__' ) ) {
+				$variable = pll__( $variable );
+			}
+		}
+    }
+
+    return $variable;
 }
+
 
 /**
  * Get Form ID from User ID.
@@ -8532,4 +8554,3 @@ if ( ! function_exists( 'ur_save_settings_options' ) ) {
 		}
 	}
 };
-


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

While using the polylang translation for field label, it was repeating specific field name for all fields in the translated version after form submission.

Closes # .

### How to test the changes in this Pull Request:

1. Use polylang translation plugin
2. Translate the page and fields in polylang
3. Go to the translated version of the page
4. Submit the form and reload the page check if the accurate translated field names are displayed or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Field Label translation in polylang.
