### PR TITLE
UR-4443 Fix - Nav menu items disappear for logged-out users when logout endpoint set to slash

### DIFF
--- a/includes/functions-ur-page.php
+++ b/includes/functions-ur-page.php
@@ -314,6 +314,8 @@ function ur_nav_menu_items( $items ) {
 	if ( ! is_user_logged_in() ) {
 		$customer_logout = get_option( 'user_registration_logout_endpoint', 'user-logout' );
 
+		$customer_logout = trim( $customer_logout, '/' );
+
 		if ( ! empty( $customer_logout ) && is_array( $items ) ) {
 			foreach ( $items as $key => $item ) {
 				if ( empty( $item->url ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

https://themegrill.atlassian.net/browse/UR-4443

When the **User Logout** endpoint setting (User Registration → Settings → My Account → User Logout) is saved as `/` (a bare slash), every navigation menu item disappears for logged-out users. Custom links sometimes remain visible depending on their URL shape, but pages and taxonomies are consistently hidden. Logged-in users are unaffected.

**Root cause:** `ur_nav_menu_items()` reads the logout endpoint from the option and uses it as a substring needle against each menu item's parsed URL path/query via `strstr()`. When the saved value is `/`, the needle matches every URL path (since every path starts with `/`), and the function unsets every menu item.

The ticket initially attributed the symptom to the legacy `urcr_access_rule` (`Legacy: Global Site Rule`) content-restriction migration. That was a red herring — disabling the plugin restored the menu because it removed the `wp_nav_menu_objects` filter, not because of any content restriction logic.

**Fix:** Trim leading/trailing slashes from the logout endpoint value before using it. If the trimmed value is empty (e.g. saved as `/` or empty), the filter short-circuits and leaves the menu untouched, preserving navigation for guests.

### How to test the changes in this Pull Request:

1. Go to **User Registration → Settings → My Account** and set the **User Logout** endpoint field to `/` (or empty). Save.
2. Open the site in an incognito/private window (logged out) and load any page with a navigation menu.
3. **Before the fix:** all page/taxonomy menu items are missing for logged-out users.
4. **After the fix:** the menu renders normally for logged-out users.
5. Restore the User Logout endpoint to the default `user-logout` and confirm a menu item literally pointing at the logout URL is still hidden for logged-out users (existing behavior preserved).
6. Log in and confirm logged-in user behavior is unchanged.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Fix - Navigation menu items disappearing for logged-out users when the User Logout endpoint setting is saved as `/`.