### PR TITLE
UR-32061 Dev - Filter to tick remember me checkbox by default in login form

### DIFF
--- a/templates/myaccount/form-login.php
+++ b/templates/myaccount/form-login.php
@@ -253,7 +253,10 @@ if ( isset( $_GET['page'] ) && 'user-registration-login-forms' === $_GET['page']
 										<input
 											class="user-registration-form__input user-registration-form__input-checkbox"
 											name="rememberme" type="checkbox" id="rememberme" value="forever"
-											<?php echo $is_login_settings ? 'disabled' : ''; ?>
+											<?php
+												echo $is_login_settings ? 'disabled' : '';
+												checked( apply_filters( 'user_registration_membership_login_form_remember_me_checked', false ), true );
+											?>
 										/>
 										<span><?php echo esc_html( $labels['remember_me'] ); ?></span>
 									</label>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR introduces the filter **user_registration_membership_login_form_remember_me_checked** to check the checkbox for Remember Me in Login form.

Closes # .

### How to test the changes in this Pull Request:

1. Use the filter **user_registration_membership_login_form_remember_me_checked**
2. Go to Login Form in frontend and check if Remember Me checkbox is checked by default or not.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Filter to tick remember me checkbox by default in login form.
