### PR TITLE
Fix:Raw css showing issue  in admins emails due to inline style tag

### DIFF
--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -5518,95 +5518,19 @@ if ( ! function_exists( 'ur_wrap_email_body_content' ) ) {
 	 *
 	 * @return string Wrapped email content.
 	 */
-	function ur_wrap_email_body_content( $body_content ) {
-		// Check if we're in editor context - exclude CSS when displaying editor on settings page.
-		// Include CSS for preview, email sending, cron, CLI, and AJAX email actions.
-		$is_preview       = isset( $_GET['ur_email_preview'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$current_screen   = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
-		$is_settings_page = $current_screen && 'user-registration_page_user-registration-settings' === $current_screen->id;
-		$is_email_action  = isset( $_REQUEST['action'] ) && (
-			'ur_send_test_email' === $_REQUEST['action'] ||
-			strpos( $_REQUEST['action'], 'email' ) !== false // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		);
+		function ur_wrap_email_body_content( $body_content ) {
+		$is_preview_mode = isset( $_GET['ur_email_preview'] ) && 'email_template_option' === sanitize_text_field( wp_unslash( $_GET['ur_email_preview'] ) );
+		$inner_width     = $is_preview_mode ? '600px' : 'auto';
 
-		// Only exclude CSS when on settings page displaying editor (not when sending emails).
-		$is_editor_context = is_admin() && ! $is_preview && $is_settings_page && ! $is_email_action &&
-							! wp_doing_cron() && ! ( defined( 'WP_CLI' ) && WP_CLI ) &&
-							! ( defined( 'DOING_AJAX' ) && DOING_AJAX && $is_email_action );
-
-		// Responsive CSS styles for email template - only include when not in editor context.
-		$responsive_styles = '';
-		if ( ! $is_editor_context ) {
-			$responsive_styles = '<style type="text/css">
-	/* Responsive Email Styles - Scoped to email wrapper only */
-	@media only screen and (max-width: 600px) {
-		.email-wrapper-outer {
-			padding: 20px 0 !important;
-		}
-		.email-wrapper-inner {
-			width: 100% !important;
-			max-width: 100% !important;
-			margin: 0 !important;
-			border-radius: 0 !important;
-		}
-		.email-header {
-			padding: 20px 15px !important;
-			border-radius: 0 !important;
-		}
-		.email-body {
-			padding: 25px 15px !important;
-		}
-		.email-footer {
-			padding: 20px 15px !important;
-		}
-		.email-logo img {
-			max-width: 150px !important;
-			max-height: 50px !important;
-		}
-		.email-header-text {
-			font-size: 16px !important;
-			margin-top: 10px !important;
-		}
-		.email-footer p {
-			font-size: 12px !important;
-		}
-		.email-footer a {
-			font-size: 13px !important;
-		}
-	}
-	@media only screen and (max-width: 480px) {
-		.email-wrapper-outer {
-			padding: 10px 0 !important;
-		}
-		.email-header {
-			padding: 15px 10px !important;
-		}
-		.email-body {
-			padding: 20px 10px !important;
-		}
-		.email-footer {
-			padding: 15px 10px !important;
-		}
-		.email-logo img {
-			max-width: 120px !important;
-			max-height: 40px !important;
-		}
-		.email-header-text {
-			font-size: 14px !important;
-		}
-	}
-</style>';
-		}
-
-		// Check if this is a preview and set width to 600px.
-		$is_preview  = isset( $_GET['ur_email_preview'] ) && 'email_template_option' === sanitize_text_field( wp_unslash( $_GET['ur_email_preview'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$email_width = $is_preview ? '600px' : 'unset';
-		$max_width   = $is_preview ? '600px' : '600px'; // Max width for better readability on all devices.
-
-		return $responsive_styles . '
-	<div class="email-wrapper-outer" style="font-family: Arial, sans-serif; padding: 100px 0;">
-	<div class="email-wrapper-inner" style="width: ' . esc_attr( $email_width ) . '; max-width: ' . esc_attr( $max_width ) . '; margin: 0 auto; background-color: #ffffff; border-radius: 12px; overflow: hidden; box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);">
-	<div class="email-body" style="padding: 30px; background-color: #ffffff;">' . $body_content . '</div></div></div>';
+		return '<div style="margin: 0; padding: 0; width: 100%; background-color: #f4f4f4; font-family: Arial, Helvetica, sans-serif;">
+	<div style="width: 100%; padding: 40px 10px; box-sizing: border-box;">
+		<div style="width: ' . esc_attr( $inner_width ) . '; max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 12px; box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1); overflow: hidden;">
+			<div style="padding: 30px; background-color: #ffffff; font-size: 14px; line-height: 1.6; color: #333333; box-sizing: border-box;">
+				' . $body_content . '
+			</div>
+		</div>
+	</div>
+</div>';
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
Fixes an issue where raw responsive CSS appeared in the admin email editor due to inline <style> tags being injected .

### How to test the changes in this Pull Request:
1. Submit the form and check the User registered email. 
2.Verify that no raw CSS is visible in the email content.

### Replication process:
The issue can be replicated by sending emails with a text/plain content type, where inline <style> tags appear as raw text:
add_filter( 'wp_mail_content_type', function () {
	return 'text/plain';
} );

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Raw css showing issue  in admins emails due to inline style tag.
