### PR TITLE
Fix - Update subscription status handling for manually created orders

### DIFF
--- a/modules/membership/includes/Admin/Views/subscription-edit.php
+++ b/modules/membership/includes/Admin/Views/subscription-edit.php
@@ -135,7 +135,9 @@ $delete_url = wp_nonce_url(
 	'ur_subscription_delete'
 );
 
-$payment_method = $subscription_order['payment_method'] ?? 'bank';
+$payment_method       = $subscription_order['payment_method'] ?? 'bank';
+$is_admin_created_meta = $orders_repository->get_order_meta_by_order_id_and_meta_key( $order_id, 'is_admin_created' );
+$is_admin_created      = ! empty( $is_admin_created_meta['meta_value'] );
 ?>
 <div class="ur-admin-page-topnav" id="ur-lists-page-topnav">
 	<div class="ur-page-title__wrapper">
@@ -550,7 +552,7 @@ $payment_method = $subscription_order['payment_method'] ?? 'bank';
 								);
 								$status_options = apply_filters( 'ur_membership_subscription_edit_status_options', $status_options, $subscription );
 								?>
-								<select name="status" id="ur-subscription-status" class="ur-enhanced-select" required <?php echo esc_attr( ! in_array( $payment_method, array( 'bank', 'paypal' ), true ) ? disabled( true ) : '' ); ?>>
+								<select name="status" id="ur-subscription-status" class="ur-enhanced-select" required <?php echo esc_attr( ( ! in_array( $payment_method, array( 'bank', 'paypal' ), true ) && ! $is_admin_created ) ? disabled( true ) : '' ); ?>>
 									<?php foreach ( $status_options as $status_value => $status_label ) : ?>
 									<option value="<?php echo esc_attr( $status_value ); ?>"
 										<?php selected( $subscription['status'], $status_value ); ?>>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

https://themegrill.atlassian.net/browse/UR-4329

### How to test the changes in this Pull Request:

1. Add the subscription manually and try to edit the subscription status
<img width="1758" height="726" alt="image" src="https://github.com/user-attachments/assets/cbf70518-1bc3-4f7f-b6ed-8b14efb6812f" />

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Update subscription status handling for manually created orders.