### PR TITLE
UR-3057 Enhance - Persistent dismissal of non urm users admin notices in UR pages.

### DIFF
--- a/assets/js/admin/ur-notice.js
+++ b/assets/js/admin/ur-notice.js
@@ -36,4 +36,19 @@ jQuery(function ($) {
 				});
 			});
 	});
+	$(".urm-per-user-notice").each(function () {
+		var notice_id = $(this).data('notice-id'),
+			notice_type = $(this).data('notice-type');
+
+		$(document)
+			.on('click', '.urm-per-user-notice .notice-dismiss', function(e) {
+				e.preventDefault();
+				$.post(user_registration_admin_data.ajax_url, {
+					action: 'user_registration_dismiss_notice_per_user',
+					notice_id: notice_id,
+					notice_type: notice_type,
+					security: ur_notice_params[notice_type + '_nonce'],
+				});
+			});
+	});
 });

--- a/assets/js/admin/ur-notice.js
+++ b/assets/js/admin/ur-notice.js
@@ -43,7 +43,7 @@ jQuery(function ($) {
 		$(document)
 			.on('click', '.urm-per-user-notice .notice-dismiss', function(e) {
 				e.preventDefault();
-				$.post(user_registration_admin_data.ajax_url, {
+				$.post(ur_notice_params.ajax_url, {
 					action: 'user_registration_dismiss_notice_per_user',
 					notice_id: notice_id,
 					notice_type: notice_type,

--- a/includes/admin/class-ur-admin-assets.php
+++ b/includes/admin/class-ur-admin-assets.php
@@ -282,6 +282,7 @@ class UR_Admin_Assets {
 				'allow-usage_nonce' => wp_create_nonce( 'allow-usage-nonce' ),
 				'survey_nonce'      => wp_create_nonce( 'survey-nonce' ),
 				'promotional_nonce' => wp_create_nonce( 'promotional-nonce' ),
+				'urm-admin-notice_nonce' => wp_create_nonce( 'urm-admin-notice-nonce' ),
 			)
 		);
 

--- a/includes/admin/class-ur-admin-user-list-manager.php
+++ b/includes/admin/class-ur-admin-user-list-manager.php
@@ -228,19 +228,53 @@ class UR_Admin_User_List_Manager {
 	 * Display a notice to admin notifying the users registered via non URM forms.
 	 */
 	public function user_registration_non_urm_users_notices() {
+
+		$current_user_id = get_current_user_id();
+
+		$urm_dismissed_notices = get_user_meta( $current_user_id, 'urm_dismissed_notices', true );
+
+		if( is_array( $urm_dismissed_notices ) && isset( $urm_dismissed_notices[ 'non_urm_users_notice' ] ) ) {
+			$closed_count = isset( $urm_dismissed_notices[ 'non_urm_users_notice' ][ 'dismiss_count' ] ) ?: 0;
+			$last_closed = isset( $urm_dismissed_notices[ 'non_urm_users_notice' ][ 'last_dismissed_at' ] ) ?: 0;
+			// if it was closed twice in a row, don't show again.
+			if( $closed_count >= 2 ) {
+				return;
+			}
+			//Don't show if it has been closed recently(within past 24 hours).
+			if( $last_closed && ( time() - $last_closed ) < DAY_IN_SECONDS ) {
+				return;
+			}
+		}
 		$users = get_transient( 'urm_users_not_from_urm_forms' );
 		$current_screen = get_current_screen();
 		$ur_pages = ur_get_screen_ids();
-		$ur_pages[] = 'users';
+		array_push( $ur_pages, 'users' );
 
 		$existing_non_urm_users = $users ? $users : 0;
-
 		if( $existing_non_urm_users >= 5 && in_array( $current_screen->id, $ur_pages ) ) {
-			echo '<div class="notice notice-info is-dismissible">';
-			echo '<p><strong>User Registration:</strong> Your site has <span class="highlight">' . $existing_non_urm_users . ' users</span> registered before this plugin.';
-			echo 'Want them to enjoy the new profile features too? Use the ';
-			echo '<a class="addon-link" href="https://wpuserregistration.com/features/profile-connect/?utm_source=admin-notices&utm_medium=profile-connect-addon-link&utm_campaign=' . UR()->utm_campaign . '" rel="noreferrer noopener" target="_blank">Profile Connect addon</a> to link these existing users to your new registration form.';
-			echo '</p></div>';
+			$utm_url = esc_url(
+            	'https://wpuserregistration.com/features/profile-connect/?utm_source=admin-notices&utm_medium=profile-connect-addon-link&utm_campaign=' . UR()->utm_campaign
+        	);
+
+        ?>
+			<div class="notice notice-info is-dismissible urm-per-user-notice urm-non-urm-users-notice" data-notice-id="non_urm_users_notice" data-notice-type="urm-admin-notice">
+				<p>
+					<strong><?php esc_html_e( 'User Registration:', 'user-registration' ); ?></strong>
+					<?php
+					printf(
+						/* translators: %s: number of existing users */
+						esc_html__( 'Your site has %s users registered before this plugin.', 'user-registration' ),
+						'<span class="highlight">' . intval( $existing_non_urm_users ) . '</span>'
+					);
+					?>
+					<?php esc_html_e( 'Want them to enjoy the new profile features too? Use the', 'user-registration' ); ?>
+					<a class="addon-link" href="<?php echo $utm_url; ?>" rel="noreferrer noopener" target="_blank">
+						<?php esc_html_e( 'Profile Connect addon', 'user-registration' ); ?>
+					</a>
+					<?php esc_html_e( 'to link these existing users to your new registration form.', 'user-registration' ); ?>
+				</p>
+			</div>
+        <?php
 		}
 	}
 	/**

--- a/includes/admin/class-ur-admin-user-list-manager.php
+++ b/includes/admin/class-ur-admin-user-list-manager.php
@@ -228,21 +228,12 @@ class UR_Admin_User_List_Manager {
 	 * Display a notice to admin notifying the users registered via non URM forms.
 	 */
 	public function user_registration_non_urm_users_notices() {
-		$users = get_users( array(
-			'fields'     => 'ID',
-			'meta_query' => array(
-				array(
-					'key'     => 'ur_form_id',
-					'compare' => 'NOT EXISTS',
-				),
-			),
-		) );
-
+		$users = get_transient( 'urm_users_not_from_urm_forms' );
 		$current_screen = get_current_screen();
 		$ur_pages = ur_get_screen_ids();
 		$ur_pages[] = 'users';
 
-		$existing_non_urm_users = count( $users );
+		$existing_non_urm_users = $users ? $users : 0;
 
 		if( $existing_non_urm_users >= 5 && in_array( $current_screen->id, $ur_pages ) ) {
 			echo '<div class="notice notice-info is-dismissible">';

--- a/includes/admin/class-ur-admin.php
+++ b/includes/admin/class-ur-admin.php
@@ -454,7 +454,7 @@ class UR_Admin {
 			return $response;
 		}
 
-		if( get_transient( 'urm_users_not_from_urm_forms' ) ) {
+		if( false === get_transient( 'urm_users_not_from_urm_forms' ) ) {
 			// Get users not registered via URM forms.
 			$urm_users_not_from_urm_forms = count( get_users( array(
 				'fields'     => 'ID',

--- a/includes/admin/class-ur-admin.php
+++ b/includes/admin/class-ur-admin.php
@@ -454,6 +454,20 @@ class UR_Admin {
 			return $response;
 		}
 
+		if( get_transient( 'urm_users_not_from_urm_forms' ) ) {
+			// Get users not registered via URM forms.
+			$urm_users_not_from_urm_forms = count( get_users( array(
+				'fields'     => 'ID',
+				'meta_query' => array(
+					array(
+						'key'     => 'ur_form_id',
+						'compare' => 'NOT EXISTS',
+					),
+				),
+			) ) );
+			set_transient( 'urm_users_not_from_urm_forms', $urm_users_not_from_urm_forms, apply_filters( 'urm_non_urm_user_transient_expiration',MINUTE_IN_SECONDS * 5 ) );
+		}
+
 		$read_time = get_option( 'user_registration_users_listing_viewed' );
 		if ( ! $read_time ) {
 			$now = current_time( 'mysql' );

--- a/includes/admin/functions-ur-admin.php
+++ b/includes/admin/functions-ur-admin.php
@@ -114,6 +114,7 @@ function ur_get_screen_ids() {
 		$ur_screen_id . '_page_user-registration-content-restriction',
 		$ur_screen_id . '_page_user-registration-coupons',
 		$ur_screen_id . '_page_member-payment-history',
+		$ur_screen_id . '_page_user-registration-users',
 		'profile',
 		'user-edit',
 	);

--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -1297,8 +1297,9 @@ class UR_AJAX {
 
 		switch( $notice_id ) {
 			case 'non_urm_users_notice':
-				[ 'dismiss_count' => $dismiss_count, 'last_dismissed_at' => $last_dismissed_at ] = isset( $urm_dismissed_notices['non_urm_users_notice'] ) ? $urm_dismissed_notices['non_urm_users_notice'] : array( 'dismiss_count' => 0 );
-				$urm_dismissed_notices[ 'non_urm_users_notice' ] = array( 'dismiss_count' => $dismiss_count + 1, 'last_dismissed_at' => current_time( 'timestamp' ) );
+				[ 'dismiss_count' => $dismiss_count, 'last_dismissed_at' => $last_dismissed_at ] = isset( $urm_dismissed_notices[ 'non_urm_users_notice' ] ) ? $urm_dismissed_notices[ 'non_urm_users_notice' ] : array( 'dismiss_count' => 0, current_time( 'timestamp' ) - 3 * DAY_IN_SECONDS );
+				$dismiss_count = current_time( 'timestamp' ) - $last_dismissed_at  <= 48 * HOUR_IN_SECONDS ? $dismiss_count + 1 : $dismiss_count;
+				$urm_dismissed_notices[ 'non_urm_users_notice' ] = array( 'dismiss_count' => $dismiss_count, 'last_dismissed_at' => current_time( 'timestamp' ) );
 				break;
 			default:
 				break;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

An admin notice was displayed previously for 5 or more users registered from other than URM forms, which kept showing even if the user closed it intentionally, impacting user experience.  

Now when the admin user closes it:  
- On first close, it will disappear for 24 hours.  
- On second close, if dismissed within the past 48 hours, it will be dismissed permanently.
- If dismissal is not within 48 hours, it just resets the admin notices close count and hides for 24 hours only.
Closes # .

### How to test the changes in this Pull Request:

1. Register 5 or more users from outside URM forms.
2. Confirm that the admin notice appears in UR pages.
3. Close the notice once → it should disappear for 24 hours.
4. Close the notice again within 48 hours → it should disappear permanently.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhance – Persistent dismissal of non-URM users admin notice in UR pages.