### PR TITLE
UR-4677 Fix - Membership field showing blank options in the form builder when a membership group is selected

### DIFF
--- a/modules/membership/includes/AJAX.php
+++ b/modules/membership/includes/AJAX.php
@@ -1458,7 +1458,6 @@ class AJAX {
 		if ( 'group' == $list_type ) {
 			$membership_group_service = new MembershipGroupService();
 			$membership_plans         = $membership_group_service->get_group_memberships( $group_id );
-			$membership_plans         = apply_filters( 'build_membership_list_frontend', $membership_plans );
 		} else {
 			$membership_service = new MembershipService();
 			$membership_plans   = $membership_service->list_active_memberships();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes the Membership field rendering blank options in the form builder when **Membership Display Options → Select a Group** is chosen. The memberships in the selected group showed up empty (radio cards with no titles) and only appeared after updating the form and reloading the builder.

Root cause: the `get_group_memberships` AJAX handler applied the `build_membership_list_frontend` filter a second time, on data that `MembershipGroupService::get_group_memberships()` had already normalized. The filter is not idempotent — the second pass reads `post_title`/`meta_value` which no longer exist on normalized items, so `title`/`type`/`amount`/`period` were overwritten with empty values. Removed the redundant filter call. The fix is applied to both the core and pro copies of the membership module to keep them in sync.

Closes #UR-4677 .

### How to test the changes in this Pull Request:

1. Open a form with a Membership field in the form builder and select the field.
2. Set **Membership Display Options** to **Select a Group** and pick a group that contains memberships.
3. Confirm the membership options render immediately with their correct titles/prices (no need to update and reload the form). Also verify **Show all Memberships** and **Select Memberships** still work correctly.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Fix - Membership field showing blank options in the form builder when a membership group is selected.
