### PR TITLE
UR-3480 Fix - Admin unable to access content while restricting whole content and using divi theme

### DIFF
--- a/modules/content-restriction/class-urcr-frontend.php
+++ b/modules/content-restriction/class-urcr-frontend.php
@@ -59,7 +59,7 @@ class URCR_Frontend {
 	 */
 	public function include_run_content_restrictions( $template ) {
 
-		if ( is_embed() ) {
+		if ( is_embed() || current_user_can('manage_options') ) {
 			return $template;
 		}
 		$content_restriction_enabled = ur_string_to_bool( get_option( 'user_registration_content_restriction_enable', true ) );
@@ -931,7 +931,6 @@ class URCR_Frontend {
 	 * Perform basic restriction task for blogs.
 	 */
 	public function basic_restrictions_templates( $template, $post ) {
-
 		if ( is_object( $post ) ) {
 			$post_id = absint( $post->ID );
 		} elseif ( is_array( $post ) && isset( $post['ID'] ) ) {
@@ -1017,7 +1016,6 @@ class URCR_Frontend {
 		} elseif ( $get_meta_data_checkbox ) {
 			$this->basic_restrictions();
 		}
-
 		return $template;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

While using whole site restriction and divi theme, contents such as email preview was not being accessible to admin .

**Note: The issue was replicated only on user's site and not on mine**
Closes # .

### How to test the changes in this Pull Request:

1. Use divi theme
2. Use whole site content restriction and access pages, email preview
3. Check if they are accessible or not.

**Note: The issue was replicated only on user's site and not on miine**

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Admin unable to access content while restricting whole content and using divi theme.