### PR TITLE
UR 2826 Fix - Reflect updated plan type in change plan

### DIFF
--- a/modules/membership/includes/AJAX.php
+++ b/modules/membership/includes/AJAX.php
@@ -316,11 +316,7 @@ class AJAX {
 			}
 
 			$meta_data = json_decode( $data["post_meta_data"]['ur_membership']["meta_value"], true );
-			if ( ! empty( $meta_data['upgrade_settings'] ) && ! empty( $old_membership_data['upgrade_settings'] ) && $meta_data['upgrade_settings']['upgrade_path'] !== $old_membership_data['upgrade_settings']['upgrade_path'] ) {
-				$transient_key          = 'urm_upgradable_memberships_for_' . $updated_ID;
-				$upgradable_memberships = $membership->get_upgradable_membership( $updated_ID );
-				set_transient( $transient_key, $upgradable_memberships, 5 * MINUTE_IN_SECONDS );
-			}
+
 
 			if ( $is_stripe_enabled && "free" !== $meta_data["type"] ) {
 
@@ -1087,12 +1083,7 @@ class AJAX {
 				);
 			}
 		}
-		$transient_key = 'urm_upgradable_memberships_for_' . $membership_id;
-		$cached_data   = get_transient( $transient_key );
 
-		if ( false !== $cached_data ) {
-			wp_send_json_success( $cached_data );
-		}
 
 		$membership_service     = new MembershipService();
 		$upgradable_memberships = $membership_service->get_upgradable_membership( $membership_id );
@@ -1105,7 +1096,6 @@ class AJAX {
 				404
 			);
 		}
-		set_transient( $transient_key, $upgradable_memberships, 5 * MINUTE_IN_SECONDS );
 		wp_send_json_success(
 			$upgradable_memberships
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes the delay of the updated plan details on the change plan.

Closes # .

### How to test the changes in this Pull Request:

1. Follow the steps on this issue to recreate and test.
2. https://themegrill.atlassian.net/browse/UR-2826

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Reflect updated plan type in change plan
