### PR TITLE
UR-3229 Fix - Navigation tab not displaying in My Account page while using Kadence theme

### DIFF
--- a/includes/functions-ur-page.php
+++ b/includes/functions-ur-page.php
@@ -16,7 +16,7 @@ add_filter( 'body_class', 'ur_body_class' );
 add_filter( 'admin_body_class', 'ur_admin_body_class' );
 
 // Hooks for my account section.
-add_action( 'user_registration_account_navigation', 'user_registration_account_navigation' );
+add_action( 'user_registration_account_navigation', 'user_registration_account_navigation', 999 );
 add_action( 'user_registration_account_content', 'user_registration_account_content' );
 add_action( 'user_registration_account_dashboard_endpoint', 'user_registration_account_dashboard' );
 add_action( 'user_registration_account_edit-profile_endpoint', 'user_registration_account_edit_profile' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

While using Kadence theme, the navigation menu was not displaying. This PR fixes it.

Closes # .

### How to test the changes in this Pull Request:

1. Use Kadence theme
2. Go to My Account Page and check if Navigation tab is visible or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Navigation tab not displaying in My Account page while using Kadence theme.
