### PR TITLE
Fix - handle array value from get_user_meta for country field in edit profile template

### DIFF
--- a/templates/myaccount/form-edit-profile.php
+++ b/templates/myaccount/form-edit-profile.php
@@ -443,6 +443,7 @@ if ( isset( $_GET['action'] ) && 'edit' === $_GET['action'] ) {
 													}
 												} elseif ( 'country' === $field_key ) {
 													$value   = get_user_meta( $user->ID, 'user_registration_' . $field_name, true );
+													$value   = is_array( $value ) ? '' : (string) $value;
 													$is_json = preg_match( '/^\{.*\}$/s', $value ) ? true : false;
 													if ( $is_json ) {
 														$country_data = json_decode( $value, true );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:
https://themegrill.atlassian.net/browse/UR-4333
1.
2.
3.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - handle array value from get_user_meta for country field in edit profile template