### PR TITLE
UR-4550 Fix - Password reset link shows invalid or expired on hosts that strip the reset cookie

### DIFF
--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -43,12 +43,6 @@ class UR_Form_Handler {
 	public static function redirect_reset_password_link() {
 		global $wp;
 
-		// CDN-proof reset handoff: some managed hosts / CDNs (e.g. Flywheel behind Fastly)
-		// strip the wp-resetpass-* cookie at the edge, so the reset form below never sees it
-		// and every user gets "invalid or expired". When the cookie is missing on the
-		// reset-form request, rebuild it from the server-side transient that step 1 stashed.
-		// Runs before the lost_password() / reset_password_form() shortcodes read the cookie,
-		// and is a no-op on hosts that deliver the cookie normally (cookie-first).
 		self::maybe_restore_reset_password_cookie();
 
 		if ( isset( $wp->query_vars['ur-lost-password'] ) && empty( $wp->query_vars['ur-lost-password'] ) ) {
@@ -66,9 +60,6 @@ class UR_Form_Handler {
 
 			$redirect_url = add_query_arg( 'show-reset-form', 'true', ur_resetpassword_url() );
 
-			// Step 1 of the CDN-proof handoff: mirror login:key into a short-lived transient
-			// keyed by an opaque token and carry the token through the redirect. The cookie
-			// set above stays the primary path; this only rescues hosts that strip it.
 			$token = wp_generate_password( 32, false );
 			set_transient( 'ur_rp_' . $token, $value, HOUR_IN_SECONDS );
 			$redirect_url = add_query_arg( 'urt', $token, $redirect_url );
@@ -79,9 +70,7 @@ class UR_Form_Handler {
 	}
 
 	/**
-	 * Repopulate the reset-password cookie from the transient handoff token when the cookie
-	 * was stripped before reaching the browser (managed hosts / CDNs). Cookie-first: a
-	 * cookie that actually arrived is always left untouched.
+	 * Restore the reset-password cookie from a transient when a CDN strips it at the edge.
 	 */
 	private static function maybe_restore_reset_password_cookie() {
 		$token = self::get_reset_password_handoff_token();
@@ -106,21 +95,15 @@ class UR_Form_Handler {
 		if ( false !== $value ) {
 			$_COOKIE[ $rp_cookie ] = $value;
 
-			// Re-stash so a slow user or a validation-error re-render still resolves while the
-			// 24h key is valid; the transient is deleted for good once the reset succeeds.
 			set_transient( 'ur_rp_' . $token, $value, HOUR_IN_SECONDS );
 		}
 	}
 
 	/**
-	 * Read and validate the opaque reset handoff token from the current request.
-	 *
-	 * wp_generate_password( 32, false ) emits [A-Za-z0-9] only, so anything else is rejected.
-	 *
-	 * @return string Validated token, or '' when absent/invalid.
+	 * @return string Validated [A-Za-z0-9] token from the current request, or ''.
 	 */
 	private static function get_reset_password_handoff_token() {
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- read-only transient lookup key; the reset key it maps to is validated by check_password_reset_key().
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- read-only lookup; key is validated by check_password_reset_key().
 		if ( empty( $_GET['show-reset-form'] ) || empty( $_GET['urt'] ) ) {
 			return '';
 		}

--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -42,6 +42,15 @@ class UR_Form_Handler {
 	 */
 	public static function redirect_reset_password_link() {
 		global $wp;
+
+		// CDN-proof reset handoff: some managed hosts / CDNs (e.g. Flywheel behind Fastly)
+		// strip the wp-resetpass-* cookie at the edge, so the reset form below never sees it
+		// and every user gets "invalid or expired". When the cookie is missing on the
+		// reset-form request, rebuild it from the server-side transient that step 1 stashed.
+		// Runs before the lost_password() / reset_password_form() shortcodes read the cookie,
+		// and is a no-op on hosts that deliver the cookie normally (cookie-first).
+		self::maybe_restore_reset_password_cookie();
+
 		if ( isset( $wp->query_vars['ur-lost-password'] ) && empty( $wp->query_vars['ur-lost-password'] ) ) {
 			return;
 		}
@@ -55,9 +64,71 @@ class UR_Form_Handler {
 			$value = sprintf( '%s:%s', sanitize_text_field( wp_unslash( $_GET['login'] ) ), sanitize_text_field( wp_unslash( $_GET['key'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification
 			UR_Shortcode_My_Account::set_reset_password_cookie( $value );
 
-			wp_safe_redirect( add_query_arg( 'show-reset-form', 'true', ur_resetpassword_url() ) );
+			$redirect_url = add_query_arg( 'show-reset-form', 'true', ur_resetpassword_url() );
+
+			// Step 1 of the CDN-proof handoff: mirror login:key into a short-lived transient
+			// keyed by an opaque token and carry the token through the redirect. The cookie
+			// set above stays the primary path; this only rescues hosts that strip it.
+			$token = wp_generate_password( 32, false );
+			set_transient( 'ur_rp_' . $token, $value, HOUR_IN_SECONDS );
+			$redirect_url = add_query_arg( 'urt', $token, $redirect_url );
+
+			wp_safe_redirect( $redirect_url );
 			exit;
 		}
+	}
+
+	/**
+	 * Repopulate the reset-password cookie from the transient handoff token when the cookie
+	 * was stripped before reaching the browser (managed hosts / CDNs). Cookie-first: a
+	 * cookie that actually arrived is always left untouched.
+	 */
+	private static function maybe_restore_reset_password_cookie() {
+		$token = self::get_reset_password_handoff_token();
+
+		if ( '' === $token ) {
+			return;
+		}
+
+		// The opaque token lands in the URL, so keep it out of the Referer header.
+		if ( ! headers_sent() ) {
+			header( 'Referrer-Policy: no-referrer' );
+		}
+
+		$rp_cookie = 'wp-resetpass-' . COOKIEHASH;
+
+		if ( ! empty( $_COOKIE[ $rp_cookie ] ) ) {
+			return;
+		}
+
+		$value = get_transient( 'ur_rp_' . $token );
+
+		if ( false !== $value ) {
+			$_COOKIE[ $rp_cookie ] = $value;
+
+			// Re-stash so a slow user or a validation-error re-render still resolves while the
+			// 24h key is valid; the transient is deleted for good once the reset succeeds.
+			set_transient( 'ur_rp_' . $token, $value, HOUR_IN_SECONDS );
+		}
+	}
+
+	/**
+	 * Read and validate the opaque reset handoff token from the current request.
+	 *
+	 * wp_generate_password( 32, false ) emits [A-Za-z0-9] only, so anything else is rejected.
+	 *
+	 * @return string Validated token, or '' when absent/invalid.
+	 */
+	private static function get_reset_password_handoff_token() {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- read-only transient lookup key; the reset key it maps to is validated by check_password_reset_key().
+		if ( empty( $_GET['show-reset-form'] ) || empty( $_GET['urt'] ) ) {
+			return '';
+		}
+
+		$token = sanitize_text_field( wp_unslash( $_GET['urt'] ) );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		return ctype_alnum( $token ) ? $token : '';
 	}
 	/**
 	 * Save and update a profie fields if the form was submitted through the user account page.
@@ -788,6 +859,12 @@ class UR_Form_Handler {
 				 * @param object $user      The user object for whom the password has been reset.
 				 */
 				do_action( 'user_registration_reset_password', $user );
+
+				// Single-use: drop the CDN-proof transient handoff token now the reset succeeded.
+				$handoff_token = self::get_reset_password_handoff_token();
+				if ( '' !== $handoff_token ) {
+					delete_transient( 'ur_rp_' . $handoff_token );
+				}
 
 				$ur_account_page_exists   = ur_get_page_id( 'myaccount' ) > 0;
 				$ur_login_or_account_page = ur_get_page_permalink( 'myaccount' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

**Problem (UR-4550):** Password reset is a two-step cookie handoff — `redirect_reset_password_link()` sets the `wp-resetpass-{COOKIEHASH}` cookie and 302-redirects to the reset form, which reads that cookie back to validate the key. Some managed hosts / CDNs (e.g. Flywheel behind Fastly) strip the non-allowlisted `Set-Cookie` header at the edge, so the form never receives the cookie and **every** user sees "Password reset link is invalid or expired" — regardless of whether their key is valid, because the key is only validated in step 2 after the cookie is read. WordPress core's own reset flow uses the same cookie pattern and breaks identically on these hosts.

**Fix:** Add a cookie-independent fallback without changing the existing flow:

- Step 1 also mirrors `login:key` into a short-lived server-side transient keyed by an opaque token, and carries that token (`urt`) through the redirect.
- Step 2 repopulates `$_COOKIE` from the transient **only when the cookie is missing**, so `lost_password()` / `reset_password_form()` run unchanged. A single restore on `template_redirect` covers both readers.
- The cookie remains the primary path — on hosts that deliver it normally, the transient is created but never read (true no-op).
- The transient is deleted once the password is actually reset (single-use).

**Security:** The auth gate is unchanged — still requires the `reset_password` nonce, `check_password_reset_key()`, the 24h key expiry, and the key being cleared on reset. The token is a 32-char CSPRNG value, server-side, single-use, 1h TTL, `ctype_alnum`-validated, and `Referrer-Policy: no-referrer` is sent on the reset-form page so the token cannot leak via the `Referer` header.

### How to test the changes in this Pull Request:

1. Simulate a host that strips the reset cookie (e.g. block/clear the `Set-Cookie` for `wp-resetpass-*`, or test on Flywheel/Fastly). On `develop` without this fix, requesting a reset and clicking the email link shows "Password reset link is invalid or expired."
2. With this branch, request a reset, click the email link — the redirect now carries a `urt` token and the **"Enter a new password"** form renders correctly even though the cookie was stripped.
3. Save a new password; confirm the reset succeeds, you can log in with it, and the `ur_rp_*` transient is gone afterward.
4. On a normal host where the cookie is delivered, confirm behaviour is unchanged (cookie used; transient never read).

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully ran tests with your changes locally? — PHP lint passes; full end-to-end save test on a cookie-stripping host still pending.
* [ ] Have you updated the documentation accordingly?

### Changelog entry

Fix - Password reset link showing "invalid or expired" on managed hosts/CDNs that strip the reset cookie, by adding a cookie-independent transient handoff fallback.
