### PR TITLE
Fix: PayPal credentials not detected during registration despite valid saved settings

### DIFF
--- a/modules/membership/includes/Admin/Services/Paypal/NewPaypalService.php
+++ b/modules/membership/includes/Admin/Services/Paypal/NewPaypalService.php
@@ -205,18 +205,19 @@ class NewPaypalService {
 		$paypal_options['return_url'] = apply_filters( 'urm_paypal_override_return_url', '' === $return_url ? wp_login_url() : $return_url );
 
 		// REST credentials.
+		$mode_key                     = $this->get_paypal_mode_key();
 		$paypal_options['client_id']  = get_option(
-			sprintf( 'user_registration_global_paypal_%s_client_id', $mode ),
+			sprintf( 'user_registration_global_paypal_%s_client_id', $mode_key ),
 			isset( $paypal_options['client_id'] ) ? $paypal_options['client_id'] : get_option( 'user_registration_global_paypal_client_id', '' )
 		);
 		$paypal_options['secret_key'] = get_option(
-			sprintf( 'user_registration_global_paypal_%s_client_secret', $mode ),
+			sprintf( 'user_registration_global_paypal_%s_client_secret', $mode_key ),
 			isset( $paypal_options['secret_key'] ) ? $paypal_options['secret_key'] : get_option( 'user_registration_global_paypal_client_secret', '' )
 		);
 
 		// Optional fallback email for compatibility and validation.
 		$paypal_options['email'] = get_option(
-			sprintf( 'user_registration_global_paypal_%s_email_address', $mode ),
+			sprintf( 'user_registration_global_paypal_%s_email_address', $mode_key ),
 			get_option( 'user_registration_global_paypal_email_address', '' )
 		);
 
@@ -1976,11 +1977,12 @@ class NewPaypalService {
 			return true;
 		}
 
-		$mode = $this->get_paypal_mode();
+		$mode     = $this->get_paypal_mode();
+		$mode_key = $this->get_paypal_mode_key();
 
 		$required = array(
-			'client_id'     => get_option( sprintf( 'user_registration_global_paypal_%s_client_id', $mode ), get_option( 'user_registration_global_paypal_client_id', '' ) ),
-			'client_secret' => get_option( sprintf( 'user_registration_global_paypal_%s_client_secret', $mode ), get_option( 'user_registration_global_paypal_client_secret', '' ) ),
+			'client_id'     => get_option( sprintf( 'user_registration_global_paypal_%s_client_id', $mode_key ), get_option( 'user_registration_global_paypal_client_id', '' ) ),
+			'client_secret' => get_option( sprintf( 'user_registration_global_paypal_%s_client_secret', $mode_key ), get_option( 'user_registration_global_paypal_client_secret', '' ) ),
 		);
 
 		// Keep compatibility with old one-time standard/email validation if needed by your UI.
@@ -2242,18 +2244,29 @@ class NewPaypalService {
 	}
 
 	/**
+	 * Get the option key segment for the current PayPal mode.
+	 * Options are stored under _live_ / _test_ keys, but the mode value is 'production' / 'test'.
+	 *
+	 * @return string 'live' or 'test'
+	 */
+	private function get_paypal_mode_key() {
+		return 'production' === $this->get_paypal_mode() ? 'live' : 'test';
+	}
+
+	/**
 	 * Get PayPal REST credentials.
 	 *
 	 * @return array
 	 */
 	private function get_paypal_rest_credentials() {
-		$mode = $this->get_paypal_mode();
+		$mode     = $this->get_paypal_mode();
+		$mode_key = $this->get_paypal_mode_key();
 
 		return array(
 			'mode'       => $mode,
-			'client_id'  => get_option( sprintf( 'user_registration_global_paypal_%s_client_id', $mode ), get_option( 'user_registration_global_paypal_client_id', '' ) ),
-			'secret_key' => get_option( sprintf( 'user_registration_global_paypal_%s_client_secret', $mode ), get_option( 'user_registration_global_paypal_client_secret', '' ) ),
-			'email'      => get_option( sprintf( 'user_registration_global_paypal_%s_email_address', $mode ), get_option( 'user_registration_global_paypal_email_address', '' ) ),
+			'client_id'  => get_option( sprintf( 'user_registration_global_paypal_%s_client_id', $mode_key ), get_option( 'user_registration_global_paypal_client_id', '' ) ),
+			'secret_key' => get_option( sprintf( 'user_registration_global_paypal_%s_client_secret', $mode_key ), get_option( 'user_registration_global_paypal_client_secret', '' ) ),
+			'email'      => get_option( sprintf( 'user_registration_global_paypal_%s_email_address', $mode_key ), get_option( 'user_registration_global_paypal_email_address', '' ) ),
 		);
 	}
 


### PR DESCRIPTION
## Description

Fixes a key naming mismatch that caused PayPal production credentials to never be found at runtime, triggering the `paypal_missing_credentials` error even when valid production keys were saved.

**Root cause:** Credentials are saved under `_live_` option keys (e.g. `user_registration_global_paypal_live_client_id`) because the settings save handler maps `production` → `live`. However, the credential retrieval code used the raw mode value `production` directly in `sprintf`, building a key like `user_registration_global_paypal_production_client_id` — which never exists. Test mode was unaffected because `test` maps to `test` on both sides.

## Changes

- Added `get_paypal_mode_key()` in `NewPaypalService.php` — maps `production` → `live` for option key lookups.
- Updated all credential and email address option lookups to use the mode key instead of the raw mode value.

## Test plan

- [ ] Set PayPal to **Production** mode with valid live Client ID and Secret saved
- [ ] Trigger a membership payment flow — should proceed without `paypal_missing_credentials` error
- [ ] Confirm `has_client_id: true` and `has_client_secret: true` in the logs
- [ ] Verify **Test/Sandbox** mode still works correctly

Fixes UR-4565.