### PR TITLE
Live Non URM Users Notice Slowdown Back Office.

### DIFF
--- a/includes/admin/class-ur-admin-user-list-manager.php
+++ b/includes/admin/class-ur-admin-user-list-manager.php
@@ -228,21 +228,12 @@ class UR_Admin_User_List_Manager {
 	 * Display a notice to admin notifying the users registered via non URM forms.
 	 */
 	public function user_registration_non_urm_users_notices() {
-		$users = get_users( array(
-			'fields'     => 'ID',
-			'meta_query' => array(
-				array(
-					'key'     => 'ur_form_id',
-					'compare' => 'NOT EXISTS',
-				),
-			),
-		) );
-
+		$users = get_transient( 'urm_users_not_from_urm_forms' );
 		$current_screen = get_current_screen();
 		$ur_pages = ur_get_screen_ids();
 		$ur_pages[] = 'users';
 
-		$existing_non_urm_users = count( $users );
+		$existing_non_urm_users = $users ? $users : 0;
 
 		if( $existing_non_urm_users >= 5 && in_array( $current_screen->id, $ur_pages ) ) {
 			echo '<div class="notice notice-info is-dismissible">';

--- a/includes/admin/class-ur-admin.php
+++ b/includes/admin/class-ur-admin.php
@@ -454,6 +454,20 @@ class UR_Admin {
 			return $response;
 		}
 
+		if( get_transient( 'urm_users_not_from_urm_forms' ) ) {
+			// Get users not registered via URM forms.
+			$urm_users_not_from_urm_forms = count( get_users( array(
+				'fields'     => 'ID',
+				'meta_query' => array(
+					array(
+						'key'     => 'ur_form_id',
+						'compare' => 'NOT EXISTS',
+					),
+				),
+			) ) );
+			set_transient( 'urm_users_not_from_urm_forms', $urm_users_not_from_urm_forms, apply_filters( 'urm_non_urm_user_transient_expiration',MINUTE_IN_SECONDS * 5 ) );
+		}
+
 		$read_time = get_option( 'user_registration_users_listing_viewed' );
 		if ( ! $read_time ) {
 			$now = current_time( 'mysql' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously, there was direct fetching of users via database to display the non urm users notice. Now, with this PR, a transient is added to get the count of non URM users defaulting to expiration time of 5 minutes.
<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Transient for non URM users live notice.
