### PR TITLE
UR-4558 Fix - Password reset link shows "invalid or expired" error after update from 5.1.6

### DIFF
--- a/includes/class-ur-form-handler.php
+++ b/includes/class-ur-form-handler.php
@@ -53,6 +53,11 @@ class UR_Form_Handler {
 
 		if ( ( $is_ur_lost_password_page || $is_ur_login_or_account_page ) && ! empty( $_GET['key'] ) && ! empty( $_GET['login'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$value = sprintf( '%s:%s', sanitize_text_field( wp_unslash( $_GET['login'] ) ), sanitize_text_field( wp_unslash( $_GET['key'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification
+
+			if ( ! headers_sent() ) {
+				nocache_headers();
+			}
+
 			UR_Shortcode_My_Account::set_reset_password_cookie( $value );
 
 			wp_safe_redirect( add_query_arg( 'show-reset-form', 'true', ur_resetpassword_url() ) );

--- a/includes/functions-ur-account.php
+++ b/includes/functions-ur-account.php
@@ -103,14 +103,21 @@ function ur_resetpassword_url( $default_url = '' ) {
 		return $default_url;
 	}
 
-	// Get reset password page from plugin option.
+	// The lost-password page is the primary page for the reset flow.
+	$lost_password_page = get_option( 'user_registration_lost_password_page_id', false );
+
+	if ( $lost_password_page && ! empty( get_post( $lost_password_page ) ) ) {
+		return get_permalink( $lost_password_page );
+	}
+
+	// Legacy fallback: a separate reset-password page (deprecated option).
 	$reset_password_page = get_option( 'user_registration_reset_password_page_id', false );
 
 	if ( $reset_password_page && ! empty( get_post( $reset_password_page ) ) ) {
 		return get_permalink( $reset_password_page );
-	} else {
-		return ur_lostpassword_url();
 	}
+
+	return ur_lostpassword_url();
 }
 add_filter( 'retrieve_password_url', 'ur_resetpassword_url', 20, 1 );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
After updating the plugin, users are unable to reset their passwords. Clicking the reset link in the email correctly loads the page with action, key, and login parameters, but immediately redirects to ?show-reset-form=true and displays: "Password reset link is invalid or expired."

Rolling back to version 5.1.6 restores the expected behavior.

#### Root Cause
The reset flow is a two-step cookie handoff:

User clicks the reset link → redirect_reset_password_link() reads key and login from the URL, stores them as login:key in the wp-resetpass-* cookie, then 302-redirects to ?show-reset-form=true
The form page reads that cookie back to validate the key and render the reset form
The bug is a priority mismatch introduced when the user_registration_reset_password_page_id option was added:

ur_resetpassword_url() — determines the redirect destination — checks user_registration_reset_password_page_id first
set_reset_password_cookie() — determines the cookie path — checks user_registration_lost_password_page_id first
When a site has the legacy user_registration_reset_password_page_id option configured, the cookie is set with the path /lost-password/ but the browser is redirected to /reset-password/. A browser only sends a cookie when the request path matches the cookie path, so the cookie is silently dropped on the second request. The form finds no cookie and shows the error.

### Steps to Reproduce
- Have user_registration_lost_password_page_id configured (standard setup)
- Also have user_registration_reset_password_page_id configured (legacy option)
- Trigger a password reset email and click the link
- Observe the "Password reset link is invalid or expired" error immediately on the form page

### How to test the changes:
Switch to this branch and see if the above issue occurs.

### Types of changes:
* [] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Password reset link shows "invalid or expired" error after update from 5.1.6