### PR TITLE
UR-3058 Fix - Price ID not found in stripe

### DIFF
--- a/modules/membership/includes/Admin/Services/Stripe/StripeService.php
+++ b/modules/membership/includes/Admin/Services/Stripe/StripeService.php
@@ -892,11 +892,6 @@ class StripeService {
 				'success' => false,
 				'message' => $ex->getMessage(),
 			);
-		} catch ( Exception $ex ) {
-			return array(
-				'success' => false,
-				'message' => $ex->getMessage(),
-			);
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

While changing the price in stripe and trying to create membership using Stripe, Invalid Request error message was displayed in the frontend. This PR fixes this issue.

Closes # .

### How to test the changes in this Pull Request:

1. Add random value in postmeta table for **ur_membership** key's price_id value
2. Save the membership plan having stripe as payment gateway enabled.
3. Submit the form selecting Stripe membership and check if it is creating membership or throwing message Invalid Request.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Price ID not found in stripe.