### PR TITLE
UR-4706 Fix - Validation for lost password n Pages Setting.

### DIFF
--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -1126,30 +1126,36 @@
 
 		data.user_registration_selected_lost_password_page = $this.val();
 
-		$this.prop("disabled", true);
 		$this.css("border", "1px solid #e1e1e1");
 
 		$this
 			.closest(".user-registration-global-settings--field")
 			.find(".error.inline")
 			.remove();
+		$this
+			.closest(".user-registration-global-settings")
+			.append('<div class="ur-spinner is-active"></div>');
 
 		$.ajax({
 			url: user_registration_settings_params.ajax_url,
 			data: data,
 			type: "POST",
 			complete: function (response) {
+				$this
+					.closest(".user-registration-global-settings")
+					.find(".ur-spinner")
+					.remove();
 				if (response.responseJSON.success === false) {
 					if (
 						$this
 							.closest(
-								".user-registration-login-form-global-settings"
+								".user-registration-global-settings--field"
 							)
 							.find(".error.inline").length === 0
 					) {
 						$this
 							.closest(
-								".user-registration-login-form-global-settings"
+								".user-registration-global-settings--field"
 							)
 							.append(
 								"<div id='message' class='error inline' style='padding:10px;'>" +
@@ -1158,32 +1164,19 @@
 							);
 					}
 					$this.css("border", "1px solid red");
-					var login_form = $this.closest(
-						".user-registration-login-form-container"
-					);
-					$(login_form)
-						.closest("#wpbody-content")
-						.find("#ur-lists-page-topnav")
-						.find('button[name="save_login_form"]')
-						.prop("disabled", true);
+					$('input[name="save"]').prop("disabled", true);
 				} else {
-					var login_form = $this.closest(
-						".user-registration-login-form-container"
-					);
-					$(login_form)
-						.closest("#wpbody-content")
-						.find("#ur-lists-page-topnav")
-						.find('button[name="save_login_form"]')
-						.prop("disabled", false);
+					$this.css("border", "1px solid #e1e1e1");
 					$this
 						.closest(
-							".user-registration-login-form-global-settings"
+							".user-registration-global-settings--field"
 						)
 						.find(".error.inline")
 						.remove();
+					if ($(".error.inline").length === 0) {
+						$('input[name="save"]').prop("disabled", false);
+					}
 				}
-
-				$this.prop("disabled", false);
 			}
 		});
 	});


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixed validation not appearing on lost password in settings pages.

Closes # .

### How to test the changes in this Pull Request:

1. Go to settings > Pages.
2. Select a page that does not have lost password shortcode.
3. A validation must appear and the save button must be disabled.
4. Also verify in the login form settings as well.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Validation for lost password n Pages Setting.
