### PR TITLE
Fix - Merged addons to module, still tracked as active addon regardle…

### DIFF
--- a/includes/stats/class-ur-stats.php
+++ b/includes/stats/class-ur-stats.php
@@ -251,12 +251,14 @@ if ( ! class_exists( 'UR_Stats' ) ) {
 
 				foreach ( $enabled_features as $slug ) {
 					if ( isset( $modules_by_slug[ $slug ] ) ) {
-						$module       = $modules_by_slug[ $slug ];
-						$product_slug = in_array( $slug, $addons_list_moved_into_module ) ? $slug . '/' . $slug . '.php' : $slug;
-						$addon_info   = array(
+						$module               = $modules_by_slug[ $slug ];
+						$is_moved_addon       = in_array( $slug, $addons_list_moved_into_module, true );
+						$is_standalone_active = $is_moved_addon && in_array( $slug . '/' . $slug . '.php', $active_plugins, true );
+						$product_slug         = $is_standalone_active ? $slug . '/' . $slug . '.php' : $slug;
+						$addon_info           = array(
 							'product_name'    => $module['name'],
 							'product_version' => UR()->version,
-							'product_type'    => in_array( $slug, $addons_list_moved_into_module ) ? 'plugin' : 'module',
+							'product_type'    => $is_standalone_active ? 'plugin' : 'module',
 							'product_slug'    => $product_slug,
 							'is_premium'      => $is_premium,
 						);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Found following issues:
1. Addons merged into core ( Membership, Content Restriction, Payments and Frontend Listing ), still tracked as active addon on metabase instead of module, inflating the data. So made changes to determine if the addon file actually exists and addon is still active as active addon ( This data will help us know how many users are still using the addons ) and if not then track it as module.

### How to test the changes in this Pull Request:

1. Verify the changes made.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Merged addons tracking and notices for deactivation.
