### PR TITLE
UR-3093 First Name smart tag not working in membership related emails

### DIFF
--- a/includes/class-ur-smart-tags.php
+++ b/includes/class-ur-smart-tags.php
@@ -693,7 +693,7 @@ class UR_Smart_Tags {
 						break;
 
 					case 'membership_end_date':
-						$membership_end_date = ( isset( $values['membership_tags'] ) && isset( $values['membership_plan_expiry_date'] ) ) ? $values['membership_plan_expiry_date'] : '';
+						$membership_end_date = ( isset( $values['membership_tags'] ) && isset( $values['membership_tags']['membership_plan_expiry_date'] ) ) ? $values['membership_tags']['membership_plan_expiry_date'] : '';
 						$content             = str_replace( '{{' . $tag . '}}', $membership_end_date, $content );
 						break;
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously, in membership related email while using first_name smart tags its was not working. This PR fixes this issue.

Closes # .

### How to test the changes in this Pull Request:

1. Use {{first_name}} smart tag in membership related forms and check if the first_name is decoded or not in email.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> First Name smart tag not working in membership related emails.