### PR TITLE
UR-3258 Fix - Pro version installed success message icon issue

### DIFF
--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -1919,7 +1919,7 @@
 		license_activation_status === "pro_activated"
 	) {
 		ur_remove_cookie("urm_license_status");
-		$successModalHtml =
+		var $successModalHtml =
 			'<p style="margin: 10px 0 20px;">' +
 			user_registration_settings_params.i18n.pro_activated_success_text +
 			"</p>" +
@@ -1935,15 +1935,20 @@
 			'">' +
 			user_registration_settings_params.i18n.continue_to_dashboard_text +
 			"</button>";
+		var $successIcon =
+			'<svg width="28" height="28" viewBox="0 0 28 28" fill="none" style="flex-shrink:0" xmlns="http://www.w3.org/2000/svg">' +
+			'<circle cx="14" cy="14" r="13" stroke="#a5dc86" stroke-width="2"/>' +
+			'<path d="M8 14l4 4 8-8" stroke="#a5dc86" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>' +
+			"</svg>";
 		Swal.fire({
-			icon: "success",
-			title: user_registration_settings_params.i18n
-				.pro_activated_success_title,
+			title:
+				$successIcon +
+				user_registration_settings_params.i18n.pro_activated_success_title,
 			html: $successModalHtml,
 			showConfirmButton: false,
 			showCloseButton: true,
 			customClass:
-				"user-registration-swal2-modal user-registration user-registration-swal2-modal--center user-registration-info swal2-show",
+				"user-registration-swal2-modal user-registration user-registration-swal2-modal--center swal2-show",
 			width: 400,
 			didOpen: function () {
 				$("#dashboard-redirect-btn").on("click", function () {

--- a/includes/class-ur-plugin-updater.php
+++ b/includes/class-ur-plugin-updater.php
@@ -161,7 +161,7 @@ class UR_Plugin_Updater extends UR_Plugin_Updates {
 
 		if ( $this->activate_license( $license_key ) ) {
 			if ( ! is_plugin_active( 'user-registration-pro/user-registration.php' ) ) {
-				setcookie( 'urm_license_status', 'license_activated', time() + 300, '/', '', is_ssl(), true );
+				setcookie( 'urm_license_status', 'license_activated', time() + 300, '/', '', is_ssl(), false );
 			}
 			wp_redirect( remove_query_arg( array( 'deactivated_license', $this->plugin_slug . '_deactivate_license' ), add_query_arg( 'activated_license', $this->plugin_slug ) ) );
 			exit;

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -3476,7 +3476,7 @@ if ( ! function_exists( 'ur_install_extensions' ) ) {
 					if ( 'user-registration-pro/user-registration.php' === $install_status['file'] ) {
 						$status['plugin'] = 'user-registration-pro/user-registration.php';
 						if ( ! is_plugin_active( 'user-registration-pro/user-registration.php' ) ) {
-							setcookie( 'urm_license_status', 'pro_activated', time() + 300, '/', '', is_ssl(), true );
+							setcookie( 'urm_license_status', 'pro_activated', time() + 300, '/', '', is_ssl(), false );
 						}
 						activate_plugin( $install_status['file'] );
 					}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixed the issue where the Install Pro popup was not appearing after activating the license in the free version. Also updated the success icon because it was not properly visible.

These fixes will not reflect during current testing because we are testing on the free version, while the popup is coming from the live Pro version, which still has the bug. The changes will reflect after the next release.

### How to test the changes in this Pull Request:

1. Active the design and verify the popup

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> UR-3258 Fix - Pro version installed success message icon issue.