### PR TITLE
UR-4701 Fix - Membership emails send/preview default content instead of saved custom content

### DIFF
--- a/includes/class-ur-preview.php
+++ b/includes/class-ur-preview.php
@@ -348,12 +348,17 @@ class UR_Preview {
 
 			$pro_content_suffix_emails = array( 'delete_account_email', 'delete_account_admin_email', 'auto_generated_password_email', 'email_verified_admin_email' );
 
+			// Membership emails whose saved content option uses a `_message` suffix (the content field id differs from $this->id).
+			$message_suffix_emails = array( 'membership_ended_user_email', 'membership_expiring_soon_user_email', 'membership_renewal_reminder_user_email' );
+
 			if ( 'passwordless_login_email' === $option_name ) {
 				$email_content = get_option( 'user_registration_' . $option_name . '_content', $class_instance->$default_content() );
 			} elseif ( 'prevent_concurrent_login_email' === $option_name ) {
 				$email_content = get_option( 'user_registration_prevent_concurrent_login_email_content', $class_instance->$default_content() );
 			} elseif ( in_array( $option_name, $pro_content_suffix_emails, true ) ) {
 				$email_content = get_option( 'user_registration_pro_' . $option_name . '_content', $class_instance->$default_content() );
+			} elseif ( in_array( $option_name, $message_suffix_emails, true ) ) {
+				$email_content = get_option( 'user_registration_' . $option_name . '_message', $class_instance->$default_content() );
 			} else {
 				$email_content = get_option( 'user_registration_' . $option_name, $class_instance->$default_content() );
 			}

--- a/modules/membership/includes/Admin/Services/EmailService.php
+++ b/modules/membership/includes/Admin/Services/EmailService.php
@@ -487,7 +487,7 @@ class EmailService {
 			'membership_tags' => $membership_tags,
 		);
 		$values  = $data + $values;
-		$message = apply_filters( 'user_registration_process_smart_tags', get_option( 'user_registration_membership_cancellation_admin_email_message', $settings->user_registration_get_membership_cancellation_user_email() ), $values, $form_id );
+		$message = apply_filters( 'user_registration_process_smart_tags', get_option( 'user_registration_membership_cancellation_user_email', $settings->user_registration_get_membership_cancellation_user_email() ), $values, $form_id );
 
 		$message     = apply_filters( 'ur_membership_membership_cancellation_email_custom_template', $message, $subject );
 		$template_id = ur_get_single_post_meta( $form_id, 'user_registration_select_email_template' );
@@ -549,7 +549,7 @@ class EmailService {
 		);
 		$values = $data + $values;
 
-		$message = apply_filters( 'user_registration_process_smart_tags', get_option( 'user_registration_membership_cancellation_admin_email_message', $settings->user_registration_get_membership_cancellation_admin_email() ), $values, $form_id );
+		$message = apply_filters( 'user_registration_process_smart_tags', get_option( 'user_registration_membership_cancellation_admin_email', $settings->user_registration_get_membership_cancellation_admin_email() ), $values, $form_id );
 
 		$message     = apply_filters( 'ur_membership_membership_cancellation_email_custom_template', $message, $subject );
 		$template_id = ur_get_single_post_meta( $form_id, 'user_registration_select_email_template' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Jira: https://themegrill.atlassian.net/browse/UR-4701

Customized content saved for the membership emails was ignored — the default (English) content was previewed and delivered instead — because of option-key mismatches between where the content is **saved** (the settings field `id`), where it is **read on send** (`EmailService.php`), and where it is **read for preview** (`class-ur-preview.php`, which builds the key from `$this->id`).

**Root cause & fix:**

1. **Membership Cancellation → user** (`EmailService.php`): sent content was read from `user_registration_membership_cancellation_admin_email_message`, but the user-email content field saves to `user_registration_membership_cancellation_user_email`. The saved key was never read, so the default was always sent. Now reads the correct key.
2. **Membership Cancellation → admin** (`EmailService.php`): same issue — read from `..._cancellation_admin_email_message` while the admin content field saves to `..._cancellation_admin_email`. Now reads the correct key.
3. **Renewal Reminder / Expiring Soon / Ended previews** (`class-ur-preview.php`): the preview builds the option key from `$this->id` (e.g. `membership_ended_user_email`), but these content fields save with a `_message` suffix (`..._user_email_message`). Added a small `$message_suffix_emails` allowlist (mirroring the existing `$pro_content_suffix_emails` pattern) so the preview reads the `_message` key. Their send paths already used the correct key, so only the preview was affected.

### How to test the changes in this Pull Request:

1. Go to **User Registration & Membership → Settings → Email**, and under "To User"/"To Admin" open each membership email (Cancellation, Renewal Reminder, Expiring Soon, Ended) via the gear icon.
2. Set custom content (e.g. an Italian translation) and save.
3. Click the eye (preview) icon:
   - Before: Renewal Reminder / Expiring Soon / Ended previews showed the default English content.
   - After: the preview shows the saved custom content.
4. Cancel a membership to trigger the Cancellation emails:
   - Before: the user (and admin) received the default English content regardless of customization.
   - After: the received email uses the saved custom content.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

Fix - Membership emails now use saved custom content for preview and delivery.