### PR TITLE
UR-4623 Fix - Multiple security and hardening issues reported in urm 5.2.4

### DIFF
--- a/includes/admin/class-ur-admin-export-users.php
+++ b/includes/admin/class-ur-admin-export-users.php
@@ -34,6 +34,25 @@ class UR_Admin_Export_Users {
 	}
 
 	/**
+	 * Neutralize spreadsheet formula characters to prevent CSV/formula injection
+	 * when the exported file is opened in spreadsheet software.
+	 *
+	 * @param mixed $value Cell value.
+	 * @return mixed
+	 */
+	private function sanitize_csv_cell( $value ) {
+		if ( ! is_string( $value ) || '' === $value ) {
+			return $value;
+		}
+
+		if ( in_array( $value[0], array( '=', '+', '-', '@', "\t", "\r" ), true ) ) {
+			return "'" . $value;
+		}
+
+		return $value;
+	}
+
+	/**
 	 * Exports users data along with extra information in CSV format.
 	 *
 	 * @param int $form_id Form ID.
@@ -125,7 +144,7 @@ class UR_Admin_Export_Users {
 
 		// Get the columns.
 		$columns = $this->generate_columns( $form_id, $unchecked_fields, $checked_additional_fields );
-		fputcsv( $handle, array_values( $columns ) );
+		fputcsv( $handle, array_map( array( $this, 'sanitize_csv_cell' ), array_values( $columns ) ), ',', '"', '\\' );
 
 		// Loop over users in batches.
 		while ( true ) {
@@ -155,7 +174,7 @@ class UR_Admin_Export_Users {
 
 			// Write the rows to the CSV.
 			foreach ( $rows as $row ) {
-				fputcsv( $handle, $row );
+				fputcsv( $handle, array_map( array( $this, 'sanitize_csv_cell' ), $row ), ',', '"', '\\' );
 			}
 
 			wp_cache_flush();

--- a/modules/membership/includes/AJAX.php
+++ b/modules/membership/includes/AJAX.php
@@ -773,6 +773,21 @@ class AJAX {
 	 */
 	public static function validate_coupon() {
 		ur_membership_verify_nonce( 'ur_members_frontend' );
+
+		$rate_limit_key = 'urm_coupon_validate_' . md5( ur_get_ip_address() );
+		$attempts       = (int) get_transient( $rate_limit_key );
+
+		if ( $attempts >= 10 ) {
+			wp_send_json_error(
+				array(
+					'message' => __( 'Too many coupon attempts. Please try again later.', 'user-registration' ),
+				),
+				429
+			);
+		}
+
+		set_transient( $rate_limit_key, $attempts + 1, MINUTE_IN_SECONDS );
+
 		$data           = isset( $_POST['coupon_data'] ) ? (array) wp_unslash( $_POST['coupon_data'] ) : array();
 		$coupon_service = new CouponService();
 
@@ -2698,6 +2713,16 @@ class AJAX {
 	 * @since 6.1.0
 	 */
 	public static function validate_payment_currency() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error(
+				array(
+					'message' => __( 'Sorry, you do not have permission to do this.', 'user-registration' ),
+				)
+			);
+		}
+
+		ur_membership_verify_nonce( 'validate_payment_currency_nonce' );
+
 		$zone_id = ! empty( sanitize_text_field( wp_unslash( $_POST['zone_id'] ) ) ) ? sanitize_text_field( wp_unslash( $_POST['zone_id'] ) ) : '';
 
 		if ( empty( $zone_id ) ) {

--- a/modules/membership/includes/AJAX.php
+++ b/modules/membership/includes/AJAX.php
@@ -2057,7 +2057,7 @@ class AJAX {
 			$data['coupon'] = sanitize_text_field( $_POST['coupon'] );
 		}
 
-		if ( isset( $_POST['type'] ) && 'multiple' === sanitize_text_field( $_POST['type'] ) ) {
+		if ( ! empty( $user_membership_ids ) ) {
 			$subscription_service = new SubscriptionService();
 			$status               = $subscription_service->can_purchase_multiple( $data );
 

--- a/modules/membership/includes/Admin/Services/MembersService.php
+++ b/modules/membership/includes/Admin/Services/MembersService.php
@@ -130,7 +130,17 @@ class MembersService {
 		}
 
 		if ( isset( $data['coupon'] ) && ! empty( $data['coupon'] ) && ur_check_module_activation( 'coupon' ) ) {
-			$response['coupon_data'] = ur_get_coupon_details( sanitize_text_field( $data['coupon'] ) );
+			$coupon_service    = new CouponService();
+			$coupon_validation = $coupon_service->validate(
+				array(
+					'coupon'        => sanitize_text_field( $data['coupon'] ),
+					'membership_id' => isset( $data['membership'] ) ? absint( $data['membership'] ) : 0,
+				)
+			);
+
+			if ( $coupon_validation['status'] ) {
+				$response['coupon_data'] = ur_get_coupon_details( sanitize_text_field( $data['coupon'] ) );
+			}
 		}
 
 		$response['user_data'] = array(

--- a/modules/membership/includes/Admin/Services/PaymentService.php
+++ b/modules/membership/includes/Admin/Services/PaymentService.php
@@ -186,12 +186,22 @@ class PaymentService {
 		// Skip for upgrades: SubscriptionService already bakes the coupon into chargeable_amount.
 		$coupon_discount = 0;
 		if ( ur_check_module_activation( 'coupon' ) && ! empty( $data['coupon'] ) && empty( $data['upgrade'] ) ) {
-			$coupon_details = ur_get_coupon_details( $data['coupon'] );
-			if ( ! empty( $coupon_details['coupon_discount_type'] ) && isset( $coupon_details['coupon_discount'] ) ) {
-				$coupon_discount = ( 'fixed' === $coupon_details['coupon_discount_type'] )
-					? floatval( $coupon_details['coupon_discount'] )
-					: floatval( $data['amount'] ) * floatval( $coupon_details['coupon_discount'] ) / 100;
-				$data['amount']  = max( 0, floatval( $data['amount'] ) - $coupon_discount );
+			$coupon_service    = new CouponService();
+			$coupon_validation = $coupon_service->validate(
+				array(
+					'coupon'        => $data['coupon'],
+					'membership_id' => isset( $data['item_id'] ) ? absint( $data['item_id'] ) : 0,
+				)
+			);
+
+			if ( $coupon_validation['status'] ) {
+				$coupon_details = ur_get_coupon_details( $data['coupon'] );
+				if ( ! empty( $coupon_details['coupon_discount_type'] ) && isset( $coupon_details['coupon_discount'] ) ) {
+					$coupon_discount = ( 'fixed' === $coupon_details['coupon_discount_type'] )
+						? floatval( $coupon_details['coupon_discount'] )
+						: floatval( $data['amount'] ) * floatval( $coupon_details['coupon_discount'] ) / 100;
+					$data['amount']  = max( 0, floatval( $data['amount'] ) - $coupon_discount );
+				}
 			}
 		}
 

--- a/modules/membership/includes/Admin/Services/Paypal/NewPaypalService.php
+++ b/modules/membership/includes/Admin/Services/Paypal/NewPaypalService.php
@@ -1151,6 +1151,28 @@ class NewPaypalService {
 				return;
 			}
 
+			$capture_status = isset( $capture_response['purchase_units'][0]['payments']['captures'][0]['status'] )
+				? $capture_response['purchase_units'][0]['payments']['captures'][0]['status']
+				: ( isset( $capture_response['status'] ) ? $capture_response['status'] : '' );
+
+			if ( 'COMPLETED' !== strtoupper( $capture_status ) ) {
+				PaymentGatewayLogging::log_error(
+					'paypal',
+					sprintf(
+						'[Member ID #%s] PayPal order capture did not complete after redirect.',
+						$member_id
+					) . "\n" . wp_json_encode(
+						array(
+							'paypal_order_id' => $order_token,
+							'member_id'       => $member_id,
+							'capture_status'  => $capture_status,
+						),
+						JSON_PRETTY_PRINT
+					)
+				);
+				return;
+			}
+
 			update_user_meta( $member_id, 'urm_paypal_order_capture_response', wp_json_encode( $capture_response ) );
 
 			$transaction_id = $this->extract_capture_id_from_order_response( $capture_response );

--- a/modules/membership/includes/Admin/Services/Paypal/NewPaypalService.php
+++ b/modules/membership/includes/Admin/Services/Paypal/NewPaypalService.php
@@ -656,6 +656,8 @@ class NewPaypalService {
 
 		if ( ! empty( $response['id'] ) ) {
 			update_user_meta( $context['member_id'], 'urm_paypal_order_id', sanitize_text_field( $response['id'] ) );
+			update_user_meta( $context['member_id'], 'urm_paypal_order_amount', (float) $context['final_amount'] );
+			update_user_meta( $context['member_id'], 'urm_paypal_order_currency', sanitize_text_field( $context['currency'] ) );
 		}
 
 		PaymentGatewayLogging::log_transaction_success(
@@ -1142,7 +1144,28 @@ class NewPaypalService {
 
 		// REST one-time order capture.
 		if ( ! empty( $order_token ) && $is_rest_one_time_payment ) {
-			$capture_response = $this->capture_paypal_order( $order_token, $this->get_paypal_rest_credentials() );
+			$expected_order_id = get_user_meta( $member_id, 'urm_paypal_order_id', true );
+
+			if ( empty( $expected_order_id ) || ! hash_equals( (string) $expected_order_id, (string) $order_token ) ) {
+				PaymentGatewayLogging::log_error(
+					'paypal',
+					sprintf(
+						'[Member ID #%s] PayPal order token does not match the order created for this member.',
+						$member_id
+					) . "\n" . wp_json_encode(
+						array(
+							'paypal_order_id'    => $order_token,
+							'expected_order_id'  => $expected_order_id,
+							'member_id'          => $member_id,
+						),
+						JSON_PRETTY_PRINT
+					)
+				);
+				return;
+			}
+
+			$paypal_credentials = $this->get_paypal_rest_credentials();
+			$capture_response   = $this->capture_paypal_order( $order_token, $paypal_credentials );
 
 			if ( is_wp_error( $capture_response ) ) {
 				PaymentGatewayLogging::log_error(
@@ -1177,6 +1200,45 @@ class NewPaypalService {
 							'paypal_order_id' => $order_token,
 							'member_id'       => $member_id,
 							'capture_status'  => $capture_status,
+						),
+						JSON_PRETTY_PRINT
+					)
+				);
+				return;
+			}
+
+			$captured_amount_data = isset( $capture_response['purchase_units'][0]['payments']['captures'][0]['amount'] )
+				? $capture_response['purchase_units'][0]['payments']['captures'][0]['amount']
+				: ( isset( $capture_response['purchase_units'][0]['amount'] ) ? $capture_response['purchase_units'][0]['amount'] : array() );
+
+			$expected_amount   = (float) get_user_meta( $member_id, 'urm_paypal_order_amount', true );
+			$expected_currency = get_user_meta( $member_id, 'urm_paypal_order_currency', true );
+			$captured_amount   = isset( $captured_amount_data['value'] ) ? (float) $captured_amount_data['value'] : 0.0;
+			$captured_currency = isset( $captured_amount_data['currency_code'] ) ? $captured_amount_data['currency_code'] : '';
+
+			$amount_mismatch   = $expected_amount > 0 && ( $captured_amount + 0.01 ) < $expected_amount;
+			$currency_mismatch = ! empty( $expected_currency ) && ! empty( $captured_currency ) && 0 !== strcasecmp( $expected_currency, $captured_currency );
+
+			$payee_email       = isset( $capture_response['purchase_units'][0]['payee']['email_address'] ) ? $capture_response['purchase_units'][0]['payee']['email_address'] : '';
+			$configured_email  = isset( $paypal_credentials['email'] ) ? $paypal_credentials['email'] : '';
+			$payee_mismatch    = ! empty( $payee_email ) && ! empty( $configured_email ) && 0 !== strcasecmp( $payee_email, $configured_email );
+
+			if ( $amount_mismatch || $currency_mismatch || $payee_mismatch ) {
+				PaymentGatewayLogging::log_error(
+					'paypal',
+					sprintf(
+						'[Member ID #%s] PayPal captured amount, currency, or payee does not match the expected order.',
+						$member_id
+					) . "\n" . wp_json_encode(
+						array(
+							'paypal_order_id'   => $order_token,
+							'member_id'         => $member_id,
+							'expected_amount'   => $expected_amount,
+							'captured_amount'   => $captured_amount,
+							'expected_currency' => $expected_currency,
+							'captured_currency' => $captured_currency,
+							'configured_payee'  => $configured_email,
+							'captured_payee'    => $payee_email,
 						),
 						JSON_PRETTY_PRINT
 					)

--- a/modules/membership/includes/Admin/Services/Paypal/NewPaypalService.php
+++ b/modules/membership/includes/Admin/Services/Paypal/NewPaypalService.php
@@ -21,6 +21,7 @@ use WPEverest\URMembership\Admin\Repositories\MembersRepository;
 use WPEverest\URMembership\Admin\Repositories\MembersSubscriptionRepository;
 use WPEverest\URMembership\Admin\Repositories\OrdersRepository;
 use WPEverest\URMembership\Admin\Repositories\SubscriptionRepository;
+use WPEverest\URMembership\Admin\Services\CouponService;
 use WPEverest\URMembership\Admin\Services\EmailService;
 use WPEverest\URMembership\Admin\Services\MembersService;
 use WPEverest\URMembership\Admin\Services\OrderService;
@@ -282,12 +283,22 @@ class NewPaypalService {
 		if ( $is_upgrading ) {
 			$final_amount = (float) ( isset( $data['amount'] ) ? $data['amount'] : $final_amount );
 		} elseif ( ! empty( $data['coupon'] ) && ur_check_module_activation( 'coupon' ) ) {
-			$coupon_details = ur_get_coupon_details( $data['coupon'] );
-			$discount_value = ( 'fixed' === ( isset( $coupon_details['coupon_discount_type'] ) ? $coupon_details['coupon_discount_type'] : '' ) )
-				? (float) ( isset( $coupon_details['coupon_discount'] ) ? $coupon_details['coupon_discount'] : 0 )
-				: ( $final_amount * (float) ( isset( $coupon_details['coupon_discount'] ) ? $coupon_details['coupon_discount'] : 0 ) / 100 );
+			$coupon_service    = new CouponService();
+			$coupon_validation = $coupon_service->validate(
+				array(
+					'coupon'        => $data['coupon'],
+					'membership_id' => absint( $membership ),
+				)
+			);
 
-			$final_amount = max( 0.0, (float) user_registration_sanitize_amount( $final_amount - $discount_value ) );
+			if ( $coupon_validation['status'] ) {
+				$coupon_details = ur_get_coupon_details( $data['coupon'] );
+				$discount_value = ( 'fixed' === ( isset( $coupon_details['coupon_discount_type'] ) ? $coupon_details['coupon_discount_type'] : '' ) )
+					? (float) ( isset( $coupon_details['coupon_discount'] ) ? $coupon_details['coupon_discount'] : 0 )
+					: ( $final_amount * (float) ( isset( $coupon_details['coupon_discount'] ) ? $coupon_details['coupon_discount'] : 0 ) / 100 );
+
+				$final_amount = max( 0.0, (float) user_registration_sanitize_amount( $final_amount - $discount_value ) );
+			}
 		}
 
 		$pre_tax_final_amount = $final_amount; // Saved before tax — used as base price in subscription plans.

--- a/modules/membership/includes/Admin/Services/Paypal/PaypalService.php
+++ b/modules/membership/includes/Admin/Services/Paypal/PaypalService.php
@@ -10,6 +10,7 @@ use WPEverest\URMembership\Admin\Repositories\MembersRepository;
 use WPEverest\URMembership\Admin\Repositories\MembersSubscriptionRepository;
 use WPEverest\URMembership\Admin\Repositories\OrdersRepository;
 use WPEverest\URMembership\Admin\Repositories\SubscriptionRepository;
+use WPEverest\URMembership\Admin\Services\CouponService;
 use WPEverest\URMembership\Admin\Services\EmailService;
 use WPEverest\URMembership\Admin\Services\MembersService;
 use WPEverest\URMembership\Admin\Services\OrderService;
@@ -165,9 +166,19 @@ class PaypalService {
 		if ( isset( $data['upgrade'] ) && $data['upgrade'] ) {
 			$final_amount = $data['amount'];
 		} elseif ( isset( $data['coupon'] ) && ! empty( $data['coupon'] ) && ur_check_module_activation( 'coupon' ) ) {
-			$coupon_details  = ur_get_coupon_details( $data['coupon'] );
-			$discount_amount = ( 'fixed' === $coupon_details['coupon_discount_type'] ) ? $coupon_details['coupon_discount'] : $membership_amount * $coupon_details['coupon_discount'] / 100;
-			$final_amount    = floatval( user_registration_sanitize_amount( $membership_amount ) - $discount_amount );
+			$coupon_service    = new CouponService();
+			$coupon_validation = $coupon_service->validate(
+				array(
+					'coupon'        => $data['coupon'],
+					'membership_id' => absint( $membership ),
+				)
+			);
+
+			if ( $coupon_validation['status'] ) {
+				$coupon_details  = ur_get_coupon_details( $data['coupon'] );
+				$discount_amount = ( 'fixed' === $coupon_details['coupon_discount_type'] ) ? $coupon_details['coupon_discount'] : $membership_amount * $coupon_details['coupon_discount'] / 100;
+				$final_amount    = floatval( user_registration_sanitize_amount( $membership_amount ) - $discount_amount );
+			}
 		}
 
 		if ( ( 'subscription' === ( $membership_type ) && ! $is_renewing ) || ( $is_automatic && $is_renewing ) ) {

--- a/modules/membership/includes/Admin/Services/Stripe/StripeService.php
+++ b/modules/membership/includes/Admin/Services/Stripe/StripeService.php
@@ -7,6 +7,7 @@ use WPEverest\URMembership\Admin\Repositories\MembershipRepository;
 use WPEverest\URMembership\Admin\Repositories\MembersOrderRepository;
 use WPEverest\URMembership\Admin\Repositories\MembersSubscriptionRepository;
 use WPEverest\URMembership\Admin\Repositories\OrdersRepository;
+use WPEverest\URMembership\Admin\Services\CouponService;
 use WPEverest\URMembership\Admin\Services\EmailService;
 use WPEverest\URMembership\Admin\Services\OrderService;
 use WPEverest\URMembership\Admin\Services\SubscriptionService;
@@ -532,11 +533,21 @@ class StripeService {
 			$amount = $payment_data['amount'];
 
 		} elseif ( isset( $payment_data['coupon'] ) && ! empty( $payment_data['coupon'] ) && ur_check_module_activation( 'coupon' ) ) {
-			$coupon_details = ur_get_coupon_details( $payment_data['coupon'] );
+			$coupon_service    = new CouponService();
+			$coupon_validation = $coupon_service->validate(
+				array(
+					'coupon'        => $payment_data['coupon'],
+					'membership_id' => isset( $payment_data['item_id'] ) ? absint( $payment_data['item_id'] ) : 0,
+				)
+			);
 
-			if ( isset( $coupon_details['coupon_discount_type'] ) && isset( $coupon_details['coupon_discount'] ) ) {
-				$discount_amount = ( 'fixed' === $coupon_details['coupon_discount_type'] ) ? $coupon_details['coupon_discount'] : $amount * $coupon_details['coupon_discount'] / 100;
-				$amount          = $amount - $discount_amount;
+			if ( $coupon_validation['status'] ) {
+				$coupon_details = ur_get_coupon_details( $payment_data['coupon'] );
+
+				if ( isset( $coupon_details['coupon_discount_type'] ) && isset( $coupon_details['coupon_discount'] ) ) {
+					$discount_amount = ( 'fixed' === $coupon_details['coupon_discount_type'] ) ? $coupon_details['coupon_discount'] : $amount * $coupon_details['coupon_discount'] / 100;
+					$amount          = $amount - $discount_amount;
+				}
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

https://themegrill.atlassian.net/browse/UR-4623
fix: verify PayPal capture status before activating one-time membership orders
fix: enforce multiple-membership policy based on server-known membership state, not client type param
fix: validate coupon eligibility before applying discounts on public membership purchase paths
fix: neutralize spreadsheet formula characters in user CSV export to prevent formula injection


### How to test the changes in this Pull Request:

1. Verify the paid membership type with PayPal
2. Verify Multiple membership purchase.
3. Verify registration with valid and expired coupon 
4. Verify the export members 

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

>  fix: verify PayPal capture status before activating one-time membership orders
    fix: enforce multiple-membership policy based on server-known membership state, not client type param
    fix: validate coupon eligibility before applying discounts on public membership purchase paths
    fix: neutralize spreadsheet formula characters in user CSV export to prevent formula injection
