### PR TITLE
Ur 4426 Enhancement - Add customizable membership registration success message in settings

### DIFF
--- a/includes/admin/settings/class-ur-settings-registration-login.php
+++ b/includes/admin/settings/class-ur-settings-registration-login.php
@@ -130,6 +130,16 @@ if ( ! class_exists( 'UR_Settings_Registration_Login' ) ) {
 									'css'      => 'min-width: 350px; min-height: 100px;',
 									'default'  => __( 'User registered. Wait until admin approves your registration.', 'user-registration' ),
 								),
+
+								array(
+									'title'    => __( 'Membership Registration', 'user-registration' ),
+									'desc'     => __( 'Enter the text message that appears after successful membership registration.', 'user-registration' ),
+									'id'       => 'user_registration_successful_membership_creation_message',
+									'type'     => 'textarea',
+									'desc_tip' => true,
+									'css'      => 'min-width: 350px; min-height: 100px;',
+									'default'  => __( 'New member has been successfully created.', 'user-registration' ),
+								),
 							),
 						),
 						'frontend_error_message_messages_settings' => array(

--- a/modules/membership/includes/AJAX.php
+++ b/modules/membership/includes/AJAX.php
@@ -716,7 +716,7 @@ class AJAX {
 			wp_send_json_success(
 				array(
 					'member_id' => $response['member_id'],
-					'message'   => esc_html__( 'New member has been successfully created. ', 'user-registration' ),
+					'message'   => get_option( 'user_registration_successful_membership_creation_message', esc_html__( 'New member has been successfully created.', 'user-registration' ) ),
 				)
 			);
 		} else {

--- a/modules/membership/includes/Admin.php
+++ b/modules/membership/includes/Admin.php
@@ -516,7 +516,7 @@ if ( ! class_exists( 'Admin' ) ) :
 						'member_id'      => absint( $member_id ),
 						'transaction_id' => esc_html( $transaction_id ),
 						'order_id'       => esc_html( $data['order_id'] ),
-						'message'        => esc_html__( 'New member has been successfully created.', 'user-registration' ),
+						'message'        => get_option( 'user_registration_successful_membership_creation_message', esc_html__( 'New member has been successfully created.', 'user-registration' ) ),
 					)
 				);
 				if ( ur_check_module_activation( 'team' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a customizable success message for membership registration, configurable from **Settings → Frontend Messages**. The membership registration success response now reads the new `user_registration_successful_membership_creation_message` option, falling back to the existing default text.

Recreated from #1261 on top of `v5.2.3` to avoid the large merge-conflict surface on that branch. Only the actual feature changes are included (3 files, 12 lines).

Closes # .

### How to test the changes in this Pull Request:
https://themegrill.atlassian.net/browse/UR-4426
1. Go to **User Registration → Settings → Frontend Messages** and set a custom value for "Membership Registration".
2. Complete a membership registration (admin create member and frontend register).
3. Confirm the configured custom message is shown on success; clearing it falls back to the default "New member has been successfully created."

### Types of changes:

* [x] Enhancement (modification of the currently available functionality)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Enhancement - Add customizable membership registration success message in settings
