### PR TITLE
fix - Field Visibility add-on does not hide selected fields on My Account / Profile Details page (UR-4643)

### DIFF
--- a/templates/myaccount/form-edit-profile.php
+++ b/templates/myaccount/form-edit-profile.php
@@ -345,14 +345,7 @@ if ( isset( $_GET['action'] ) && 'edit' === $_GET['action'] ) {
 								$form_id         = ur_get_form_id_by_userid( $user_id );
 								$form_data_array = ( $form_id ) ? UR()->form->get_form( $form_id, array( 'content_only' => true ) ) : array();
 
-								/**
-								 * Apply the profile-account field visibility filter to the read-only
-								 * profile view as well, so fields configured to be hidden on Profile
-								 * Details (e.g. via the Field Visibility add-on) are not rendered here.
-								 *
-								 * Mirrors the filtering already applied to the editable profile form
-								 * through user_registration_form_data().
-								 */
+								// Apply field visibility filter to the read-only view too, so fields hidden on Profile Details are not rendered here.
 								$form_data_array = apply_filters( 'user_registration_profile_account_filter_all_fields', $form_data_array, $form_id, current_user_can( 'manage_options' ) );
 
 								$row_ids = array();

--- a/templates/myaccount/form-edit-profile.php
+++ b/templates/myaccount/form-edit-profile.php
@@ -345,6 +345,16 @@ if ( isset( $_GET['action'] ) && 'edit' === $_GET['action'] ) {
 								$form_id         = ur_get_form_id_by_userid( $user_id );
 								$form_data_array = ( $form_id ) ? UR()->form->get_form( $form_id, array( 'content_only' => true ) ) : array();
 
+								/**
+								 * Apply the profile-account field visibility filter to the read-only
+								 * profile view as well, so fields configured to be hidden on Profile
+								 * Details (e.g. via the Field Visibility add-on) are not rendered here.
+								 *
+								 * Mirrors the filtering already applied to the editable profile form
+								 * through user_registration_form_data().
+								 */
+								$form_data_array = apply_filters( 'user_registration_profile_account_filter_all_fields', $form_data_array, $form_id, current_user_can( 'manage_options' ) );
+
 								$row_ids = array();
 							if ( ! empty( $form_data_array ) ) {
 								$row_ids       = get_post_meta( $form_id, 'user_registration_form_row_ids', true );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes **UR-4643** — the Field Visibility add-on did not hide fields on the My Account / Profile Details page.

The My Account → **Profile Details** page is rendered by `templates/myaccount/form-edit-profile.php`, which has two branches:

- **Edit mode** (`?action=edit`) renders fields from `user_registration_form_data()`, which applies the `user_registration_profile_account_filter_all_fields` filter — the hook the Field Visibility add-on uses to strip fields marked *Registration Form only*. So hiding already worked here.
- **Read-only view** (the default Profile Details display) re-fetched the form data **raw** via `UR()->form->get_form()` and iterated it directly, **without applying that filter** — so every field showed regardless of its "Show on" setting.

This PR applies the same `user_registration_profile_account_filter_all_fields` filter to the read-only view, making it consistent with the editable form. It reuses the existing (idempotent) filter — no add-on change and no existing logic removed.

### How to test the changes in this Pull Request:

1. Activate User Registration + the **Field Visibility** add-on.
2. Edit a registration form and, on a field such as **First Name** (also try Email / Last Name / Nickname), open **Advanced → Visibility Settings → Show on** and choose **Registration Form**.
3. Register a new **non-admin** user through that form, then log in as that user.
4. Go to **My Account → Profile Details**. Before this fix the field still appeared; after the fix it is hidden.
5. Change the field's *Show on* to **Profile Details** or **Registration Form & Profile Details** and confirm it appears again.

> Note: the add-on intentionally exempts administrators (`current_user_can( 'manage_options' )`), so hidden fields remain visible to admins on their own profile — verify with a non-admin account.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally? — verified via `php -l` and a standalone harness that runs the real add-on callback over a sample form (non-admin: `reg_form` fields removed; admin: exemption preserved). Full browser E2E pending a running site.
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Fix - Field Visibility add-on now hides fields on the My Account / Profile Details read-only view, matching the editable profile form.
