### PR TITLE
UR-4670 Fix - Added spinner on Membership Reactivation.

### DIFF
--- a/assets/js/modules/membership/frontend/user-registration-membership-frontend.js
+++ b/assets/js/modules/membership/frontend/user-registration-membership-frontend.js
@@ -3501,7 +3501,8 @@
 							subscription_id: $this.data("id")
 						},
 						beforeSend: function () {
-							$this.text(urmf_data.labels.i18n_sending_text);
+							ur_membership_frontend_utils.append_spinner($this);
+							ur_membership_frontend_utils.toggleSaveButtons(true, $this);
 						},
 						success: function (response) {
 							if (!response.success) {
@@ -3529,7 +3530,8 @@
 							}
 						},
 						complete: function () {
-							$this.text(button_text);
+							ur_membership_frontend_utils.remove_spinner($this);
+							ur_membership_frontend_utils.toggleSaveButtons(false, $this);
 						}
 					});
 				}

--- a/modules/membership/includes/Admin/Repositories/MembersSubscriptionRepository.php
+++ b/modules/membership/includes/Admin/Repositories/MembersSubscriptionRepository.php
@@ -185,6 +185,7 @@ class MembersSubscriptionRepository extends BaseRepository implements MembersSub
 						       wu.ID as member_id,
 						       wp.post_title as membership_plan_name,
 						       wums.item_id as membership,
+						       wums.ID as subscription_id,
 						       wums.next_billing_date,
 						       wums.expiry_date
 						FROM  $this->table wums
@@ -216,13 +217,14 @@ class MembersSubscriptionRepository extends BaseRepository implements MembersSub
 						       wu.ID as member_id,
 						       wp.post_title as membership_plan_name,
 						       wums.item_id as membership,
+						       wums.ID as subscription_id,
 						       wums.next_billing_date,
 						       wums.expiry_date
 						FROM  $this->table wums
 					    LEFT JOIN $this->users_table wu ON wums.user_id = wu.ID
 					    LEFT JOIN $this->posts_table wp ON wums.item_id = wp.ID
 						WHERE wums.status = 'expired'
-						AND DATE(wums.expiry_date) = DATE('%s')
+						AND wums.expiry_date >= '%s'
 						",
 			$check_date
 		);

--- a/modules/membership/includes/Admin/Services/SubscriptionService.php
+++ b/modules/membership/includes/Admin/Services/SubscriptionService.php
@@ -1125,7 +1125,13 @@ class SubscriptionService {
 		$email_service = new EmailService();
 		foreach ( $subscriptions as $subscription ) {
 
-			$user_id      = $subscription['member_id'];
+			$user_id = $subscription['member_id'];
+
+			// Skip memberships already scheduled to cancel; no "expiring soon / renew" reminder for them.
+			if ( get_user_meta( $user_id, 'urm_pending_cancel_' . ( $subscription['subscription_id'] ?? '' ), true ) ) {
+				continue;
+			}
+
 			$checked_date = get_user_meta( $user_id, 'urm_expiring_reminder_sent_for_date', true );
 
 			if ( $checked_date === $subscription['next_billing_date'] ) {
@@ -1142,8 +1148,10 @@ class SubscriptionService {
 	 * @return void
 	 */
 	public function daily_membership_ended_check() {
-		$date          = new \DateTime( 'today' );
-		$check_date    = $date->modify( '-1 day' )->format( 'Y-m-d H:i:s' );
+		// Look back a window (not a single day) and dedupe per subscription, so a late status flip,
+		// cron-order drift, or a missed cron day can't permanently skip the ended email.
+		$lookback_days = (int) apply_filters( 'urm_ended_email_lookback_days', 7 );
+		$check_date    = ( new \DateTime( "-{$lookback_days} days" ) )->format( 'Y-m-d H:i:s' );
 		$subscriptions = $this->members_subscription_repository->get_expired_subscriptions( $check_date );
 
 		if ( empty( $subscriptions ) ) {
@@ -1151,13 +1159,12 @@ class SubscriptionService {
 		}
 		$email_service = new EmailService();
 		foreach ( $subscriptions as $subscription ) {
-			$user_id      = $subscription['member_id'];
-			$checked_date = get_user_meta( $user_id, 'urm_expired_reminder_sent_for_date', true );
-			if ( $checked_date === $subscription['expiry_date'] ) {
+			$sent_key = 'urm_ended_email_sent_' . ( $subscription['subscription_id'] ?? '' );
+			if ( get_user_meta( $subscription['member_id'], $sent_key, true ) ) {
 				continue;
 			}
 			$email_service->send_email( $subscription, 'membership_ended' );
-			update_user_meta( $subscription['member_id'], 'urm_expired_reminder_sent_for_date', $subscription['expiry_date'] );
+			update_user_meta( $subscription['member_id'], $sent_key, $subscription['expiry_date'] );
 		}
 	}
 
@@ -1202,7 +1209,9 @@ class SubscriptionService {
 				( new NewPaypalService() )->cancel_suspended_subscription( $subscription['gateway_subscription_id'] );
 			}
 			delete_user_meta( $user_id, 'urm_pending_cancel_' . $subscription_id );
-			$update_result = $this->members_subscription_repository->update( $subscription_id, array( 'status' => 'expired' ) );
+			// A pending-cancel subscription reaching its date is a cancellation, not a natural expiry.
+			$new_status    = $pending_cancel_meta ? 'canceled' : 'expired';
+			$update_result = $this->members_subscription_repository->update( $subscription_id, array( 'status' => $new_status ) );
 
 			if ( $update_result ) {
 				++$expired_count;
@@ -1224,13 +1233,14 @@ class SubscriptionService {
 					array( 'source' => 'urm-membership-expiration' )
 				);
 
-				// Prepare data to trigger subscription expired event.
+				// Cancellation email already went out at cancel time; the membership_ended cron only targets 'expired', so a canceled sub gets no expiry email either.
 				$payload = array(
 					'subscription_id' => $subscription_id,
 					'member_id'       => $user_id,
-					'event_type'      => 'expired',
+					'event_type'      => $pending_cancel_meta ? 'canceled' : 'expired',
 					'meta'            => array(
 						'membership_id' => $membership_id,
+						'mode'          => 'expiry',
 					),
 				);
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Added spinner instead of sending text when reactivating.

Closes # .

### How to test the changes in this Pull Request:

1. Subscribe to a membership using Mollie or Authoriznet
2. Cancel the Subscription From Subscriptions tab.
3. Click Reactivate and check if the spinner appears or not also check if double clicks are causing resubmissions or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Added spinner on Membership Reactivation.
