### PR TITLE
UR-4453 Fix - Membership upgrade action not available after disabling group add-on

### DIFF
--- a/modules/membership/includes/Admin/Membership/Membership.php
+++ b/modules/membership/includes/Admin/Membership/Membership.php
@@ -513,11 +513,13 @@ class Membership {
 			$group_id         = $membership_group['ID'] ?? 0;
 		}
 
-		foreach ( $memberships as $key => $_membership ) {
-			$current_membership_group = $membership_group_repository->get_membership_group_by_membership_id( $_membership['ID'] );
+		if ( ur_check_module_activation( 'membership-groups' ) ) {
+			foreach ( $memberships as $key => $_membership ) {
+				$current_membership_group = $membership_group_repository->get_membership_group_by_membership_id( $_membership['ID'] );
 
-			if ( ! empty( $current_membership_group ) && absint( $current_membership_group['ID'] ) !== $group_id ) {
-				unset( $memberships[ $key ] );
+				if ( ! empty( $current_membership_group ) && absint( $current_membership_group['ID'] ) !== $group_id ) {
+					unset( $memberships[ $key ] );
+				}
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

https://themegrill.atlassian.net/browse/UR-4453

When the Membership Groups add-on is disabled, the membership-upgrade action was no longer available in the action list. This happened because the membership filtering loop (which removes memberships belonging to a different group) ran unconditionally, even when the membership-groups module was inactive — causing all memberships that had previously been assigned to a group to be stripped from the list.

The fix wraps the filtering loop inside a `ur_check_module_activation( 'membership-groups' )` guard so the filter only applies when the add-on is actually active.

### How to test the changes in this Pull Request:

1. Install and activate the Membership Groups add-on, create a membership and assign it to a group.
2. Deactivate the Membership Groups add-on.
3. Go to **User Registration → Memberships** and open or create a membership rule that uses the "Upgrade" action.
4. **Before fix:** The membership list in the upgrade action dropdown is empty / unavailable.
5. **After fix:** All active memberships appear in the upgrade action dropdown regardless of whether the Membership Groups add-on is active.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Fix - Membership upgrade action not available after disabling the Membership Groups add-on.