### PR TITLE
UR-3364 Fix - Membership smart tag and plural translation for membership duration

### DIFF
--- a/includes/Functions/CoreFunctions.php
+++ b/includes/Functions/CoreFunctions.php
@@ -398,7 +398,7 @@ if ( ! function_exists( 'build_membership_list_frontend' ) ) {
 				'amount'            => ! empty( $membership_meta_value ) ? $membership['meta_value']['amount'] : 0,
 				'currency_symbol'   => $symbol,
 				'calculated_amount' => 'free' === $membership_type ? 0 : ( ! empty( $membership_meta_value ) ? round( $membership_meta_value['amount'] ) : 0 ),
-				'period'            => 'free' === $membership_type ? __( 'Free', 'user-registration' ) : ( ( ! empty( $membership_meta_value ) && 'subscription' === $membership_meta_value['type'] ) ? $membership_cur_amount . ' / ' . number_format( $membership['meta_value']['subscription']['value'] ) . ' ' . ucfirst( $duration_label ) . ( $membership['meta_value']['subscription']['value'] > 1 ? 's' : '' ) : $membership_cur_amount ),
+				'period'            => 'free' === $membership_type ? __( 'Free', 'user-registration' ) : ( ( ! empty( $membership_meta_value ) && 'subscription' === $membership_meta_value['type'] ) ? $membership_cur_amount . ' / ' . number_format( $membership['meta_value']['subscription']['value'] ) . ' ' . ucfirst( $duration_label ) . ( $membership['meta_value']['subscription']['value'] > 1 ? __('s', 'user-registration'): '' ) : $membership_cur_amount ),
 			);
 			if ( isset( $membership['meta_value']['payment_gateways'] ) ) {
 				foreach ( $membership['meta_value']['payment_gateways'] as $key => $gateways ) {

--- a/modules/membership/includes/Admin/Services/EmailService.php
+++ b/modules/membership/includes/Admin/Services/EmailService.php
@@ -330,8 +330,9 @@ class EmailService
 		$user     = get_userdata( $data['member_id'] );
 		$form_id  = ur_get_form_id_by_userid( $data['member_id'] );
 		$settings = new UR_Settings_Membership_Cancellation_User_Email();
-		$values   = array(
-			'membership_plan_name' => esc_html__( $data['membership_metas']['title'] )
+		$subscription_service = new SubscriptionService();
+		$values               = array(
+			'membership_tags' => $subscription_service->get_membership_plan_details( $data )
 		);
 		$message  = apply_filters( 'user_registration_process_smart_tags', get_option( 'user_registration_membership_cancellation_admin_email_message', $settings->user_registration_get_membership_cancellation_user_email() ), $values, $form_id );;
 		$message     = apply_filters( 'ur_membership_membership_cancellation_email_custom_template', $message, $subject );

--- a/modules/membership/includes/Emails/User/UR_Settings_Membership_Expiring_Soon_User_Email.php
+++ b/modules/membership/includes/Emails/User/UR_Settings_Membership_Expiring_Soon_User_Email.php
@@ -154,7 +154,7 @@ class UR_Settings_Membership_Expiring_Soon_User_Email {
 					Just a reminder — your membership is set to expire on {{membership_end_date}}. <br>
 					To avoid any interruption in access to your member benefits, please make sure to renew before the expiration date. <br>
 					Otherwise, you can manually renew in just a few clicks.<br>
-					({renewal_link})<br>
+					({membership_renewal_link})<br>
 					Stay connected and keep enjoying everything your membership offers!<br>
 					Best regards, <br>
 					{{blog_info}}',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

While using membership_end_date and membership_renewal_link smart tags in other places instead of only membership expiring soon email. It was returning empty value. Also while translating the plural duration in membership listing in registration form it was adding (s) no matter what was the plural form in other languages

Closes # .

### How to test the changes in this Pull Request:

1. Create a membership form and translate the site using translation plugins
2. Search (s) in translation plugin and translate the text and check if it is accurate or not
3. Use membership_end_date and membership_renewal_link smart tags in all membership email and check if it is working as expected or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
