### PR TITLE
UR 2858 Fix - login form block user state not working.

### DIFF
--- a/includes/blocks/block-types/class-ur-block-login-form.php
+++ b/includes/blocks/block-types/class-ur-block-login-form.php
@@ -36,6 +36,10 @@ class UR_Block_Login_Form extends UR_Block_Abstract {
 			$parameters['logout_redirect'] = $attr['logoutUrl'];
 		}
 
+		if ( ! empty( $attr['userState'] ) ) {
+			$parameters['userState'] = $attr['userState'];
+		}
+
 		return UR_Shortcodes::login(
 			$parameters
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changes proposed in this Pull Request:

Fixes an issue in the Login Form block where the user state toggle was not functional.  
Now, based on the selected user state, the block will display content accordingly.

Closes # .

### How to test the changes in this Pull Request:

1. Add a Login Form block to a page.
2. Change the user state setting in the block inspector control settings.
3. Verify that the login form block content updates based on the selected user state.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Fix - Login Form block user state not working.