### PR TITLE
UR-4489 Fix - Misleading toast error shown when Stripe card field is left blank

### DIFF
--- a/assets/js/modules/membership/frontend/user-registration-membership-frontend.js
+++ b/assets/js/modules/membership/frontend/user-registration-membership-frontend.js
@@ -3120,39 +3120,44 @@
 			$(document).on(
 				"user_registration_frontend_validate_before_form_submit",
 				function (e, $form) {
-					var stripe_selected = false;
-					$('input[name="urm_payment_method"]:visible').each(
-						function () {
-							if (
-								$(this).val() === "stripe" &&
-								$(this).is(":checked")
-							) {
-								stripe_selected = true;
-							}
-						}
+					// Detect Stripe by presence of a visible card container — works
+					// even when there is only one payment method and no radio button.
+					var $stripeContainer = $form.find(
+						".stripe-input-container"
 					);
-					// console.log('[URM Stripe Debug] stripe_selected:', stripe_selected, '| stripe_mode_validated:', stripe_mode_validated, '| elements.card:', !!elements.card, '| elements.stripe:', !!elements.stripe);
-					if (!stripe_selected) return;
-
-					if (stripe_mode_validated) return;
-
-					var stripeEmpty = $(".ur-frontend-form").find(
-						".stripe-input-container .StripeElement--empty"
-					).length;
-					// console.log('[URM Stripe Debug] elements.card:', !!elements.card, '| StripeElement--empty found:', stripeEmpty);
 					if (
-						!elements ||
-						!elements.stripe ||
-						!elements.card ||
-						stripeEmpty
+						!$stripeContainer.length ||
+						!$stripeContainer.is(":visible")
 					) {
-						// console.log('[URM Stripe Debug] Early return — skipping pre-validation');
 						return;
 					}
 
-					stripe_settings.show_stripe_error(
-						urmf_data.labels.i18n_validating_stripe_card
-					);
+					if (stripe_mode_validated) {
+						return;
+					}
+
+					// Remove any stale error label from a previous attempt.
+					$form.find("#stripe-errors.user-registration-error").remove();
+
+					var stripeEmpty = $stripeContainer.find(
+						".StripeElement--empty"
+					).length;
+
+					if (stripeEmpty) {
+						// Show inline label directly in the form — no dependency on
+						// stripe_settings or $membership_registration_form.
+						$stripeContainer.append(
+							'<label id="stripe-errors" class="user-registration-error" role="alert">' +
+							urmf_data.labels.i18n_empty_card_details +
+							"</label>"
+						);
+						return;
+					}
+
+					// Card has content: run async API validation.
+					if (!elements || !elements.stripe || !elements.card) {
+						return;
+					}
 
 					elements.stripe
 						.createPaymentMethod({
@@ -3161,9 +3166,9 @@
 						})
 						.then(function (pmResult) {
 							if (pmResult.error) {
-								stripe_settings.show_stripe_error(
-									pmResult.error.message
-								);
+								$form
+									.find("#stripe-errors")
+									.text(pmResult.error.message);
 								return;
 							}
 
@@ -3171,12 +3176,13 @@
 								urmf_data.ajax_url,
 								{
 									action: "user_registration_membership_validate_stripe_card_mode",
-									_nonce: urmf_data._nonce,
-									payment_method_id: pmResult.paymentMethod.id
+									security: urmf_data._nonce,
+									payment_method_id:
+										pmResult.paymentMethod.id
 								},
 								function (response) {
 									if (response.success) {
-										$membership_registration_form
+										$form
 											.find("#stripe-errors")
 											.remove();
 										validated_stripe_pm_id =
@@ -3189,13 +3195,15 @@
 											$form.submit();
 										}
 									} else {
-										stripe_settings.show_stripe_error(
-											response.data &&
-												response.data.message
-												? response.data.message
-												: urmf_data.labels
-														.i18n_stripe_mode_error
-										);
+										$form
+											.find("#stripe-errors")
+											.text(
+												response.data &&
+													response.data.message
+													? response.data.message
+													: urmf_data.labels
+															.i18n_stripe_mode_error
+											);
 									}
 								}
 							);
@@ -3853,6 +3861,16 @@
 					.not(seatInput)
 					.prop("disabled", true);
 			});
+
+			// If Stripe is already selected on page load, initialize it so elements.card
+			// is ready before the first submit attempt.
+			var $initialMethod = $('input[name="urm_payment_method"]:checked');
+			if ($initialMethod.length && $initialMethod.val() === "stripe") {
+				if (!elements || !elements.card) {
+					$(".stripe-container").removeClass("urm-d-none");
+					stripe_settings.init();
+				}
+			}
 		},
 		validateSwitchCurrency: function (paymentMethod) {
 			var $select = $("#ur-local-currency-switch-currency");

--- a/modules/membership/includes/Frontend/Frontend.php
+++ b/modules/membership/includes/Frontend/Frontend.php
@@ -37,10 +37,31 @@ class Frontend {
 	 */
 	private function init_hooks() {
 		add_action( 'wp_enqueue_membership_scripts', array( $this, 'load_scripts' ), 10, 2 );
+		add_action( 'user_registration_enqueue_scripts', array( $this, 'maybe_load_scripts_for_form' ), 10, 2 );
 
 		add_action( 'template_redirect', array( $this, 'set_thank_you_transient' ) );
 		add_action( 'wp_loaded', array( $this, 'clear_upgrade_data' ) );
 		add_action( 'user_registration_before_register_user_action', array( $this, 'validate_stripe_card_before_register' ), 10, 2 );
+	}
+
+	public function maybe_load_scripts_for_form( $form_data_array, $form_id ) {
+		if ( wp_script_is( 'user-registration-membership-frontend-script', 'enqueued' ) ) {
+			return;
+		}
+		if ( empty( $form_data_array ) || ! is_iterable( $form_data_array ) ) {
+			return;
+		}
+		foreach ( $form_data_array as $row ) {
+			foreach ( $row as $grid ) {
+				foreach ( $grid as $field ) {
+					$field_key = isset( $field->field_key ) ? $field->field_key : '';
+					if ( 'membership' === $field_key ) {
+						$this->load_scripts();
+						return;
+					}
+				}
+			}
+		}
 	}
 
 	/**

--- a/modules/membership/includes/Templates/membership-registration-form.php
+++ b/modules/membership/includes/Templates/membership-registration-form.php
@@ -554,9 +554,13 @@
 			</span>
 		</div>
 		<?php endif; ?>
-		<?php if ( $is_coupon_addon_activated || $is_tax_calculation_enabled ) :; ?>
+		<?php if ( $is_coupon_addon_activated || $is_tax_calculation_enabled ) : ?>
 			<hr class="ur_membership_divider urm-pre-total-divider" style="display:none;">
+		<?php endif; ?>
+		<div class="urm-membership-total-value">
+			<label class="ur_membership_input_label ur-label"
 					for="ur-membership-total"><?php echo apply_filters( 'user_registration_membership_subscription_payment_gateway_total', esc_html__( 'Total', 'user-registration' ) ); ?></label>
+			<span class="ur_membership_input_class"
 					id="ur-membership-total"
 					data-key-name="<?php echo apply_filters( 'user_registration_membership_subscription_payment_gateway_total', esc_html__( 'Total', 'user-registration' ) ); ?>"
 					disabled


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

https://themegrill.atlassian.net/browse/UR-4489

### How to test the changes in this Pull Request:

1. Submit the form with no card details and verify the error
<img width="1223" height="646" alt="image" src="https://github.com/user-attachments/assets/798c3aca-4686-4f95-b37e-7c6d757574c1" />

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> UR-4489 Fix - Misleading toast error shown when Stripe card field is left blank.