### PR TITLE
UR-4425 Fix - Validate user ownership before deleting profile picture attachment

### DIFF
--- a/includes/frontend/class-ur-frontend.php
+++ b/includes/frontend/class-ur-frontend.php
@@ -111,6 +111,10 @@ class UR_Frontend {
 
 			if ( ! empty( $previous_attachment_id ) && ! empty( $removed_attachment_id ) && ! empty( $previous_attachment_id[0] ) ) {
 				if ( in_array( $previous_attachment_id[0], $removed_attachment_id ) ) {
+					// Verify the attachment belongs to this user before deleting.
+					if ( (int) get_post_field( 'post_author', $previous_attachment_id[0] ) !== (int) $user_id ) {
+						return $profile;
+					}
 					unlink( get_attached_file( $previous_attachment_id[0] ) );
 					wp_delete_attachment( $previous_attachment_id[0], true );
 				}

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -4259,6 +4259,13 @@ if ( ! function_exists( 'ur_upload_profile_pic' ) ) {
 				}
 			}
 		} else {
+			// A numeric value is sent when the user keeps their existing profile picture
+			// (the template pre-populates the hidden field with the stored attachment ID).
+			// Only allow it if the attachment actually belongs to this user; a bare numeric
+			// ID referencing another user's media must be rejected.
+			if ( (int) get_post_field( 'post_author', $upload_file ) !== (int) $user_id ) {
+				return;
+			}
 			$attachment_id = $upload_file;
 		}
 		$attachment_id = ! empty( $attachment_id ) ? $attachment_id : '';


### PR DESCRIPTION

### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:
https://themegrill.atlassian.net/browse/UR-4425?focusedCommentId=44152

### How to test the changes in this Pull Request:

1. Verify the profile upload and edit profile working.
2. Pro branch = `UR-4425-fix/urm-authenticated-subscriber-insecure-direct-object-reference-to-arbitrary-media-deletion-via-profile-pic-url-parameter`

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you updated the documentation accordingly?

### Changelog entry

> Fix - Validate user ownership before deleting profile picture attachment.
