### PR TITLE
Fix - Membership upgrade action unavailable after disabling Groups add-on

### DIFF
--- a/modules/membership/includes/Admin/Membership/Membership.php
+++ b/modules/membership/includes/Admin/Membership/Membership.php
@@ -513,11 +513,13 @@ class Membership {
 			$group_id         = $membership_group['ID'] ?? 0;
 		}
 
-		foreach ( $memberships as $key => $_membership ) {
-			$current_membership_group = $membership_group_repository->get_membership_group_by_membership_id( $_membership['ID'] );
+		if ( ur_check_module_activation( 'membership-groups' ) ) {
+			foreach ( $memberships as $key => $_membership ) {
+				$current_membership_group = $membership_group_repository->get_membership_group_by_membership_id( $_membership['ID'] );
 
-			if ( ! empty( $current_membership_group ) && absint( $current_membership_group['ID'] ) !== $group_id ) {
-				unset( $memberships[ $key ] );
+				if ( ! empty( $current_membership_group ) && absint( $current_membership_group['ID'] ) !== $group_id ) {
+					unset( $memberships[ $key ] );
+				}
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

https://themegrill.atlassian.net/browse/UR-XXXX

### How to test the changes in this Pull Request:

1. Create two or more memberships and assign them to a group via the Groups add-on.
2. Disable the Groups add-on from User Registration settings.
3. Edit one of the memberships → go to the Advanced tab → the Upgrade Action toggle should now be enabled and functional.
4. Re-enable the Groups add-on and verify the group data is restored and the membership's upgrade action is suppressed again.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Fix - Membership upgrade action unavailable after disabling Groups add-on.