### PR TITLE
UR-4512  Fix - Cancel previous subscription on upgrade.

### DIFF
--- a/modules/membership/includes/AJAX.php
+++ b/modules/membership/includes/AJAX.php
@@ -905,8 +905,9 @@ class AJAX {
 				$is_delayed            = ! empty( $next_subscription['delayed_until'] );
 				if ( ! empty( $previous_subscription ) && ! $is_delayed ) {
 					$previous_subscription = json_decode( $previous_subscription, true );
-					$stripe_service        = new StripeService();
-					$stripe_service->cancel_subscription( array(), $previous_subscription );
+					$previous_order        = json_decode( get_user_meta( $member_id, 'urm_previous_order_data', true ), true );
+					$subscription_service  = new SubscriptionService();
+					$subscription_service->cancel_subscription( is_array( $previous_order ) ? $previous_order : array(), $previous_subscription, true );
 					delete_user_meta( $member_id, 'urm_next_subscription_data' );
 					delete_user_meta( $member_id, 'urm_previous_subscription_data' );
 					delete_user_meta( $member_id, 'urm_previous_order_data' );

--- a/modules/membership/includes/Admin/Services/Paypal/NewPaypalService.php
+++ b/modules/membership/includes/Admin/Services/Paypal/NewPaypalService.php
@@ -1541,7 +1541,7 @@ class NewPaypalService {
 
 		if ( ! empty( $new_subscription_data ) ) {
 			if ( empty( $new_subscription_data['delayed_until'] ) && ! empty( $get_user_old_subscription['subscription_id'] ) ) {
-				$cancel_subscription = $this->cancel_subscription( $get_user_old_order, $get_user_old_subscription );
+				$cancel_subscription = $subscription_service->cancel_subscription( $get_user_old_order, $get_user_old_subscription, true );
 
 				if ( empty( $cancel_subscription['status'] ) ) {
 					PaymentGatewayLogging::log_error(
@@ -2192,7 +2192,7 @@ class NewPaypalService {
 	 *
 	 * @return array
 	 */
-	public function cancel_subscription( $order, $subscription ) {
+	public function cancel_subscription( $order, $subscription, $force_cancel = false ) {
 		if ( empty( $subscription['subscription_id'] ) ) {
 			$message = esc_html__( 'PayPal subscription ID not present.', 'user-registration' );
 			return array(
@@ -2203,13 +2203,23 @@ class NewPaypalService {
 
 		$paypal_options = $this->get_paypal_rest_credentials();
 
-		$response = $this->suspend_paypal_subscription(
-			$subscription['subscription_id'],
-			array(
-				'reason' => 'User initiated cancellation',
-			),
-			$paypal_options
-		);
+		if ( $force_cancel ) {
+			$response = $this->cancel_paypal_subscription(
+				$subscription['subscription_id'],
+				array(
+					'reason' => 'Membership upgrade',
+				),
+				$paypal_options
+			);
+		} else {
+			$response = $this->suspend_paypal_subscription(
+				$subscription['subscription_id'],
+				array(
+					'reason' => 'User initiated cancellation',
+				),
+				$paypal_options
+			);
+		}
 
 		if ( is_wp_error( $response ) ) {
 			PaymentGatewayLogging::log_transaction_failure(

--- a/modules/membership/includes/Admin/Services/SubscriptionService.php
+++ b/modules/membership/includes/Admin/Services/SubscriptionService.php
@@ -192,12 +192,12 @@ class SubscriptionService {
 	 *
 	 * @return array|bool[]|void
 	 */
-	public function cancel_subscription( $order, $subscription ) {
+	public function cancel_subscription( $order, $subscription, $force_cancel = false ) {
 		switch ( $order['payment_method'] ) {
 			case 'paypal':
 				$paypal_service = new NewPaypalService();
 
-				return $paypal_service->cancel_subscription( $order, $subscription );
+				return $paypal_service->cancel_subscription( $order, $subscription, $force_cancel );
 
 			case 'stripe':
 				$stripe_service = new StripeService();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Cross-gateway subscription upgrades now cancel the previous subscription at its own gateway (via the payment-method–aware dispatcher, with PayPal forced to truly cancel instead of suspend) and correctly switch the user to the new plan.

Closes # .

### How to test the changes in this Pull Request:

1. On the **local** site, create two subscription plans in a Membership Group with **upgrade enabled**; put ≥2 gateways in test mode (e.g. Stripe + Mollie).
2. Register a user and buy **Plan 1 with Stripe** (test card `4242…`); confirm Plan 1 shows active in My Account.
3. **Upgrade to Plan 2 with Mollie** and complete payment.
4. Verify: My Account shows **Plan 2 active**; Stripe dashboard shows Plan 1 **canceled**; DB `wp_ur_membership_subscriptions` has the Plan 2 row active + old row canceled.
5. Check `wp-content/uploads/ur-logs/urm-pg-mollie-*.log` for `upgrade_cancel_success` → `upgrade_completed` (no cancel failure/exception).
6. Repeat a reverse pair (e.g. **PayPal → Stripe**) and confirm the old **PayPal** sub is **Cancelled** (not just Suspended) in the PayPal dashboard.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Cancel previous subscription on upgrade.
