### PR TITLE
UR-2984 Enhance - Content restriction for membership status not active.

### DIFF
--- a/modules/content-restriction/class-urcr-frontend.php
+++ b/modules/content-restriction/class-urcr-frontend.php
@@ -965,7 +965,7 @@ class URCR_Frontend {
 			$members_subscription    = new \WPEverest\URMembership\Admin\Repositories\MembersSubscriptionRepository();
 			$subscription            = $members_subscription->get_member_subscription( wp_get_current_user()->ID );
 			$current_user_membership = ( ! empty( $subscription ) ) ? $subscription['item_id'] : array();
-			$subscription_status = ( ! empty( $subscription[ 'status' ] ) ) && 'canceled' == $subscription['status'];
+			$is_user_membership_active = ( ! empty( $subscription[ 'status' ] ) ) && 'active' == $subscription['status'];
 		}
 		$whole_site_access_restricted = ur_string_to_bool( get_option( 'user_registration_content_restriction_whole_site_access', false ) );
 
@@ -987,7 +987,7 @@ class URCR_Frontend {
 						$template = $this->urcr_restrict_contents_template( $template, $post );
 					}
 				} elseif ( '3' === get_option( 'user_registration_content_restriction_allow_access_to' ) ) {
-					if ( is_array( $allowed_memberships ) && in_array( $current_user_membership, $allowed_memberships ) && $subscription_status ) {
+					if ( is_array( $allowed_memberships ) && in_array( $current_user_membership, $allowed_memberships ) && $is_user_membership_active ) {
 						return $template;
 					}
 					$template = $this->urcr_restrict_contents_template( $template, $post );
@@ -1009,7 +1009,7 @@ class URCR_Frontend {
 					$template = $this->urcr_restrict_contents_template( $template, $post );
 				}
 			} elseif ( $get_meta_data_allow_to === '3' ) {
-				if ( is_array( $allowed_memberships ) && in_array( $current_user_membership, $allowed_memberships ) ) {
+				if ( is_array( $allowed_memberships ) && in_array( $current_user_membership, $allowed_memberships ) && $is_user_membership_active ) {
 					return $template;
 				}
 				return $this->urcr_restrict_contents_template( $template, $post );
@@ -1054,6 +1054,7 @@ class URCR_Frontend {
 			$subscription              = $members_subscription->get_member_subscription( wp_get_current_user()->ID );
 			$current_user_membership   = ( ! empty( $subscription ) ) ? $subscription['item_id'] : array();
 			$get_meta_data_memberships = get_post_meta( $post_id, 'urcr_meta_memberships', $single = true );
+			$is_user_membership_active = ! empty( $subscription[ 'status' ] ) && 'active' === $subscription[ 'status' ];
 		}
 
 		$whole_site_access_restricted = ur_string_to_bool( get_option( 'user_registration_content_restriction_whole_site_access', false ) );
@@ -1077,7 +1078,7 @@ class URCR_Frontend {
 					}
 					return $post;
 				} elseif ( '3' === get_option( 'user_registration_content_restriction_allow_access_to' ) ) {
-					if ( is_array( $allowed_memberships ) && in_array( $current_user_membership, $allowed_memberships ) ) {
+					if ( is_array( $allowed_memberships ) && in_array( $current_user_membership, $allowed_memberships ) && $is_user_membership_active ) {
 						return;
 					}
 					$this->urcr_restrict_contents();
@@ -1102,7 +1103,7 @@ class URCR_Frontend {
 
 				return $post;
 			} elseif ( $get_meta_data_allow_to === '3' ) {
-				if ( is_array( $get_meta_data_memberships ) && in_array( $current_user_membership, $get_meta_data_memberships ) ) {
+				if ( is_array( $get_meta_data_memberships ) && in_array( $current_user_membership, $get_meta_data_memberships ) && $is_user_membership_active ) {
 					return $post;
 				}
 				$this->urcr_restrict_contents();

--- a/modules/content-restriction/class-urcr-shortcodes.php
+++ b/modules/content-restriction/class-urcr-shortcodes.php
@@ -81,6 +81,7 @@ class URCR_Shortcodes {
 				$subscription         = $members_subscription->get_member_subscription( wp_get_current_user()->ID );
 
 				$current_user_membership = ( ! empty( $subscription ) ) ? $subscription['item_id'] : array();
+				$is_user_membership_active = ! empty( $subscription[ 'status' ] ) && 'active' === $subscription[ 'status' ];
 			}
 
 			if ( empty( $roles ) ) {
@@ -101,7 +102,7 @@ class URCR_Shortcodes {
 							return do_shortcode( $content );
 						}
 					} elseif ( '3' === get_option( 'user_registration_content_restriction_allow_access_to' ) ) {
-						if ( is_array( $allowed_memberships ) && in_array( $current_user_membership, $allowed_memberships ) ) {
+						if ( is_array( $allowed_memberships ) && in_array( $current_user_membership, $allowed_memberships ) && $is_user_membership_active ) {
 							return do_shortcode( $content );
 						}
 					}
@@ -128,7 +129,7 @@ class URCR_Shortcodes {
 							break;
 						case '3':
 							if ( ! empty( $get_meta_data_memberships ) ) {
-								if ( is_array( $get_meta_data_memberships ) && in_array( $current_user_membership, $get_meta_data_memberships ) ) {
+								if ( is_array( $get_meta_data_memberships ) && in_array( $current_user_membership, $get_meta_data_memberships ) && $is_user_membership_active ) {
 									return do_shortcode( $content );
 								}
 							}
@@ -175,7 +176,7 @@ class URCR_Shortcodes {
 						break;
 
 					case 'memberships':
-						if (!empty($memberships_roles) && in_array($current_user_membership, $memberships_roles, true)) {
+						if (!empty($memberships_roles) && in_array($current_user_membership, $memberships_roles, true) && $is_user_membership_active) {
 							$matched = true;
 						}
 						break;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

---

### Changes proposed in this Pull Request:

Previously, **content restriction** was **not applied** to members whose membership status was **no longer active**.  
With this update:
- If content is allowed only for a **specific membership plan**, members without an active subscription for that plan will be **restricted**.

Closes # .

---

### How to test the changes in this Pull Request:

1. Go to **URM > Membership** and create a membership plan.
2. Test for content restrictions for membership:
 - Global content restriction.
 - Content restriction to pages/posts.
 - Content restriction via shortcodes.
3. Verify that only membership with active status can access the restricted content but members with other status or non-members cannot access the restricted content.
---

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

---

### Changelog entry

> Enhance – Content restriction applied to members whose membership is not active.