### PR TITLE
UR-4413 Fix - Admins cannot access content restricted by membership rules

### DIFF
--- a/modules/functions-ur-modules.php
+++ b/modules/functions-ur-modules.php
@@ -582,11 +582,15 @@ if ( ! function_exists( 'urm_check_user_membership_has_access' ) ) {
 	 * @param array $allowed_memberships Allowed memberships for access.
 	 */
 	function urm_check_user_membership_has_access( $allowed_memberships ) {
-		$members_subscription = new \WPEverest\URMembership\Admin\Repositories\MembersSubscriptionRepository();
+		if ( is_super_admin() ) {
+			return true;
+		}
 
 		if ( ! is_user_logged_in() ) {
 			return false;
 		}
+
+		$members_subscription = new \WPEverest\URMembership\Admin\Repositories\MembersSubscriptionRepository();
 
 		$user_memberships = $members_subscription->get_member_subscription( wp_get_current_user()->ID );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

https://themegrill.atlassian.net/browse/UR-4413

The `urm_check_user_membership_has_access()` function in `modules/functions-ur-modules.php` was missing the `is_super_admin()` early-return that the pro version already has. As a result, when content is restricted via a membership rule, administrators were evaluated against the membership subscription check and blocked if they had no active membership — even though admins should always bypass restrictions.

Fix: Added `if ( is_super_admin() ) { return true; }` at the top of `urm_check_user_membership_has_access()`, matching the pro version exactly.

### How to test the changes in this Pull Request:

1. Install User Registration & Membership. Set a page/post to be restricted to a specific membership plan (restrict → membership rule).
2. Log in as an Administrator user who is not subscribed to that membership plan. Navigate to the restricted page — before this fix the admin would be blocked and see the restriction message.
3. Verify that after this fix the admin can access the restricted content without subscribing to the membership plan.
4. Optionally, connect the admin user to a User Registration & Membership form (as noted in the ticket), then repeat steps 2–3 to confirm the fix holds in that scenario.
5. Confirm that a non-admin user who is not a member of the required plan is still blocked as expected.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Fix - Admins blocked from accessing content restricted by membership rules due to missing super admin bypass in urm_check_user_membership_has_access.