### PR TITLE
UR-4678 Fix - Membership registration with Stripe now shows the configured success message instead of a hardcoded gateway-specific one

### DIFF
--- a/modules/membership/includes/Admin/Services/Stripe/StripeService.php
+++ b/modules/membership/includes/Admin/Services/Stripe/StripeService.php
@@ -1004,7 +1004,7 @@ class StripeService {
 			$member_order = $this->members_orders_repository->get_member_orders( $member_id );
 
 			if ( 'completed' === $member_order['status'] ) {
-				$response['message'] = $is_upgrading ? __( 'Membership upgraded successfully.', 'user-registration' ) : __( 'New member has been successfully created with successful stripe payment.', 'user-registration' );
+				$response['message'] = $is_upgrading ? __( 'Membership upgraded successfully.', 'user-registration' ) : get_option( 'user_registration_successful_membership_creation_message', esc_html__( 'New member has been successfully created.', 'user-registration' ) );
 				$response['status']  = true;
 
 				return $response;
@@ -1145,7 +1145,7 @@ class StripeService {
 		}
 
 		return array(
-			'message' => $is_upgrading ? __( 'Membership upgraded successfully.', 'user-registration' ) : __( 'New member has been successfully created with successful stripe payment.', 'user-registration' ),
+			'message' => $is_upgrading ? __( 'Membership upgraded successfully.', 'user-registration' ) : get_option( 'user_registration_successful_membership_creation_message', esc_html__( 'New member has been successfully created.', 'user-registration' ) ),
 			'status'  => true,
 		);
 	}
@@ -1632,7 +1632,7 @@ class StripeService {
 				$this->sendEmail( $member_order['ID'], $member_subscription, $membership_metas, $member_id, $response );
 
 				$response['subscription'] = $subscription;
-				$response['message']      = __( 'New member has been successfully created with successful stripe subscription.', 'user-registration' );
+				$response['message']      = get_option( 'user_registration_successful_membership_creation_message', esc_html__( 'New member has been successfully created.', 'user-registration' ) );
 				$response['status']       = true;
 			} elseif ( 'incomplete' === $subscription_status ) {
 				PaymentGatewayLogging::log_general(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Membership registration via Stripe showed a hardcoded, gateway-specific success message ("New member has been successfully created with successful stripe payment." / "...successful stripe subscription.") instead of the message configured under **User Registration → Settings → Registration/Login → Membership Registration**.

This PR makes the Stripe success paths in `StripeService` read the configured `user_registration_successful_membership_creation_message` option (falling back to the default "New member has been successfully created."), so the success message is consistent regardless of plan type (one-time/recurring) or payment gateway. The `is_upgrading` branch ("Membership upgraded successfully.") is left unchanged. The same fix is applied to both the free (`user-registration`) and pro (`user-registration-pro`) copies of the membership module.

Closes UR-4678.

### How to test the changes in this Pull Request:

1. Go to **User Registration → Settings → Registration/Login** and set a custom "Membership Registration" success message.
2. Create a registration form with a one-time (paid) membership plan that has Stripe enabled.
3. Register as a new member and pay using the Stripe test card `4242 4242 4242 4242`.
4. Confirm the success message shown matches the configured message (not the old "...with successful stripe payment." text). Repeat with a recurring/subscription plan.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Fix - Membership registration with Stripe now shows the configured success message instead of a hardcoded gateway-specific one.
