### PR TITLE
UR-3250 Fix - Undefined variable warning

### DIFF
--- a/modules/membership/includes/Templates/Emails/payment-successful-email.php
+++ b/modules/membership/includes/Templates/Emails/payment-successful-email.php
@@ -5,8 +5,8 @@ $currency   = get_user_meta( $user_id, 'ur_payment_currency', true );
 $currency   = ! empty( $currency ) ? $currency : 'USD';
 $symbol     = $currencies[ $currency ]['symbol'] ?? '$';
 $trial_status = isset($invoice_details['membership_plan_trial_status']) ? $invoice_details['membership_plan_trial_status'] : 'off';
-$trial_amount = $trial_status === 'On' ? $symbol."0.00" : $invoice_details['membership_plan_trial_amount'];
-$total_amount = $trial_status === 'On' ? $symbol."0.00" : $invoice_details['membership_plan_total'];
+$trial_amount = $trial_status === 'On' ? $symbol . "0.00" : ($invoice_details['membership_plan_trial_amount'] ?? $symbol . "0.00");
+$total_amount = $trial_status === 'On' ? $symbol . "0.00" : ($invoice_details['membership_plan_total'] ?? $symbol . "0.00");
 if ( $invoice_details['is_membership'] ) :
 
 	// Define label–key pairs for membership rows


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In normal registration form, undefined variable warning was thrown in log and in payment success email. This PR fixes this issue.

Closes # .

### How to test the changes in this Pull Request:

1. Create normal payment form
2. In payment successful email for user, check if undefined variable is printed or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Undefined variable warning.
