### PR TITLE
UR 4382 Fix - Store paypal transaction id and subscription id properly in database

### DIFF
--- a/modules/membership/includes/Admin/Services/Paypal/PaypalService.php
+++ b/modules/membership/includes/Admin/Services/Paypal/PaypalService.php
@@ -753,7 +753,13 @@ class PaypalService {
 				)
 			);
 
-			$this->members_orders_repository->update( $latest_order['ID'], array( 'status' => 'completed' ) );
+			$this->members_orders_repository->update(
+				$latest_order['ID'],
+				array(
+					'status'         => 'completed',
+					'transaction_id' => sanitize_text_field( $data['txn_id'] ?? '' ),
+				)
+			);
 
 			PaymentGatewayLogging::log_general(
 				'paypal',
@@ -856,6 +862,8 @@ class PaypalService {
 			return;
 		}
 		$payment_status = strtolower( $data['payment_status'] );
+		$transaction_id = '';
+		$order_id       = null;
 
 		// Verify receiver's email address.
 		if ( empty( $receiver_email ) || ! is_email( $receiver_email ) || strtolower( $data['business'] ) !== strtolower( trim( $receiver_email ) ) ) {
@@ -928,7 +936,7 @@ class PaypalService {
 		} elseif ( 'subscr_eot' == $txn_type ) {
 			// Verify further if eot is ever received for time specified subscriptions
 		}
-		if ( 'completed' === $payment_status ) {
+		if ( 'completed' === $payment_status && empty( $order_id ) ) {
 			PaymentGatewayLogging::log_transaction_success(
 				'paypal',
 				'Payment completed successfully',

--- a/modules/membership/includes/Admin/Services/Paypal/PaypalService.php
+++ b/modules/membership/includes/Admin/Services/Paypal/PaypalService.php
@@ -204,7 +204,7 @@ class PaypalService {
 			$item_name            .= ' - ' . $currency_symbol . $final_amount . ' for ' . $subscription_value . ' ' . $subscription_duration;
 		}
 
-		//override with team subscription data
+		// override with team subscription data
 		if ( ! empty( $data['team_id'] ) && ! empty( $data['team_data'] ) && 'subscription' === $membership_type ) {
 			$subscription_value    = $data['team_data']['team_duration_value'];
 			$subscription_duration = $data['team_data']['team_duration_period'];
@@ -936,7 +936,7 @@ class PaypalService {
 		} elseif ( 'subscr_eot' == $txn_type ) {
 			// Verify further if eot is ever received for time specified subscriptions
 		}
-		if ( 'completed' === $payment_status && empty( $order_id ) ) {
+		if ( 'completed' === $payment_status && ! empty( $order_id ) ) {
 			PaymentGatewayLogging::log_transaction_success(
 				'paypal',
 				'Payment completed successfully',
@@ -980,7 +980,7 @@ class PaypalService {
 			$subscription_service->update_subscription_data_for_renewal( $subscription, $membership_metas );
 		}
 
-		//only send email if IPN is received for failed attempt.
+		// only send email if IPN is received for failed attempt.
 		if ( 1 === intval( get_user_meta( $member_id, 'urm_is_payment_retrying', true ) ) ) {
 			$email_service = new EmailService();
 			$email_data    = array(
@@ -1420,7 +1420,7 @@ class PaypalService {
 			$paypal_status = $subscription_data['status'] ?? '';
 
 			if ( in_array( $paypal_status, array( 'SUSPENDED', 'CANCELLED' ) ) ) {
-				//Only if the paypal status is suspended or cancelled.
+				// Only if the paypal status is suspended or cancelled.
 				PaymentGatewayLogging::log_general(
 					'paypal',
 					'Attempting to reactivate suspended/cancelled PayPal subscription',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Checked and verified that the transaction id and subscription id already exists, added for one missing place.

Closes # .

### How to test the changes in this Pull Request:

1. Setup Paypal from Settings > Payments.
2. Create a One time and Subscription based membership.
3. Register as a user and see if the txn id and subscription id are set accordingly.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Store missing subscription and payment ids.
