### PR TITLE
UR-3407 Dev- Filter to modify profile picture max size

### DIFF
--- a/templates/myaccount/form-edit-profile-non-urm-user.php
+++ b/templates/myaccount/form-edit-profile-non-urm-user.php
@@ -112,7 +112,7 @@ $endpoint_label = isset( $args['endpoint_label'] ) ? $args['endpoint_label'] : '
 								?>
 									<img class="profile-preview" alt="profile-picture" src="<?php echo esc_url( $image ); ?>" style='max-width:96px; max-height:96px;' >
 
-									<p class="user-registration-tips"><?php echo esc_html__( 'Max size: ', 'user-registration' ) . esc_attr( size_format( $max_upload_size ) ); ?></p>
+									<p class="user-registration-tips"><?php echo esc_html__( 'Max size: ', 'user-registration' ) . esc_attr( apply_filters ('user_registration_profile_picture_max_upload_size', size_format( $max_upload_size ) ) ); ?></p>
 									</div>
 									<header>
 										<p><strong>

--- a/templates/myaccount/form-edit-profile.php
+++ b/templates/myaccount/form-edit-profile.php
@@ -125,7 +125,7 @@ do_action( 'user_registration_before_edit_profile_form_data', $user_id, $form_id
 								?>
 									<img class="profile-preview" alt="profile-picture" src="<?php echo esc_url( $image ); ?>" style='max-width:96px; max-height:96px;' >
 
-									<p class="user-registration-tips"><?php echo esc_html__( 'Max size: ', 'user-registration' ) . esc_attr( size_format( $max_upload_size ) ); ?></p>
+									<p class="user-registration-tips"><?php echo esc_html__( 'Max size: ', 'user-registration' ) . esc_attr( apply_filters ( 'user_registration_profile_picture_max_upload_size', size_format( $max_upload_size ) ) ); ?></p>
 									</div>
 									<header>
 										<p class="ur-new-profile-image-message"><strong>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds the filter **user_registration_profile_picture_max_upload_size** to modify the max file size for profile picture. 

Closes # .

### How to test the changes in this Pull Request:

1. Use filter user_registration_profile_picture_max_upload_size to modify the profile picture size in My account page.
2. Login ad user and check the max size under Profile Picture.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev- Filter to modify profile picture max size.
