### PR TITLE
UR-3222 Fix - Duplicate Profile Detail text on My Account Page while using Vertical Layout

### DIFF
--- a/templates/myaccount/form-edit-password.php
+++ b/templates/myaccount/form-edit-password.php
@@ -37,15 +37,6 @@ ur_do_deprecated_action( 'user_registration_before_edit_account_form', array(), 
  */
 do_action( 'user_registration_before_change_password_form' );
 
-$layout = get_option( 'user_registration_my_account_layout', 'horizontal' );
-
-if ( 'vertical' === $layout ) {
-	?>
-	<div class="user-registration-MyAccount-content__header">
-		<h1><?php echo wp_kses_post( $endpoint_label ); ?></h1>
-	</div>
-	<?php
-}
 ?>
 <div class="user-registration-MyAccount-content__body">
 	<div class="ur-frontend-form login" id="ur-frontend-form">

--- a/templates/myaccount/form-edit-profile-non-urm-user.php
+++ b/templates/myaccount/form-edit-profile-non-urm-user.php
@@ -24,15 +24,6 @@ $user           = wp_get_current_user();
 $user_id        = get_current_user_id();
 $endpoint_label = isset( $args['endpoint_label'] ) ? $args['endpoint_label'] : '';
 
-$layout = get_option('user_registration_my_account_layout', 'horizontal');
-
-if ('vertical' === $layout) {
-	?>
-	<div class="user-registration-MyAccount-content__header">
-		<h1><?php echo wp_kses_post($endpoint_label); ?></h1>
-	</div>
-	<?php
-}
 ?>
 <div class="user-registration-MyAccount-content__body">
 	<div class="ur-frontend-form login ur-edit-profile" id="ur-frontend-form">

--- a/templates/myaccount/form-edit-profile.php
+++ b/templates/myaccount/form-edit-profile.php
@@ -41,15 +41,6 @@ do_action_deprecated( 'user_registration_before_edit_profile_form', array(), '3.
  */
 do_action( 'user_registration_before_edit_profile_form_data', $user_id, $form_id );
 
-$layout = get_option( 'user_registration_my_account_layout', 'horizontal' );
-
-if ( 'vertical' === $layout ) {
-	?>
-	<div class="user-registration-MyAccount-content__header">
-		<h1><?php echo wp_kses_post( $endpoint_label ); ?></h1>
-	</div>
-	<?php
-}
 ?>
 <div class="user-registration-MyAccount-content__body">
 	<div class="ur-frontend-form login ur-edit-profile" id="ur-frontend-form">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

While using vertical layout for My Account Page, Duplicate Profile Detail text was displaying. This PR removes the sub heading one.

Closes # .

### How to test the changes in this Pull Request:

1. Go to URM >  Settings > Select Vertical as layout under > My Account Section
2. Click on Save Changes button
3. Now login as user and navigate to Edit Profile Page then check if there are double title Profile Details or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Duplicate Profile Detail text on My Account Page while using Vertical Layout.