### PR TITLE
Fix Logic error in conditional check for payment meta (handling `false` return value)

### DIFF
--- a/includes/frontend/class-ur-frontend.php
+++ b/includes/frontend/class-ur-frontend.php
@@ -331,7 +331,7 @@ class UR_Frontend {
 			);
 		}
 
-		if ( 'membership' === $user_source || ( '' !== $payment_method && ( '' !== $ur_payment_subscription || 'paypal_standard' === $payment_method ) ) ) {
+		if ( 'membership' === $user_source || ( ! empty( $payment_method ) && ( ! empty( $ur_payment_subscription ) || 'paypal_standard' === $payment_method ) ) ) {
 			add_action( 'wp_loaded', array( $this, 'ur_add_membership_tab_endpoint' ) );
 			add_filter( 'user_registration_account_menu_items', array( $this, 'ur_membership_tab' ), 10, 1 );
 			add_action(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://github.com/wpeverest/user-registration/issues/1144 .

### How to test the changes in this Pull Request:

1. With a PHP debugger you can check if the `get_user_meta` return `false`, the condition that I fixed is `true` and it go inside the `if`.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

This pull request makes a minor update to the conditional logic in the `ur_register_payment_tab_if_eligible` function to improve how payment method and subscription values are checked for membership tab eligibility.

* Logic now uses `! empty()` checks for `$payment_method` and `$ur_payment_subscription` instead of comparing to empty strings, ensuring more robust handling of these variables. (`includes/frontend/class-ur-frontend.php`, [includes/frontend/class-ur-frontend.phpL334-R334](diffhunk://#diff-c6b985f6111fede7dd55c21e68ab7dcc04b46510150838528a6505a31eee2896L334-R334))