### PR TITLE
UR-4570 Fix - Login/logout redirects, the lost-password link, and the 2FA post-OTP redirect now resolve to the active language's translated page on multilingual sites (Polylang/WPML).

### DIFF
--- a/includes/frontend/class-ur-frontend.php
+++ b/includes/frontend/class-ur-frontend.php
@@ -221,7 +221,7 @@ class UR_Frontend {
 		} elseif ( 'internal-page' === $redirect_option ) {
 			$page_id = get_option( 'user_registration_login_options_after_login_redirect_page', 0 );
 			if ( 0 !== absint( $page_id ) ) {
-				$redirect = get_permalink( $page_id );
+				$redirect = get_permalink( ur_get_translated_page_id( $page_id ) );
 			} else {
 				ur_get_logger()->info( sprintf( 'Invalid page ID %s set for after login redirection.', $page_id ), array( 'source' => 'user-registration' ) );
 			}
@@ -252,7 +252,7 @@ class UR_Frontend {
 		} elseif ( 'internal-page' === $redirect_option ) {
 			$page_id = get_option( 'user_registration_login_options_after_logout_redirect_page', 0 );
 			if ( 0 !== absint( $page_id ) ) {
-				$redirect = get_permalink( $page_id );
+				$redirect = get_permalink( ur_get_translated_page_id( $page_id ) );
 			} else {
 				ur_get_logger()->info( sprintf( 'Invalid page ID %s set for after logout redirection.', $page_id ), array( 'source' => 'user-registration' ) );
 			}

--- a/includes/functions-ur-account.php
+++ b/includes/functions-ur-account.php
@@ -56,7 +56,7 @@ function ur_lostpassword_url( $default_url = '' ) {
 	$lost_password_page = get_option( 'user_registration_lost_password_page_id', false );
 
 	if ( $lost_password_page && ! empty( get_post( $lost_password_page ) ) ) {
-		return get_permalink( $lost_password_page );
+		return get_permalink( ur_get_translated_page_id( $lost_password_page ) );
 	} else {
 		$ur_account_page_url = ur_get_page_permalink( 'myaccount' );
 
@@ -107,14 +107,14 @@ function ur_resetpassword_url( $default_url = '' ) {
 	$lost_password_page = get_option( 'user_registration_lost_password_page_id', false );
 
 	if ( $lost_password_page && ! empty( get_post( $lost_password_page ) ) ) {
-		return get_permalink( $lost_password_page );
+		return get_permalink( ur_get_translated_page_id( $lost_password_page ) );
 	}
 
 	// Legacy fallback: a separate reset-password page (deprecated option).
 	$reset_password_page = get_option( 'user_registration_reset_password_page_id', false );
 
 	if ( $reset_password_page && ! empty( get_post( $reset_password_page ) ) ) {
-		return get_permalink( $reset_password_page );
+		return get_permalink( ur_get_translated_page_id( $reset_password_page ) );
 	}
 
 	return ur_lostpassword_url();

--- a/includes/functions-ur-page.php
+++ b/includes/functions-ur-page.php
@@ -123,6 +123,42 @@ function ur_get_wpml_page_language( $page_id ) {
 	return $cache[ $cache_key ];
 }
 
+if ( ! function_exists( 'ur_get_translated_page_id' ) ) {
+	/**
+	 * Map a stored (default language) page ID to its translation for the active language.
+	 *
+	 * Plugin options store the page ID of the default language page. When Polylang or WPML
+	 * is active, redirect and account links must point to the translated page for the current
+	 * language instead. Returns the original ID when no translation exists or no multilingual
+	 * plugin is active.
+	 *
+	 * @since 5.2.6
+	 *
+	 * @param int $page_id Page ID stored in plugin options (default language).
+	 *
+	 * @return int Translated page ID, or the original when no translation applies.
+	 */
+	function ur_get_translated_page_id( $page_id ) {
+		$page_id = absint( $page_id );
+
+		if ( $page_id <= 0 ) {
+			return $page_id;
+		}
+
+		if ( function_exists( 'pll_current_language' ) ) {
+			$current_language = pll_current_language();
+			if ( ! empty( $current_language ) ) {
+				$translations = pll_get_post_translations( $page_id );
+				$page_id      = isset( $translations[ $current_language ] ) ? $translations[ $current_language ] : $page_id;
+			}
+		} elseif ( class_exists( 'SitePress', false ) ) {
+			$page_id = ur_get_wpml_page_language( $page_id );
+		}
+
+		return absint( $page_id );
+	}
+}
+
 /**
  * Retrieve page permalink.
  *

--- a/includes/functions-ur-template.php
+++ b/includes/functions-ur-template.php
@@ -153,7 +153,7 @@ if ( ! function_exists( 'ur_get_form_redirect_url' ) ) {
 						$selected_page = ur_get_single_post_meta( $form_id, 'user_registration_form_setting_redirect_page', get_option( 'user_registration_thank_you_page_id', '' ) );
 
 						if ( ! empty( $selected_page ) && 'no-redirection' !== $selected_page ) {
-							$page_url     = get_permalink( $selected_page );
+							$page_url     = get_permalink( ur_get_translated_page_id( $selected_page ) );
 							$redirect_url = $page_url;
 						} else {
 							$redirect_url = '';

--- a/includes/shortcodes/class-ur-shortcode-my-account.php
+++ b/includes/shortcodes/class-ur-shortcode-my-account.php
@@ -659,14 +659,14 @@ class UR_Shortcode_My_Account {
 		$lost_password_page_id = get_option( 'user_registration_lost_password_page_id', false );
 
 		if ( $lost_password_page_id && get_post( $lost_password_page_id ) ) {
-			$path = wp_parse_url( get_permalink( $lost_password_page_id ), PHP_URL_PATH );
+			$path = wp_parse_url( get_permalink( ur_get_translated_page_id( $lost_password_page_id ) ), PHP_URL_PATH );
 			if ( ! empty( $path ) ) {
 				$rp_path = trailingslashit( $path );
 			}
 		} else {
 			$reset_password_page_id = get_option( 'user_registration_reset_password_page_id', false );
 			if ( $reset_password_page_id && get_post( $reset_password_page_id ) ) {
-				$path = wp_parse_url( get_permalink( $reset_password_page_id ), PHP_URL_PATH );
+				$path = wp_parse_url( get_permalink( ur_get_translated_page_id( $reset_password_page_id ) ), PHP_URL_PATH );
 				if ( ! empty( $path ) ) {
 					$rp_path = trailingslashit( $path );
 				}

--- a/templates/myaccount/form-login.php
+++ b/templates/myaccount/form-login.php
@@ -324,7 +324,7 @@ if ( isset( $_GET['page'] ) && 'user-registration-login-forms' === $_GET['page']
 				<input type="hidden" name="previous_page" value="<?php echo esc_attr( wp_get_raw_referer() ); ?>"/>
 				<?php
 
-				$url_options = get_option( 'user_registration_general_setting_registration_url_options', get_permalink( get_option( 'user_registration_registration_page_id' ) ) );
+				$url_options = get_option( 'user_registration_general_setting_registration_url_options', get_permalink( ur_get_translated_page_id( get_option( 'user_registration_registration_page_id' ) ) ) );
 
 				if ( ! empty( $url_options ) || $is_login_settings ) {
 					$url_pattern = "/^https?:\\/\\/(?:www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}(\\.[a-zA-Z0-9()]{1,6})?\\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*)$/";


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

On multilingual sites (Polylang/WPML), the login form's redirect links and the lost-password link always pointed to the default-language pages, regardless of the active language. This happened because stored page IDs were converted to URLs with a raw `get_permalink()` that skipped the language/translation lookup the plugin already uses elsewhere.

This PR:

- Adds a reusable helper `ur_get_translated_page_id()` (Polylang + WPML aware; returns the original ID unchanged when no multilingual plugin is active).
- Applies it to the login/logout custom redirect (`UR_Frontend::login_redirect()` / `logout_redirect()`), the "Lost your password?" link, the reset-password URL, and the reset-password cookie path.
- Fixes the 2FA post-OTP redirect by wiring up the `?lang=` param the OTP scripts already send (new guarded helper `ur2fa_set_current_language()`), so both the custom redirect and the account-page fallback resolve to the correct-language page.

Files: `includes/functions-ur-page.php`, `includes/frontend/class-ur-frontend.php`, `includes/functions-ur-account.php`, `includes/shortcodes/class-ur-shortcode-my-account.php`, and the 2FA add-on (`includes/Functions.php`, `includes/Ajax.php`, `includes/Frontend.php`).

Closes # — Jira: UR-4570.

### How to test the changes in this Pull Request:
https://themegrill.atlassian.net/browse/UR-4570?focusedCommentId=45697
1. Activate Polylang (or WPML); add English (default) + French; create translated page pairs for My Account, Lost Password, and login/logout redirect targets. Set them in *User Registration → Settings* and enable the Login Form → Advanced custom redirects.
2. On the **French** login page: the "Lost your password?" link must point to the French page (`/fr/...`), logging in must land on the French redirect page, and logging out must land on the French logout page.
3. Enable 2FA for the test role, log in on the French page, complete the OTP → must land on the French redirect/account page (not the English default). Repeat with custom redirect off (falls back to the French My Account page).
4. Deactivate Polylang/WPML and confirm single-language behavior is unchanged.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Fix - Login/logout redirects, the lost-password link, and the 2FA post-OTP redirect now resolve to the active language's translated page on multilingual sites (Polylang/WPML).
