### PR TITLE
Fix - Validation of key while saving the stripe payment settings

### DIFF
--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -1755,8 +1755,7 @@
 			if ( testPubKey && testPubKey.indexOf( "pk_test_" ) !== 0 ) {
 				$this.find( ".ur-spinner" ).remove();
 				show_failure_message(
-					user_registration_settings_params.i18n.invalid_stripe_test_publishable_key ||
-					"Invalid Stripe test publishable key. It must start with pk_test_."
+					user_registration_settings_params.i18n.invalid_stripe_test_publishable_key
 				);
 				return;
 			}
@@ -1764,8 +1763,7 @@
 			if ( livePubKey && livePubKey.indexOf( "pk_live_" ) !== 0 ) {
 				$this.find( ".ur-spinner" ).remove();
 				show_failure_message(
-					user_registration_settings_params.i18n.invalid_stripe_live_publishable_key ||
-					"Invalid Stripe live publishable key. It must start with pk_live_."
+					user_registration_settings_params.i18n.invalid_stripe_live_publishable_key
 				);
 				return;
 			}

--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -1748,6 +1748,29 @@
 			section_data[name] = value;
 		});
 
+		if ( setting_id === "stripe" ) {
+			var testPubKey = section_data["user_registration_stripe_test_publishable_key"] || "";
+			var livePubKey = section_data["user_registration_stripe_live_publishable_key"] || "";
+
+			if ( testPubKey && testPubKey.indexOf( "pk_test_" ) !== 0 ) {
+				$this.find( ".ur-spinner" ).remove();
+				show_failure_message(
+					user_registration_settings_params.i18n.invalid_stripe_test_publishable_key ||
+					"Invalid Stripe test publishable key. It must start with pk_test_."
+				);
+				return;
+			}
+
+			if ( livePubKey && livePubKey.indexOf( "pk_live_" ) !== 0 ) {
+				$this.find( ".ur-spinner" ).remove();
+				show_failure_message(
+					user_registration_settings_params.i18n.invalid_stripe_live_publishable_key ||
+					"Invalid Stripe live publishable key. It must start with pk_live_."
+				);
+				return;
+			}
+		}
+
 		update_payment_section_settings(
 			setting_id,
 			section_data,

--- a/includes/admin/class-ur-admin-settings.php
+++ b/includes/admin/class-ur-admin-settings.php
@@ -258,6 +258,8 @@ class UR_Admin_Settings {
 					'pro_install_popup_title'            => esc_html__( 'Install User Registration & Membership Pro to Unlock All Features', 'user-registration' ),
 					'will_install_and_activate_pro_text' => esc_html__( 'This will automatically install and activate the User Registration & Membership Pro Plugin for you.', 'user-registration' ),
 					'installing_plugin_text'             => esc_html__( 'Installing Plugin', 'user-registration' ),
+					'invalid_stripe_test_publishable_key' => esc_html__( 'Invalid Stripe test publishable key. It must start with pk_test_.', 'user-registration' ),
+					'invalid_stripe_live_publishable_key' => esc_html__( 'Invalid Stripe live publishable key. It must start with pk_live_.', 'user-registration' ),
 					'pro_activated_success_title'        => esc_html__( 'Success!', 'user-registration' ),
 					'pro_activated_success_text'         => esc_html__( 'URM Pro has been successfully installed and activated. You now have access to all premium features!', 'user-registration' ),
 					'continue_to_dashboard_text'         => esc_html__( 'Continue to dashboard', 'user-registration' ),

--- a/modules/stripe/class-ur-stripe-module.php
+++ b/modules/stripe/class-ur-stripe-module.php
@@ -163,9 +163,50 @@ class User_Registration_Stripe_Module {
 				return $response;
 			}
 
-			// Detect mode from key
-			if ( strpos( $secret_key, 'sk_test_' ) === 0 ) {
+			// Validate publishable key is present.
+			if ( empty( $publishable_key ) ) {
+				$response['status']  = false;
+				$response['message'] = esc_html__( 'Stripe publishable key is missing.', 'user-registration' );
+				return $response;
+			}
 
+			// Validate publishable key prefix matches the selected mode.
+			$expected_pk_prefix = ( 'test' === $mode ) ? 'pk_test_' : 'pk_live_';
+			if ( strpos( $publishable_key, $expected_pk_prefix ) !== 0 ) {
+				$response['status']  = false;
+				$response['message'] = ( 'test' === $mode )
+					? esc_html__( 'Invalid Stripe test publishable key. It must start with pk_test_.', 'user-registration' )
+					: esc_html__( 'Invalid Stripe live publishable key. It must start with pk_live_.', 'user-registration' );
+				return $response;
+			}
+
+			// Verify the publishable key against the Stripe API.
+			// POST /v1/tokens is a publishable-key-accessible endpoint:
+			//   HTTP 401 → key does not exist in Stripe (invalid)
+			//   HTTP 400 → key is valid, request just lacks required card fields
+			$stripe_pk_check = wp_remote_post(
+				'https://api.stripe.com/v1/tokens',
+				array(
+					'headers' => array(
+						'Authorization' => 'Bearer ' . $publishable_key,
+					),
+					'body'    => array(),
+					'timeout' => 10,
+				)
+			);
+
+			if ( ! is_wp_error( $stripe_pk_check ) ) {
+				$pk_response_code = wp_remote_retrieve_response_code( $stripe_pk_check );
+				if ( 401 === $pk_response_code ) {
+					$response['status']    = false;
+					$response['connected'] = false;
+					$response['message']   = esc_html__( 'Invalid Stripe publishable key. Please verify the key and try again.', 'user-registration' );
+					return $response;
+				}
+			}
+
+			// Detect mode from key.
+			if ( strpos( $secret_key, 'sk_test_' ) === 0 ) {
 				if ( 'live' === $mode ) {
 					$response['status']  = false;
 					$response['message'] = esc_html__( 'Test key used while Live mode is selected.', 'user-registration' );
@@ -173,14 +214,14 @@ class User_Registration_Stripe_Module {
 				}
 			}
 
-			\Stripe\Stripe::setApiKey( $secret_key ); // Replace with your actual key
+			\Stripe\Stripe::setApiKey( $secret_key );
 
 			try {
 				$customers = \Stripe\Customer::all( array( 'limit' => 1 ) );
 			} catch ( \Stripe\Exception\AuthenticationException $e ) {
 				$response['status']    = false;
 				$response['connected'] = false;
-				$response['message']   = 'Invalid stripe credentials';
+				$response['message']   = esc_html__( 'Invalid Stripe secret key. Please verify the key and try again.', 'user-registration' );
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previously user can save any key while sving the stripe settings. This PR validate the key and allow user to save.

### How to test the changes in this Pull Request:

1. Go to Global Paymets Settings.
2. Try to save valid and invalid key for the stripe.
3. Check whether the issue has been resolved or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Validation of key while saving the stripe payment settings.
