### PR TITLE
UR-3213 Fix - Ordermeta table sql error

### DIFF
--- a/modules/membership/includes/Admin/Repositories/OrdersRepository.php
+++ b/modules/membership/includes/Admin/Repositories/OrdersRepository.php
@@ -160,15 +160,19 @@ class OrdersRepository extends BaseRepository implements OrdersInterface {
 	}
 
 	public function get_order_metas( $order_id ) {
+		$ordermeta_table = $this->wpdb()->prefix . 'ur_membership_ordermeta';
+
 		$result = $this->wpdb()->get_row(
 			$this->wpdb()->prepare(
 				"
 				SELECT wpom.*
 				FROM $this->table urmo
-					 JOIN wp_ur_membership_ordermeta wpom ON urmo.ID = wpom.order_id
-				WHERE urmo.ID = %d and wpom.meta_key = 'delayed_until' and wpom.meta_value > NOW()
+				JOIN $ordermeta_table wpom ON urmo.ID = wpom.order_id
+				WHERE urmo.ID = %d
+				AND wpom.meta_key = 'delayed_until'
+				AND wpom.meta_value > NOW()
 				ORDER BY urmo.ID DESC
-		",
+				",
 				$order_id
 			),
 			ARRAY_A


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes the issue of ordermeta table does not exists in SQL.

Closes # .

### How to test the changes in this Pull Request:

This occurs occasionally and occurred in user's site.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Ordermeta table sql error.