### PR TITLE
UR-4683 Fix - Prevent arbitrary shortcode execution through user-controlled smart tags (display name, full name, username, all fields) in Content Restriction messages.

### DIFF
--- a/includes/class-ur-smart-tags.php
+++ b/includes/class-ur-smart-tags.php
@@ -505,6 +505,7 @@ class UR_Smart_Tags {
 
 					case 'author_name':
 						$author  = get_the_author_meta( 'display_name' );
+						$author  = strip_shortcodes( $author );
 						$content = str_replace( '{{' . $other_tag . '}}', sanitize_text_field( $author ), $content );
 						break;
 					case 'unique_id':
@@ -846,21 +847,24 @@ class UR_Smart_Tags {
 						$user       = get_user_by( 'login', $username );
 						$user_id    = isset( $user->ID ) ? $user->ID : 0;
 						$first_name = get_user_meta( $user_id, 'first_name', true );
-						$content    = str_replace( '{{' . $other_tag . '}}', $first_name, $content );
+						$first_name = strip_shortcodes( $first_name );
+						$content    = str_replace( '{{' . $other_tag . '}}', esc_html( $first_name ), $content );
 						break;
 					case 'first_name':
 						$username   = $values['username'] ?? $values['membership_tags']['username'] ?? null;
 						$user       = get_user_by( 'login', $username );
 						$user_id    = isset( $user->ID ) ? $user->ID : get_current_user_id();
 						$first_name = get_user_meta( $user_id, 'first_name', true );
-						$content    = str_replace( '{{' . $other_tag . '}}', $first_name, $content );
+						$first_name = strip_shortcodes( $first_name );
+						$content    = str_replace( '{{' . $other_tag . '}}', esc_html( $first_name ), $content );
 						break;
 					case 'last_name':
 						$username  = $values['username'] ?? $values['membership_tags']['username'] ?? null;
 						$user      = get_user_by( 'login', $username );
 						$user_id   = isset( $user->ID ) ? $user->ID : get_current_user_id();
 						$last_name = get_user_meta( $user_id, 'last_name', true );
-						$content   = str_replace( '{{' . $other_tag . '}}', $last_name, $content );
+						$last_name = strip_shortcodes( $last_name );
+						$content   = str_replace( '{{' . $other_tag . '}}', esc_html( $last_name ), $content );
 						break;
 					case 'membership_end_date':
 						$membership_end_date = ( isset( $values['membership_tags'] ) && isset( $values['membership_tags']['membership_plan_expiry_date'] ) ) ? $values['membership_tags']['membership_plan_expiry_date'] : '';

--- a/includes/class-ur-smart-tags.php
+++ b/includes/class-ur-smart-tags.php
@@ -272,7 +272,8 @@ class UR_Smart_Tags {
 						} else {
 							$name = isset( $values['username'] ) ? $values['username'] : '';
 						}
-						$content = str_replace( '{{' . $other_tag . '}}', $name, $content );
+						$name    = strip_shortcodes( $name );
+						$content = str_replace( '{{' . $other_tag . '}}', esc_html( $name ), $content );
 						break;
 
 					case 'ur_login':
@@ -381,7 +382,8 @@ class UR_Smart_Tags {
 							$all_fields = '';
 						}
 
-						$content = str_replace( '{{' . $other_tag . '}}', $all_fields, $content );
+						$all_fields = strip_shortcodes( $all_fields );
+						$content    = str_replace( '{{' . $other_tag . '}}', $all_fields, $content );
 						break;
 
 					case 'admin_email':
@@ -579,6 +581,7 @@ class UR_Smart_Tags {
 						$user_id      = ! empty( $values['user_id'] ) ? $values['user_id'] : get_current_user_id();
 						$user_obj     = get_userdata( $user_id );
 						$display_name = isset( $user_obj->display_name ) ? $user_obj->display_name : '';
+						$display_name = strip_shortcodes( $display_name );
 						$content      = str_replace( '{{' . $tag . '}}', esc_html( $display_name ), $content );
 						break;
 
@@ -603,7 +606,8 @@ class UR_Smart_Tags {
 							$userdata  = get_userdata( get_current_user_id() );
 							$full_name = isset( $userdata->display_name ) ? $userdata->display_name : '';
 						}
-						$content = str_replace( '{{' . $tag . '}}', esc_html( $full_name ), $content );
+						$full_name = strip_shortcodes( $full_name );
+						$content   = str_replace( '{{' . $tag . '}}', esc_html( $full_name ), $content );
 						break;
 					case 'profile_details_link':
 						$endpoint             = ur_string_translation( 0, 'user_registration_edit-profile_slug', 'edit-profile' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes an authenticated arbitrary shortcode execution vulnerability (<= 5.2.4). User-controlled smart tags (`{{display_name}}`, `{{full_name}}`, `{{username}}`, `{{all_fields}}`) were substituted into Content Restriction messages before shortcode processing, so a subscriber could set their display name to `[gallery ids=26]` and have it execute on a restricted page.

Fixed in `UR_Smart_Tags::process()` by running `strip_shortcodes()` on these four values before substitution (and escaping the previously unescaped `username`). Admin-authored shortcodes in the message are unaffected.

Closes # UR-4683.

### How to test the changes in this Pull Request:

1. Set the Global Restriction Message (Settings → Membership → Content Restriction) to include `{{display_name}}`, and restrict a page to a paid plan using it.
2. Register a user with display name `[gallery ids=26]`, log in, and open the restricted page.
3. Confirm the literal text `[gallery ids=26]` shows instead of the shortcode output.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Fix: Prevent arbitrary shortcode execution through user-controlled smart tags in Content Restriction messages.
