### PR TITLE
UR-3485 Fix - Form redirection timeout not working while set to 0

### DIFF
--- a/assets/js/frontend/user-registration.js
+++ b/assets/js/frontend/user-registration.js
@@ -1524,9 +1524,6 @@
 											ajax_response.responseText
 										);
 
-<<<<<<< Updated upstream
-										var timeout = response.data.redirect_timeout ?? 2000;
-=======
 									var timeout = (
 										response &&
 										response.data &&
@@ -1536,7 +1533,6 @@
 											)
 												? response.data.redirect_timeout
 												: 2000;
->>>>>>> Stashed changes
 
 										if (
 											typeof response.success !==


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. URM> all forms > create new one or select existing one > go to form settings > general
2.go to Redirect After Registration > and select a page 
3. add 0 in Delay Before Redirect ( Seconds )
4. preview the form and check if the redirection is working as expected or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Form redirection timeout not working while set to 0.
