### PR TITLE
UR-3056 Fix - Header already sent warning on lost password page

### DIFF
--- a/includes/shortcodes/class-ur-shortcode-my-account.php
+++ b/includes/shortcodes/class-ur-shortcode-my-account.php
@@ -92,11 +92,11 @@ class UR_Shortcode_My_Account {
 
 				ur_get_template(
 					'myaccount/form-login.php',
-						array(
-							'recaptcha_node' => $recaptcha_node,
-							'redirect'       => $redirect_url,
-						)
-					);
+					array(
+						'recaptcha_node' => $recaptcha_node,
+						'redirect'       => $redirect_url,
+					)
+				);
 
 				$login_form = ob_get_clean();
 
@@ -333,8 +333,10 @@ class UR_Shortcode_My_Account {
 	 * Lost password page handling.
 	 */
 	public static function lost_password() {
-		nocache_headers();
-		header( 'Expires: Wed, 11 Jan 1984 05:00:00 GMT' );
+		if ( ! headers_sent() ) {
+			nocache_headers();
+			header( 'Expires: Wed, 11 Jan 1984 05:00:00 GMT' );
+		}
 		/**
 		 * After sending the reset link, don't show the form again.
 		 */
@@ -343,36 +345,36 @@ class UR_Shortcode_My_Account {
 
 
 		} elseif ( ! empty( $_GET['show-reset-form'] ) ) {
-			    if ( isset( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ] ) && 0 < strpos( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ], ':' ) ) {
-					list( $rp_login, $rp_key ) = array_map( 'ur_clean', explode( ':', wp_unslash( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ] ), 2 ) );
+			if ( isset( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ] ) && 0 < strpos( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ], ':' ) ) {
+				list( $rp_login, $rp_key ) = array_map( 'ur_clean', explode( ':', wp_unslash( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ] ), 2 ) );
 					$user = get_user_by( 'login', $rp_login );
 					$rp_login = $user ? $user->user_login : $rp_login;
 
-					$user = self::check_password_reset_key( $rp_key, $rp_login );
+				$user = self::check_password_reset_key( $rp_key, $rp_login );
 
-					if ( ! empty( $user ) ) {
+				if ( ! empty( $user ) ) {
 						$form_id = ur_get_form_id_by_userid( $user->ID );
 						$enable_strong_password = ur_string_to_bool( ur_get_single_post_meta( $form_id, 'user_registration_form_setting_enable_strong_password' ) );
-						$minimum_password_strength = ur_get_single_post_meta( $form_id, 'user_registration_form_setting_minimum_password_strength' );
+					$minimum_password_strength = ur_get_single_post_meta( $form_id, 'user_registration_form_setting_minimum_password_strength' );
 
-						if ( $enable_strong_password ) {
-							wp_enqueue_script( 'ur-password-strength-meter' );
-						}
-
-						return ur_get_template(
-							'myaccount/form-reset-password.php',
-							array(
-								'key'                       => $rp_key,
-								'login'                     => $rp_login,
-								'enable_strong_password'    => $enable_strong_password,
-								'minimum_password_strength' => $minimum_password_strength,
-							)
-						);
+					if ( $enable_strong_password ) {
+						wp_enqueue_script( 'ur-password-strength-meter' );
 					}
+
+					return ur_get_template(
+						'myaccount/form-reset-password.php',
+						array(
+							'key'                       => $rp_key,
+							'login'                     => $rp_login,
+							'enable_strong_password'    => $enable_strong_password,
+							'minimum_password_strength' => $minimum_password_strength,
+						)
+					);
+				}
 				}
 				else{
-					return '<p>Password reset link is invalid or expired.</p>';
-				}
+				return '<p>Password reset link is invalid or expired.</p>';
+			}
 		}
 
 		/**
@@ -484,44 +486,44 @@ class UR_Shortcode_My_Account {
 
 	public static function reset_password_form( $atts ) {
 
-        if ( isset( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ] ) && 0 < strpos( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ], ':' ) ) {
-            list( $rp_login, $rp_key ) = array_map( 'ur_clean', explode( ':', wp_unslash( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ] ), 2 ) );
+		if ( isset( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ] ) && 0 < strpos( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ], ':' ) ) {
+			list( $rp_login, $rp_key ) = array_map( 'ur_clean', explode( ':', wp_unslash( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ] ), 2 ) );
             $user = get_user_by( 'login', $rp_login );
             $rp_login = isset( $user->user_login ) ? $user->user_login : $rp_login;
 
-            $user = self::check_password_reset_key( $rp_key, $rp_login );
+			$user = self::check_password_reset_key( $rp_key, $rp_login );
 
-            if ( ! empty( $user ) ) {
+			if ( ! empty( $user ) ) {
                 $form_id = ur_get_form_id_by_userid( $user->ID );
                 $enable_strong_password = ur_string_to_bool( ur_get_single_post_meta( $form_id, 'user_registration_form_setting_enable_strong_password' ) );
-                $minimum_password_strength = ur_get_single_post_meta( $form_id, 'user_registration_form_setting_minimum_password_strength' );
+				$minimum_password_strength = ur_get_single_post_meta( $form_id, 'user_registration_form_setting_minimum_password_strength' );
 
-                if ( $enable_strong_password ) {
-                    wp_enqueue_script( 'ur-password-strength-meter' );
-                    wp_dequeue_script( 'wc-password-strength-meter' );
-                    wp_localize_script(
-                        'ur-password-strength-meter',
-                        'ur_frontend_params_with_form_id',
-                        array(
-                            'custom_password_params' => UR_Frontend_Scripts::get_custom_password_params( $form_id ),
-                        )
-                    );
-                }
+				if ( $enable_strong_password ) {
+					wp_enqueue_script( 'ur-password-strength-meter' );
+					wp_dequeue_script( 'wc-password-strength-meter' );
+					wp_localize_script(
+						'ur-password-strength-meter',
+						'ur_frontend_params_with_form_id',
+						array(
+							'custom_password_params' => UR_Frontend_Scripts::get_custom_password_params( $form_id ),
+						)
+					);
+				}
 
-                return ur_get_template(
-                    'myaccount/form-reset-password.php',
-                    array(
+				return ur_get_template(
+					'myaccount/form-reset-password.php',
+					array(
                         'key' => $rp_key,
                         'login' => $rp_login,
                         'enable_strong_password' => $enable_strong_password,
-                        'minimum_password_strength' => $minimum_password_strength,
-                    )
-                );
-            } else {
+						'minimum_password_strength' => $minimum_password_strength,
+					)
+				);
+			} else {
                 UR_Shortcode_My_Account::set_reset_password_cookie();
 				ur_clear_notices();
 			}
-        }
+		}
 		// If the user is in admin context, or user is trying to save the page.
 		if( is_admin() || ( defined('REST_REQUEST') && REST_REQUEST ) ) {
 			return '[user_registration_reset_password_form]';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In Lost password page, there was header already sent warning displaying. This PR fixes this issue.

Closes # .

### How to test the changes in this Pull Request:

1. Go to the Lost Password page and check if the warning is displayed or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Header already sent warning on lost password page.
