### PR TITLE
UR-3483 Fix - Arbitrary code execution shortcode [gallery ids=18]

### DIFF
--- a/includes/blocks/block-types/class-ur-block-registration-form.php
+++ b/includes/blocks/block-types/class-ur-block-registration-form.php
@@ -25,17 +25,33 @@ class UR_Block_Regstration_Form extends UR_Block_Abstract {
 	 * @return string
 	 */
 	protected function build_html( $content ) {
-		$form_id = isset( $this->attributes['formId'] ) ? $this->attributes['formId'] : '';
+		$form_id    = isset( $this->attributes['formId'] ) ? $this->attributes['formId'] : '';
 		$user_state = isset( $this->attributes['userState'] ) ? $this->attributes['userState'] : 'logged_out';
 		if ( empty( $form_id ) ) {
 			return $content;
 		}
 
-		return UR_Shortcodes::form(
-			array(
-				'id' => $form_id,
-				'userState' => $user_state
+		return $this->escape_shortcodes_in_html(
+			UR_Shortcodes::form(
+				array(
+					'id'        => $form_id,
+					'userState' => $user_state,
+				)
 			)
+		);
+	}
+
+	/**
+	 * Escape shortcodes in html.
+	 *
+	 * @param string $html HTML content.
+	 * @return string
+	 */
+	private function escape_shortcodes_in_html( $html ) {
+		return str_replace(
+			array( '[', ']' ),
+			array( '&#91;', '&#93;' ),
+			$html
 		);
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?


### Changes proposed in this Pull Request:
https://themegrill.atlassian.net/browse/UR-3483
### How to test the changes in this Pull Request:

1. Create form with field display name field.
2. Create registration page with registration form block > Register > display name value [gallery ids=18]
3. Login > visit registration page > verify the gallery rendering or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?


### Changelog entry

>  Fix - Arbitrary code execution shortcode [gallery ids=18].
