### PR TITLE
UR-3228 Fix - Character limit validation message not translatable

### DIFF
--- a/assets/js/frontend/user-registration-form-validator.js
+++ b/assets/js/frontend/user-registration-form-validator.js
@@ -677,6 +677,20 @@
 					element.step
 				);
 			};
+
+			$.validator.messages.minlength = function (params, element) {
+				return user_registration_params.message_min_length_fields.replace(
+					"%qty%",
+					params
+				);
+			};
+
+			$.validator.messages.maxlength = function (params, element) {
+				return user_registration_params.message_max_length_fields.replace(
+					"%qty%",
+					params
+				);
+			};
 		}
 	};
 

--- a/includes/class-ur-frontend-scripts.php
+++ b/includes/class-ur-frontend-scripts.php
@@ -473,6 +473,8 @@ class UR_Frontend_Scripts {
 					'message_confirm_number_field_max'  => esc_html__( 'Please enter a value less than or equal to %qty%.', 'user-registration' ),
 					'message_confirm_number_field_min'  => esc_html__( 'Please enter a value greater than or equal to %qty%.', 'user-registration' ),
 					'message_confirm_number_field_step' => esc_html__( 'Please enter a multiple of %qty%.', 'user-registration' ),
+					'message_min_length_fields'         => esc_html__( 'Please enter at least %qty% characters.', 'user-registration' ),
+					'message_max_length_fields'         => esc_html__( 'Please enter no more than %qty% characters.', 'user-registration' ),
 					'ursL10n'                           => array(
 						'user_successfully_saved'     => get_option( 'user_registration_successful_form_submission_message_manual_registation', esc_html__( 'User successfully registered.', 'user-registration' ) ),
 						'user_under_approval'         => get_option( 'user_registration_successful_form_submission_message_admin_approval', esc_html__( 'User registered. Wait until admin approves your registration.', 'user-registration' ) ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The validation message for minimum character count was not translatable. This PR fixes this issue.

Closes # .

### How to test the changes in this Pull Request:

1. Enable minimum character count for any text field
2. Use translation plugin and check if the text is translatable or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Character limit validation message not translatable.
