### PR TITLE
Fix - Export Members causes fatal memory exhaustion on large user datasets

### DIFF
--- a/includes/admin/class-ur-admin-export-users.php
+++ b/includes/admin/class-ur-admin-export-users.php
@@ -78,20 +78,30 @@ class UR_Admin_Export_Users {
 		$to_date       = isset( $_POST['to_date'] ) ? sanitize_text_field( wp_unslash( $_POST['to_date'] ) ) : '';
 		$export_format = isset( $_POST['export_format'] ) ? sanitize_text_field( wp_unslash( $_POST['export_format'] ) ) : 'csv';
 
-		$users = get_users(
+		// Build the meta_query to filter users by form ID properly.
+		$form_meta_query = array(
 			array(
-				'ur_form_id' => $form_id,
+				'key'     => 'ur_form_id',
+				'value'   => $form_id,
+				'compare' => '=',
+			),
+		);
+
+		$check_users = get_users(
+			array(
+				'fields'     => 'ID',
+				'meta_query' => $form_meta_query, //phpcs:ignore
 				'number'     => 1,
 			)
 		);
 
-		if ( count( $users ) === 0 ) {
+		if ( count( $check_users ) === 0 ) {
 			echo '<div id="message" class="updated inline notice notice-error"><p><strong>' . esc_html__( 'No users found with this form id.', 'user-registration' ) . '</strong></p></div>';
 			return;
 		}
 
-		// Batch size.
-		$batch_size = apply_filters( 'user_registration_export_users_batch_size', 500 );
+		// Batch size — kept small to avoid bulk usermeta cache exhausting memory.
+		$batch_size = apply_filters( 'user_registration_export_users_batch_size', 50 );
 		$offset     = 0;
 
 		// Open the file for writing.
@@ -119,19 +129,24 @@ class UR_Admin_Export_Users {
 
 		// Loop over users in batches.
 		while ( true ) {
-			// Fetch users in batches.
-			$users = get_users(
+			// Fetch only user IDs to avoid bulk-loading all usermeta in one query.
+			$user_ids = get_users(
 				array(
-					'ur_form_id' => $form_id,
+					'fields'     => 'ID',
+					'meta_query' => $form_meta_query, //phpcs:ignore
 					'number'     => $batch_size,
 					'offset'     => $offset,
 				)
 			);
 
 			// If no users are found, break the loop.
-			if ( empty( $users ) ) {
+			if ( empty( $user_ids ) ) {
 				break;
 			}
+
+			// Load full user objects individually — prevents the single bulk
+			// usermeta SQL query from exhausting available memory.
+			$users = array_map( 'get_userdata', $user_ids );
 
 			// Generate rows for this batch.
 			$rows = $this->generate_rows( $users, $form_id, $unchecked_fields, $checked_additional_fields, $from_date, $to_date );
@@ -140,6 +155,8 @@ class UR_Admin_Export_Users {
 			foreach ( $rows as $row ) {
 				fputcsv( $handle, $row );
 			}
+
+			wp_cache_flush();
 
 			// Increase the offset for the next batch.
 			$offset += $batch_size;
@@ -232,6 +249,24 @@ class UR_Admin_Export_Users {
 
 		$rows = array();
 
+		// Cache expensive calls outside the user loop to prevent repeated DB queries.
+		$user_form_fields        = ur_get_form_fields( $form_id );
+		$columns                 = $this->generate_columns( $form_id, $unchecked_fields );
+		$columns_with_additional = $this->generate_columns( $form_id, $unchecked_fields, $checked_additional_fields );
+		$user_table_data         = ur_get_user_table_fields();
+		$user_meta_data          = ur_get_registered_user_meta_fields();
+
+		// Detect profile picture field once for all users.
+		$urm_form_has_profile_picture = false;
+		$user_profile_picture_key     = '';
+		foreach ( $user_form_fields as $field_key => $field_data ) {
+			if ( isset( $field_data->field_key ) && 'profile_picture' === $field_data->field_key ) {
+				$urm_form_has_profile_picture = true;
+				$user_profile_picture_key     = $field_key;
+				break;
+			}
+		}
+
 		foreach ( $users as $user ) {
 
 			if ( ! isset( $user->data->ID ) ) {
@@ -246,19 +281,8 @@ class UR_Admin_Export_Users {
 			if ( $user_form_id !== $form_id ) {
 				continue;
 			}
-			$user_id_row                  = array();
-			$user_extra_row               = ur_get_user_extra_fields( $user->data->ID, 'export_users' );
-			$user_form_fields             = ur_get_form_fields( $form_id );
-			$urm_form_has_profile_picture = false;
-			$user_profile_picture_key     = '';
-
-			foreach ( $user_form_fields as $field_key => $field_data ) {
-				if ( isset( $field_data->field_key ) && 'profile_picture' === $field_data->field_key ) {
-					$urm_form_has_profile_picture = true;
-					$user_profile_picture_key     = $field_key;
-					break;
-				}
-			}
+			$user_id_row    = array();
+			$user_extra_row = ur_get_user_extra_fields( $user->data->ID, 'export_users' );
 
 			if ( $urm_form_has_profile_picture && ! empty( $user_profile_picture_key ) ) {
 				$profile_picture_id = get_user_meta( $user->data->ID, 'user_registration_profile_pic_url', true );
@@ -272,8 +296,6 @@ class UR_Admin_Export_Users {
 				// Assign profile picture URL to user extra row.
 				$user_extra_row[ $user_profile_picture_key ] = $profile_picture_url;
 			}
-
-			$columns = $this->generate_columns( $form_id, $unchecked_fields );
 
 			foreach ( $user_extra_row as $user_extra_data_key => $user_extra_data ) {
 
@@ -304,25 +326,19 @@ class UR_Admin_Export_Users {
 				}
 			}
 
-			$user_table_data     = ur_get_user_table_fields();
 			$user_table_data_row = array();
 
 			// Get user table data that are on column.
 			foreach ( $user_table_data as $data ) {
-				$columns = $this->generate_columns( $form_id, $unchecked_fields );
-
 				if ( isset( $columns[ $data ] ) ) {
 					$user_table_data_row = array_merge( $user_table_data_row, array( $data => $user->$data ) );
 				}
 			}
 
-			$user_meta_data     = ur_get_registered_user_meta_fields();
 			$user_meta_data_row = array();
 
 			// Get user meta table data that are on column.
 			foreach ( $user_meta_data as $meta_data ) {
-				$columns = $this->generate_columns( $form_id, $unchecked_fields );
-
 				if ( isset( $columns[ $meta_data ] ) ) {
 					$user_meta_data_row = array_merge( $user_meta_data_row, array( $meta_data => get_user_meta( $user->data->ID, $meta_data, true ) ) );
 				}
@@ -333,6 +349,7 @@ class UR_Admin_Export_Users {
 
 			$profile = user_registration_form_data( $user->ID, $form_id );
 
+			$user_before_merge_value = array();
 			foreach ( $user_extra_row as $key => $value ) {
 				if ( ! metadata_exists( 'user', $user->ID, 'user_registration_' . $key ) && empty( $value ) ) {
 					$profile_key = 'user_registration_' . $key;
@@ -402,7 +419,7 @@ class UR_Admin_Export_Users {
 				 *
 				 * @see https://stackoverflow.com/a/44774818/9520912
 				 */
-				$user_row = array_merge( array_fill_keys( array_keys( $this->generate_columns( $form_id, $unchecked_fields, $checked_additional_fields ) ), '' ), $user_row );
+				$user_row = array_merge( array_fill_keys( array_keys( $columns_with_additional ), '' ), $user_row );
 				$rows[]   = $user_row;
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:
https://themegrill.atlassian.net/browse/UR-4332
1.
2.
3.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Export Members causes fatal memory exhaustion on large user datasets
