### PR TITLE
UR-3055 Fix - Undefined variable on edit profile for non URM users

### DIFF
--- a/templates/myaccount/form-edit-profile-non-urm-user.php
+++ b/templates/myaccount/form-edit-profile-non-urm-user.php
@@ -20,23 +20,24 @@ if (! defined('ABSPATH')) {
 	exit;
 }
 
-$user = wp_get_current_user();
-$user_id = get_current_user_id();
+$user           = wp_get_current_user();
+$user_id        = get_current_user_id();
+$endpoint_label = isset( $args['endpoint_label'] ) ? $args['endpoint_label'] : '';
 
 $layout = get_option('user_registration_my_account_layout', 'horizontal');
 
 if ('vertical' === $layout) {
-?>
+	?>
 	<div class="user-registration-MyAccount-content__header">
 		<h1><?php echo wp_kses_post($endpoint_label); ?></h1>
 	</div>
-<?php
+	<?php
 }
 ?>
 <div class="user-registration-MyAccount-content__body">
 	<div class="ur-frontend-form login ur-edit-profile" id="ur-frontend-form">
 	<?php if ( current_user_can( 'manage_options' ) ): ?>
-			  <div class="user-registration-myaccount-notice-box">
+				<div class="user-registration-myaccount-notice-box">
 				<div class="user-registration-myaccount-notice-box--title">
 					<div class="user-registration-myaccount-notice-box--title-icon">
 						<span class="dashicons dashicons-info-outline notice-icon"></span>
@@ -60,7 +61,7 @@ if ('vertical' === $layout) {
 					);
 					$user_query = new WP_User_Query( $user_args );
 					$existing_non_urm_user = $user_query->get_total();
-				?>
+					?>
 				<?php if ( $existing_non_urm_user >= 5 ): ?>
 					<p class="existing-users">
 					<strong>Existing users:</strong> Your site has <span class="highlight"><?php echo $existing_non_urm_user; ?> users</span> registered before this plugin.
@@ -93,7 +94,7 @@ if ('vertical' === $layout) {
 						<?php
 						$is_profile_pic_on_form    = ! ur_option_checked( 'user_registration_disable_profile_picture', false );
 						if ( $is_profile_pic_on_form ) {
-						?>
+							?>
 						<div class="user-registration-profile-header">
 							<div class="user-registration-img-container" style="width:100%">
 								<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

While using the vertical layout for my account setting, navigating to profile edit tab as non URM registered user undefined variable $endpoint_label was thrown. This PR fixes this issue.

Closes # .

### How to test the changes in this Pull Request:

1. Go to URM > Settings > General > Select Vertical Layout
2. Now go to Profile Edit page on My account by logging in as non URM registered user.
3. Check if the error is thrown or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Undefined variable on edit profile for non URM users.