### PR TITLE
UR-3334 Fix - 3D secure not working for stripe on subscription membership

### DIFF
--- a/assets/js/modules/membership/frontend/user-registration-membership-frontend.js
+++ b/assets/js/modules/membership/frontend/user-registration-membership-frontend.js
@@ -1499,9 +1499,11 @@
 									data.subscription.status = "active";
 									resolve({
 										subscription: data.subscription,
-										form_id: data.form_id,
+										form_id: data.form_response.form_id,
 										response_data: data.response_data,
-										form_response: data.form_response
+										prepare_members_data: data.prepare_members_data,
+										form_response: data.form_response,
+										three_d_secure: true
 									});
 								} else {
 									var message =
@@ -1529,7 +1531,7 @@
 						? data.response_data.data.is_renewing
 						: false;
 
-			if (is_upgrading || is_renewing) {
+			if (is_upgrading || is_renewing || true === data.three_d_secure) {
 				stripe_settings.update_order_status(
 					data.subscription,
 					data.response_data,

--- a/modules/membership/includes/Admin/Services/Stripe/StripeService.php
+++ b/modules/membership/includes/Admin/Services/Stripe/StripeService.php
@@ -289,6 +289,13 @@ class StripeService {
 
 	public function update_order( $data ) {
 		$transaction_id = $data['payment_result']['paymentIntent']['id'] ?? '';
+
+		if(empty($transaction_id)){
+			$transaction_id = $data['payment_result']['latest_invoice']['payment_intent']['next_action']['use_stripe_sdk']['directory_server_encryption']['server_transaction_id'] ?? '';
+		}
+
+		$three_d_secure_2_source = $data['payment_result']['latest_invoice']['payment_intent']['next_action']['use_stripe_sdk']['three_d_secure_2_source'] ?? '';
+
 		$payment_status = sanitize_text_field( $data['payment_status'] );
 		$member_id      = absint( $_POST['member_id'] );
 		$is_upgrading   = ur_string_to_bool( get_user_meta( $member_id, 'urm_is_upgrading', true ) );
@@ -381,7 +388,7 @@ class StripeService {
 				)
 			);
 
-			if ( $is_order_updated && 'paid' === $member_order['order_type'] ) {
+			if ( ($is_order_updated && 'paid' === $member_order['order_type']) || ($is_order_updated && !empty($three_d_secure_2_source) && 'subscription' === $member_order['order_type']) ) {
 				$this->members_subscription_repository->update(
 					$member_subscription['ID'],
 					array(
@@ -684,17 +691,23 @@ class StripeService {
 				)
 			);
 
-			if ( 'active' === $subscription_status || 'trialing' === $subscription_status ) {
+			$three_ds2_source = $subscription->latest_invoice->payment_intent->next_action->use_stripe_sdk->three_d_secure_2_source ?? '';
+
+			if ( 'active' === $subscription_status || 'trialing' === $subscription_status || ( 'incomplete' === $subscription_status && ! empty( $three_ds2_source ) ) ) {
+				$status = ( 'incomplete' === $subscription_status && ! empty( $three_ds2_source ) ) ? 'pending' : 'completed';
 				$this->members_orders_repository->update(
 					$member_order['ID'],
 					array(
-						'status'         => 'completed',
+						'status'         => $status,
 						'transaction_id' => $subscription->id,
 					)
 				);
 				switch ( $subscription_status ) {
 					case 'trialing':
 						$subscription_status = ( $is_upgrading && ! empty( $next_subscription['delayed_until'] ) ) ? 'active' : 'trial';
+						break;
+					case ( 'incomplete' === $subscription_status && ! empty( $three_ds2_source ) ):
+						$subscription_status = 'pending';
 						break;
 					default:
 						break;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

3D secure for stripe membership subscription was not working. This PR fixes the issue.

Closes # .

### How to test the changes in this Pull Request:

1. Create a membership form with subscription plan.
2. Use either 4000 0025 0000 3155 or 4000 0027 6000 3184 for 3d secure payment in stripe membership
3. Check if the pop up opens or not for secure payment.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - 3D secure not working for stripe on subscription membership.