### PR TITLE
UR-4559 Fix - Harden membership coupon apply paths against PHP 8 TypeError

### DIFF
--- a/modules/membership/includes/Admin/Services/CouponService.php
+++ b/modules/membership/includes/Admin/Services/CouponService.php
@@ -78,8 +78,8 @@ class CouponService {
 			return $this->set_coupon_response( false, 422, 'Invalid coupon type.', );
 		}
 
-		$coupon_membership = json_decode( $coupon_details['coupon_membership'], true );
-		if ( ! in_array( $data['membership_id'], $coupon_membership ) ) {
+		$coupon_membership = (array) json_decode( $coupon_details['coupon_membership'], true );
+		if ( ! in_array( $membership_id, $coupon_membership ) ) {
 			return $this->set_coupon_response( false, 422, 'Coupon cannot be applied for the selected membership.' );
 		}
 
@@ -87,6 +87,10 @@ class CouponService {
 			return $this->set_coupon_response( false, 422, 'Coupon is not valid until ' . date_i18n( get_option( 'date_format' ), strtotime( $coupon_details['coupon_start_date'] ) ) . '.', );
 		}
 		$membership_details = $this->membership_repository->get_single_membership_by_ID( $membership_id );
+
+		if ( empty( $membership_details['meta_value'] ) ) {
+			return $this->set_coupon_response( false, 404, 'Membership does not exist.' );
+		}
 
 		$membership_meta = json_decode( $membership_details['meta_value'], true );
 		if ( 'free' === $membership_meta['type'] ) {

--- a/modules/membership/includes/Admin/Services/MembersService.php
+++ b/modules/membership/includes/Admin/Services/MembersService.php
@@ -66,7 +66,7 @@ class MembersService {
 					'message' => __( 'Invalid coupon type.', 'user-registration' ),
 				);
 			}
-			$coupon_membership = json_decode( $coupon_details['coupon_membership'], true );
+			$coupon_membership = (array) json_decode( $coupon_details['coupon_membership'], true );
 			if ( ! in_array( $data['membership'], $coupon_membership ) ) {
 				return array(
 					'status'  => false,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

https://themegrill.atlassian.net/browse/UR-4559

The membership coupon apply paths could fatal with a PHP 8+ `TypeError` when a stored `coupon_membership` value was not a JSON array. These two service files ship in the **free** plugin (membership module), so the hardening from the Pro fix (wpeverest/user-registration-pro#1339) needs to land here too:

- `modules/membership/includes/Admin/Services/CouponService.php`
  - Cast `json_decode( coupon_membership )` with `(array)` before `in_array()` so a malformed stored value can no longer cause a `TypeError`.
  - Compare against the sanitized `$membership_id` (consistent with the rest of the method) instead of the raw `$data['membership_id']`.
  - Guard a missing membership lookup (`empty( $membership_details['meta_value'] )`) and return a clear "Membership does not exist." response instead of erroring on `json_decode`.
- `modules/membership/includes/Admin/Services/MembersService.php`
  - Same `(array)` cast before `in_array()` in the coupon validation path.

The changed files are byte-identical to their counterparts in the Pro PR.

Closes # .

### How to test the changes in this Pull Request:

1. Create a membership coupon, then make its stored `coupon_membership` value non-array (or use a coupon created before the array fix).
2. Apply the coupon at checkout / membership registration — verify it returns a normal validation message instead of a PHP 8 `TypeError`.
3. Apply a valid coupon to a valid membership — verify it still applies correctly.
4. Apply a coupon referencing a membership that no longer exists — verify the "Membership does not exist." message instead of a fatal.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Fix - Harden membership coupon apply paths against PHP 8 TypeError (free membership module)
