### PR TITLE
Fix - Grammer error  in order note of payment history

### DIFF
--- a/modules/membership/includes/Admin/Services/OrderService.php
+++ b/modules/membership/includes/Admin/Services/OrderService.php
@@ -45,7 +45,7 @@ class OrderService {
 		if ( ! empty( $type ) ) {
 			$note = sprintf(__('%s created order for %s of %s', 'user-registration'), $creator , $type , $membership['post_title']);
 		} else {
-			$note = sprintf(__('%s created an order for %s', 'user-registration'), $creator, $membership['post_title'] );
+			$note = sprintf(__('%s created order for %s', 'user-registration'), $creator, $membership['post_title'] );
 		}
 
 		$orders_data = array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR correct the grammer error on Order Notes of payment history popup.

### How to test the changes in this Pull Request:

1. Create new membership and check payment history.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Grammer error  in order note of payment history.
