### PR TITLE
UR-3409 Fix - PHP warning array to string conversion

### DIFF
--- a/includes/abstracts/abstract-ur-log-handler.php
+++ b/includes/abstracts/abstract-ur-log-handler.php
@@ -39,7 +39,8 @@ abstract class UR_Log_Handler implements UR_Log_Handler_Interface {
 	protected static function format_entry( $timestamp, $level, $message, $context ) {
 		$time_string  = self::format_time( $timestamp );
 		$level_string = strtoupper( $level );
-		$entry        = "{$time_string} {$level_string} {$message}";
+		$entry_message = is_array( $message ) ? json_encode( $message ) : $message;
+		$entry         = "{$time_string} {$level_string} {$entry_message}";
 		/**
 		 * Filter the format log entry.
 		 *


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes the issue of PHP warning array to string conversion.+

Closes # .

### How to test the changes in this Pull Request:

1. Go to admin dashboard and check if PHP warning Array to String is displayed or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - PHP warning array to string conversion.