### PR TITLE
UR-4552: Fix My Account payment tab pulling footer content inside the tab area

### DIFF
--- a/templates/myaccount/payments.php
+++ b/templates/myaccount/payments.php
@@ -141,11 +141,9 @@ $gateway_labels = array(
 
 		</div>
 
-		<!--
 		<?php
 		if ( $total_pages > 1 ) :
 			?>
-			-->
 			<div class="ur-pagination">
 				<?php
 				echo paginate_links(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

On the My Account **Payments** tab, the pagination block was wrapped in HTML comment markers like this:

```php
<!--
<?php if ( $total_pages > 1 ) : ?>
-->
```

The opening `<!--` was always rendered, but the closing `-->` was only rendered when `$total_pages > 1`. So on any payments list with a single page, the unclosed `<!--` swallowed everything after it — including the site footer — pulling the footer content inside the tab area.

This PR removes the stray `<!--` / `-->` comment markers so the `if ( $total_pages > 1 )` block is clean and the footer renders in its own section again.

Closes #UR-4552.

### How to test the changes in this Pull Request:

1. Log in as a user with at least one payment/order so the My Account **Payments** tab is shown.
2. Ensure the payments list has only a single page (i.e. `$total_pages <= 1`).
3. Open the Payments tab and confirm the footer now renders in the separate footer section, not inside the tab area.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

### Changelog entry

> Fix: My Account payment tab pulling footer content inside the tab area.
