### PR TITLE
UR-3104 Fix - Membership fields data translatable

### DIFF
--- a/includes/class-ur-smart-tags.php
+++ b/includes/class-ur-smart-tags.php
@@ -602,19 +602,39 @@ class UR_Smart_Tags {
 						$content = str_replace( '{{' . $tag . '}}', isset( $values['membership_plan_name'] ) ? $values['membership_plan_name'] : '', $content );
 						break;
 					case 'membership_plan_type':
-						$content = str_replace( '{{' . $tag . '}}', isset( $values['membership_plan_type'] ) ? $values['membership_plan_type'] : '', $content );
+						$membership_plan_types = array(
+							'Paid'         => __( 'Paid', 'user-registration' ),
+							'Free'         => __( 'Free', 'user-registration' ),
+							'Subscription' => __( 'Subscription', 'user-registration' ),
+						);
+						$membership_plan_type  = isset( $values['membership_tags']['membership_plan_type'] ) ? $membership_plan_types[ $values['membership_tags']['membership_plan_type'] ] : '';
+						$content               = str_replace( '{{' . $tag . '}}', $membership_plan_type, $content );
 						break;
 					case 'membership_plan_payment_method':
-						$content = str_replace( '{{' . $tag . '}}', isset( $values['membership_plan_payment_method'] ) ? $values['membership_plan_payment_method'] : '', $content );
+						$content = str_replace( '{{' . $tag . '}}', isset( $values['membership_tags']['membership_plan_payment_method'] ) ? $values['membership_tags']['membership_plan_payment_method'] : '', $content );
 						break;
 					case 'membership_plan_payment_amount':
 						$content = str_replace( '{{' . $tag . '}}', isset( $values['membership_plan_payment_amount'] ) ? $values['membership_plan_payment_amount'] : '', $content );
 						break;
 					case 'membership_plan_payment_status':
-						$content = str_replace( '{{' . $tag . '}}', isset( $values['membership_plan_payment_status'] ) ? $values['membership_plan_payment_status'] : '', $content );
+						$membership_plan_payment_statuses = array(
+							'Completed' => __( 'Completed', 'user-registration' ),
+							'Failed'    => __( 'Failed', 'user-registration' ),
+							'Pending'   => __( 'Pending', 'user-registration' ),
+						);
+						$membership_plan_payment_status   = isset( $values['membership_tags']['membership_plan_payment_status'] ) ? $membership_plan_payment_statuses[ $values['membership_tags']['membership_plan_payment_status'] ] : '';
+						$content                          = str_replace( '{{' . $tag . '}}', $membership_plan_payment_status, $content );
 						break;
 					case 'membership_plan_billing_cycle':
-						$content = str_replace( '{{' . $tag . '}}', isset( $values['membership_plan_billing_cycle'] ) ? $values['membership_plan_billing_cycle'] : '', $content );
+						$membership_plan_billing_cycles = array(
+							'N/A'     => __( 'N/A', 'user-registration' ),
+							'Daily'   => __( 'Daily', 'user-registration' ),
+							'Weekly'  => __( 'Weekly', 'user-registration' ),
+							'Monthly' => __( 'Monthly', 'user-registration' ),
+							'Yearly'  => __( 'Yearly', 'user-registration' ),
+						);
+						$membership_plan_billing_cycle  = isset( $values['membership_tags']['membership_plan_billing_cycle'] ) ? $membership_plan_billing_cycles[ $values['membership_tags']['membership_plan_billing_cycle'] ] : '';
+						$content                        = str_replace( '{{' . $tag . '}}', $membership_plan_billing_cycle, $content );
 						break;
 					case 'membership_plan_trial_period':
 						$content = str_replace( '{{' . $tag . '}}', isset( $values['membership_plan_trial_period'] ) ? $values['membership_plan_trial_period'] : '', $content );
@@ -626,7 +646,13 @@ class UR_Smart_Tags {
 						$content = str_replace( '{{' . $tag . '}}', isset( $values['membership_plan_expiry_date'] ) ? $values['membership_plan_expiry_date'] : '', $content );
 						break;
 					case 'membership_plan_status':
-						$content = str_replace( '{{' . $tag . '}}', isset( $values['membership_plan_status'] ) ? $values['membership_plan_status'] : '', $content );
+						$membership_plan_statuses = array(
+							'Pending' => __( 'Pending', 'user-registration' ),
+							'Active'  => __( 'Active', 'user-registration' ),
+							'Expired' => __( 'Expired', 'user-registration' ),
+						);
+						$membership_plan_status   = isset( $values['membership_tags']['membership_plan_status'] ) ? $membership_plan_statuses[ $values['membership_tags']['membership_plan_status'] ] : '';
+						$content                  = str_replace( '{{' . $tag . '}}', $membership_plan_status, $content );
 						break;
 					case 'membership_renewal_link':
 						$content = str_replace( '{{' . $tag . '}}', isset( $values['membership_renewal_link'] ) ? $values['membership_renewal_link'] : '', $content );
@@ -634,18 +660,40 @@ class UR_Smart_Tags {
 					case 'membership_plan_details':
 						$new_content = '';
 						if ( ! empty( $values['membership_tags'] ) ) {
-							$membership_tags = $values['membership_tags'];
-							$details         = array(
+							$membership_tags                  = $values['membership_tags'];
+							$membership_plan_types            = array(
+								'Paid'         => __( 'Paid', 'user-registration' ),
+								'Free'         => __( 'Free', 'user-registration' ),
+								'Subscription' => __( 'Subscription', 'user-registration' ),
+							);
+							$membership_plan_payment_statuses = array(
+								'Completed' => __( 'Completed', 'user-registration' ),
+								'Failed'    => __( 'Failed', 'user-registration' ),
+								'Pending'   => __( 'Pending', 'user-registration' ),
+							);
+							$membership_plan_billing_cycles   = array(
+								'N/A'     => __( 'N/A', 'user-registration' ),
+								'Daily'   => __( 'Daily', 'user-registration' ),
+								'Weekly'  => __( 'Weekly', 'user-registration' ),
+								'Monthly' => __( 'Monthly', 'user-registration' ),
+								'Yearly'  => __( 'Yearly', 'user-registration' ),
+							);
+							$membership_plan_statuses         = array(
+								'Pending' => __( 'Pending', 'user-registration' ),
+								'Active'  => __( 'Active', 'user-registration' ),
+								'Expired' => __( 'Expired', 'user-registration' ),
+							);
+							$details                          = array(
 								'Plan Name'         => $membership_tags['membership_plan_name'] ?? '',
-								'Membership Type'   => $membership_tags['membership_plan_type'] ?? '',
+								'Membership Type'   => $membership_plan_types[ $membership_tags['membership_plan_type'] ] ?? '',
 								'Payment Details'   => array(
-									'Method' => $membership_tags['membership_plan_payment_method'] ?? '',
+									'Method' => $values['membership_tags']['membership_plan_payment_method'] ?? '',
 									'Amount' => $membership_tags['membership_plan_total'] ?? '',
-									'Status' => $membership_tags['membership_plan_payment_status'] ?? '',
+									'Status' => $membership_plan_payment_statuses[ $membership_tags['membership_plan_payment_status'] ] ?? '',
 								),
-								'Billing Cycle'     => $membership_tags['membership_plan_billing_cycle'] ?? '',
+								'Billing Cycle'     => $membership_plan_billing_cycles[ $membership_tags['membership_plan_billing_cycle'] ] ?? '',
 								'Next Billing Date' => $membership_tags['membership_plan_next_billing_date'] ?? '',
-								'Membership Status' => $membership_tags['membership_plan_status'] ?? '',
+								'Membership Status' => $membership_plan_statuses[ $membership_tags['membership_plan_status'] ] ?? '',
 							);
 
 							$new_content = '<ul>';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR makes Billing data and payment status data translatable in membership email.

Closes # .

### How to test the changes in this Pull Request:

1. Use the smart tags **membership_plan_type, membership_plan_payment_status, membership_plan_billing_cycle** and in the membership_plan_details smart tag the membership plan type, payment status, billing cycle ans plan status. It must be translated in email.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Membership fields data translatable.