### PR TITLE
UR-4509 Fix - Duplicate validation message displayed on lost password page

### DIFF
--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -755,15 +755,11 @@ class UR_Form_Handler {
 			if ( empty( $posted_fields['password_1'] ) ) {
 				$err_msg = apply_filters( 'user_registration_reset_password_error_message', __( 'Please enter your password.', 'user-registration' ) );
 				ur_add_notice( $err_msg, 'error' );
-			}
-
-			if ( $posted_fields['password_1'] !== $posted_fields['password_2'] ) {
-				$err_msg = apply_filters( 'user_registration_reset_password_error_message', __( 'New passwords do not match.', 'user-registration' ) );
+			} elseif ( $posted_fields['password_1'] !== $posted_fields['password_2'] ) {
+				$err_msg = apply_filters( 'user_registration_reset_password_mismatch_error_message', __( 'New passwords do not match.', 'user-registration' ) );
 				ur_add_notice( $err_msg, 'error' );
-			}
-
-			if ( wp_check_password( $posted_fields['password_1'], $user->user_pass, $user->ID ) ) {
-				$err_msg = apply_filters( 'user_registration_reset_password_error_message', __( 'New password must not be same as old password.', 'user-registration' ) );
+			} elseif ( wp_check_password( $posted_fields['password_1'], $user->user_pass, $user->ID ) ) {
+				$err_msg = apply_filters( 'user_registration_reset_password_same_password_error_message', __( 'New password must not be same as old password.', 'user-registration' ) );
 				ur_add_notice( $err_msg, 'error' );
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

https://themegrill.atlassian.net/browse/UR-4509?focusedCommentId=44488

### How to test the changes in this Pull Request:

1. Verify the message and design

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> UR-4509 Fix - Duplicate validation message displayed on lost password page.
