### PR TITLE
UR-4608  Enhance - Grace period before membership expiry.

### DIFF
--- a/modules/membership/includes/Admin/Services/SubscriptionService.php
+++ b/modules/membership/includes/Admin/Services/SubscriptionService.php
@@ -1167,7 +1167,7 @@ class SubscriptionService {
 	 */
 	public function daily_membership_expiration_check() {
 		// Grace period gives the hourly missed-payment backfill time to catch a renewal
-		$grace_hours   = (int) apply_filters( 'urm_expiry_grace_hours', 24 );
+		$grace_hours   = (int) apply_filters( 'urm_expiry_grace_hours', 12 );
 		$date          = new \DateTime( "-{$grace_hours} hours" );
 		$check_date    = $date->format( 'Y-m-d H:i:s' );
 		$subscriptions = $this->members_subscription_repository->get_subscriptions_to_expire( $check_date );

--- a/modules/membership/includes/Admin/Services/SubscriptionService.php
+++ b/modules/membership/includes/Admin/Services/SubscriptionService.php
@@ -1166,7 +1166,9 @@ class SubscriptionService {
 	 * @return void
 	 */
 	public function daily_membership_expiration_check() {
-		$date          = new \DateTime( 'today' );
+		// Grace period gives the hourly missed-payment backfill time to catch a renewal
+		$grace_hours   = (int) apply_filters( 'urm_expiry_grace_hours', 24 );
+		$date          = new \DateTime( "-{$grace_hours} hours" );
 		$check_date    = $date->format( 'Y-m-d H:i:s' );
 		$subscriptions = $this->members_subscription_repository->get_subscriptions_to_expire( $check_date );
 		if ( empty( $subscriptions ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The expiration cron now waits 12 hours past the expiry date before locking anyone out — giving the hourly renewal check time to confirm payment first, so paying members never get wrongly blocked.

Closes # .

### How to test the changes in this Pull Request:

1. Use a [Stripe test clock](https://stripe.com/docs/billing/testing/test-clocks) subscription in test mode.
2. Advance the clock past the renewal date so Stripe renews the subscription.
3. Delay/hold the webhook (disable the endpoint briefly, or don't process it) so local expiry_date stays stale.
4. Let the expiration cron run → member keeps access (within 12h).
5. Re-enable the webhook / run backfill → expiry_date catches up. No lockout occurred.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhance - Grace period before membership expiry.
