### PR TITLE
UR-4297 Fix - Fatal error when saving stripe subscription plan with yearly billing cycle greater than 3 years

### DIFF
--- a/modules/membership/includes/AJAX.php
+++ b/modules/membership/includes/AJAX.php
@@ -158,7 +158,12 @@ class AJAX {
 				$data['membership_id'] = $new_membership_ID;
 				$membership_repository = new MembershipRepository();
 				$membership            = $membership_repository->get_single_membership_by_ID( $new_membership_ID );
-				$stripe_service->sync_product_and_price_in_stripe( $membership );
+				try {
+					$stripe_service->sync_product_and_price_in_stripe( $membership );
+				} catch ( \Exception $e ) {
+					wp_delete_post( $new_membership_ID, true );
+					wp_send_json_error( array( 'message' => $e->getMessage() ) );
+				}
 			}
 
 			// Create or update content access rule if rule data provided
@@ -229,6 +234,26 @@ class AJAX {
 		}
 
 		$data = apply_filters( 'ur_membership_after_create_membership_data_prepare', $data );
+
+		if ( $is_stripe_enabled ) {
+			$meta_data_check = json_decode( $data['post_meta_data']['ur_membership']['meta_value'], true );
+			if (
+				'free' !== $meta_data_check['type'] &&
+				isset( $meta_data_check['subscription']['duration'], $meta_data_check['subscription']['value'] ) &&
+				'year' === $meta_data_check['subscription']['duration'] &&
+				(int) $meta_data_check['subscription']['value'] > 3
+			) {
+				wp_send_json_error(
+					array(
+						'message' => sprintf(
+							/* translators: %d: number of years */
+							__( 'Stripe does not support yearly subscription periods greater than 3 years. The value %d years is not allowed. Please set the subscription period to 3 years or less.', 'user-registration' ),
+							(int) $meta_data_check['subscription']['value']
+						),
+					)
+				);
+			}
+		}
 
 		$updated_ID = wp_insert_post( $data['post_data'] );
 

--- a/modules/membership/includes/AJAX.php
+++ b/modules/membership/includes/AJAX.php
@@ -245,11 +245,7 @@ class AJAX {
 			) {
 				wp_send_json_error(
 					array(
-						'message' => sprintf(
-							/* translators: %d: number of years */
-							__( 'Stripe does not support yearly subscription periods greater than 3 years. The value %d years is not allowed. Please set the subscription period to 3 years or less.', 'user-registration' ),
-							(int) $meta_data_check['subscription']['value']
-						),
+						'message' => __( 'Stripe does not support yearly subscription periods greater than 3 years.', 'user-registration' ),
 					)
 				);
 			}

--- a/modules/membership/includes/Admin/Services/Stripe/StripeService.php
+++ b/modules/membership/includes/Admin/Services/Stripe/StripeService.php
@@ -2890,6 +2890,15 @@ class StripeService {
 		);
 
 		if ( 'subscription' === $type ) {
+			if ( 'year' === $interval && $interval_count > 3 ) {
+				throw new \Exception(
+					sprintf(
+						/* translators: %d: interval count */
+						__( 'Stripe does not support yearly subscription periods greater than 3 years. The value %d years is not allowed. Please set the subscription period to 3 years or less.', 'user-registration' ),
+						$interval_count
+					)
+				);
+			}
 			$data['recurring'] = array(
 				'interval'       => $interval,
 				'interval_count' => $interval_count,

--- a/modules/membership/includes/Admin/Services/Stripe/StripeService.php
+++ b/modules/membership/includes/Admin/Services/Stripe/StripeService.php
@@ -2892,11 +2892,7 @@ class StripeService {
 		if ( 'subscription' === $type ) {
 			if ( 'year' === $interval && $interval_count > 3 ) {
 				throw new \Exception(
-					sprintf(
-						/* translators: %d: interval count */
-						__( 'Stripe does not support yearly subscription periods greater than 3 years. The value %d years is not allowed. Please set the subscription period to 3 years or less.', 'user-registration' ),
-						$interval_count
-					)
+					__( 'Stripe does not support yearly subscription periods greater than 3 years.', 'user-registration' )
 				);
 			}
 			$data['recurring'] = array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:
https://themegrill.atlassian.net/browse/UR-4297?focusedCommentId=44497

### How to test the changes in this Pull Request:

1. Create new membership or update the existing with > 3 years recurring period and verify the error message

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> UR-4297 Fix - Fatal error when saving stripe subscription plan with yearly billing cycle greater than 3 years.
