### PR TITLE
UR-4674 - Enhance - Reset password smart tag validation in email content.

### DIFF
--- a/includes/admin/settings/emails/class-ur-settings-reset-password-email.php
+++ b/includes/admin/settings/emails/class-ur-settings-reset-password-email.php
@@ -51,6 +51,25 @@ if ( ! class_exists( 'UR_Settings_Reset_Password_Email', false ) ) :
 			$this->title       = __( 'Reset Password', 'user-registration' );
 			$this->description = __( 'Sends a secure password reset link to the user who requested a reset.', 'user-registration' );
 			$this->receiver    = 'User';
+
+			add_filter( 'user_registration_admin_settings_sanitize_option_user_registration_reset_password_email', array( $this, 'validate_reset_link_smart_tag' ), 10, 2 );
+		}
+
+		public function validate_reset_link_smart_tag( $value, $option ) {
+			$required_url = '{{home_url}}/{{ur_reset_pass_slug}}?action=rp&key={{key}}&login={{username}}';
+			$content      = html_entity_decode( (string) $value, ENT_QUOTES );
+
+			if ( false === strpos( $content, $required_url ) ) {
+				UR_Admin_Settings::add_error(
+					sprintf(
+						/* translators: %s: required reset password link. */
+						__( 'Reset Password email not saved: the reset link <code>%s</code> is required and cannot be removed or modified.', 'user-registration' ),
+						esc_html( $required_url )
+					)
+				);
+				return UR_Admin_Settings::get_option( $option['id'], $option['default'] );
+			}
+			return $value;
 		}
 
 		/**

--- a/includes/class-ur-smart-tags.php
+++ b/includes/class-ur-smart-tags.php
@@ -67,6 +67,7 @@ class UR_Smart_Tags {
 		$smart_tags = array(
 			'{{blog_info}}'        => esc_html__( 'Blog Info', 'user-registration' ),
 			'{{home_url}}'         => esc_html__( 'Home URL', 'user-registration' ),
+			'{{ur_reset_pass_slug}}' => esc_html__( 'Reset Password Slug', 'user-registration' ),
 			'{{admin_email}}'      => esc_html__( 'Site Admin Email', 'user-registration' ),
 			'{{site_name}}'        => esc_html__( 'Site Name', 'user-registration' ),
 			'{{site_url}}'         => esc_html__( 'Site URL', 'user-registration' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add validation for the required slug or pattern for the reset password email.

Closes # .

### How to test the changes in this Pull Request:

1. Settings > Emails > To user > Reset Password
2. Remove the click here which is by default as a link.
3. A validation must appear which wont allow changes to be saved if it is not present.

### Types of changes:

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhance - Reset password smart tag validation in email content.
