### PR TITLE
UR-2630 Fix - WooCommerce value not populating on URM users page

### DIFF
--- a/includes/admin/settings/class-ur-users-menu.php
+++ b/includes/admin/settings/class-ur-users-menu.php
@@ -987,6 +987,8 @@ if (! class_exists('User_Registration_Users_Menu')) {
 											} else {
 												$value = esc_html($default_value);
 											}
+										} elseif (metadata_exists('user', $user_id, $field_name)) {
+											$value = get_user_meta($user_id, $field_name, true);
 										} else {
 											$value = '';
 										}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The WooCommerce Shipping and Billing Address value was empty in the URM->Users Page. This PR fixes this issue.

Closes # .

### How to test the changes in this Pull Request:

1. Create a form using WooCommerce Fields such as Shipping and Billing Fields.
2. Perform the registration using those fields.
3. Check in the URM > Users Detail page and check whether the accurate shipping and billing data are displayed or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - WooCommerce value not populating on URM users page.