### PR TITLE
UR-4695 Fix - Show upgrade prompt for Plus-gated membership group toggles on lower plans

### DIFF
--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -439,17 +439,22 @@ function ur_help_tip( $tip, $allow_html = false, $classname = 'user-registration
 }
 
 function ur_render_premium_feature_gate_template( $args = array() ) {
-	if ( UR_PRO_ACTIVE ) {
-		return;
-	}
-
 	$args = wp_parse_args(
 		$args,
 		array(
 			'template_id' => 'ur-pro-feature',
 			'utm_source'  => 'ur-membership-create',
+			'plan_gated'  => false,
+			'title'       => esc_html__( 'You have run into a premium feature, please upgrade to URM Pro', 'user-registration' ),
+			'button_text' => esc_html__( 'Upgrade to Pro', 'user-registration' ),
 		)
 	);
+
+	// Render for free installs, or when a higher plan is required even though Pro is active.
+	if ( UR_PRO_ACTIVE && empty( $args['plan_gated'] ) ) {
+		return;
+	}
+
 	if ( empty( $args['upgrade_url'] ) ) {
 		$args['upgrade_url'] = 'https://wpuserregistration.com/upgrade/?utm_source=' . esc_attr( $args['utm_source'] ) . '&utm_medium=upgrade-link&utm-campaign=lite-version';
 	}
@@ -463,11 +468,11 @@ function ur_render_premium_feature_gate_template( $args = array() ) {
 	<template id="<?php echo esc_attr( $args['template_id'] ); ?>">
 		<div class="ur-feature">
 			<div class="ur-feature__title">
-				<?php esc_html_e( 'You have run into a premium feature, please upgrade to URM Pro', 'user-registration' ); ?>
+				<?php echo esc_html( $args['title'] ); ?>
 			</div>
 			<a class="ur-feature__btn" target="_blank" href="<?php echo esc_url( $args['upgrade_url'] ); ?>">
 				<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11.562 3.266a.5.5 0 0 1 .876 0L15.39 8.87a1 1 0 0 0 1.516.294L21.183 5.5a.5.5 0 0 1 .798.519l-2.834 10.246a1 1 0 0 1-.956.734H5.81a1 1 0 0 1-.957-.734L2.02 6.02a.5.5 0 0 1 .798-.519l4.276 3.664a1 1 0 0 0 1.516-.294z"></path><path d="M5 21h14"></path></svg>
-				<?php esc_html_e( 'Upgrade to Pro', 'user-registration' ); ?>
+				<?php echo esc_html( $args['button_text'] ); ?>
 			</a>
 		</div>
 	</template>
@@ -475,18 +480,23 @@ function ur_render_premium_feature_gate_template( $args = array() ) {
 }
 
 function ur_render_premium_feature_gate( $args = array() ) {
-	if ( UR_PRO_ACTIVE ) {
-		return;
-	}
-
-	$args                = wp_parse_args(
+	$args = wp_parse_args(
 		$args,
 		array(
 			'template_id'     => 'ur-pro-feature',
 			'utm_source'      => 'ur-membership-create',
 			'render_template' => true,
+			'plan_gated'      => false,
+			'title'           => esc_html__( 'You have run into a premium feature, please upgrade to URM Pro', 'user-registration' ),
+			'button_text'     => esc_html__( 'Upgrade to Pro', 'user-registration' ),
 		)
 	);
+
+	// Render for free installs, or when a higher plan is required even though Pro is active.
+	if ( UR_PRO_ACTIVE && empty( $args['plan_gated'] ) ) {
+		return;
+	}
+
 	$args['upgrade_url'] = 'https://wpuserregistration.com/upgrade/?utm_source=' . esc_attr( $args['utm_source'] ) . '&utm_medium=upgrade-link&utm-campaign=lite-version';
 
 	if ( ! empty( $args['render_template'] ) ) {

--- a/modules/membership/includes/Admin/Membership/ListTable.php
+++ b/modules/membership/includes/Admin/Membership/ListTable.php
@@ -154,7 +154,7 @@ class ListTable extends \UR_List_Table {
 	 */
 	public function column_status( $membership ) {
 		$membership_content = json_decode( $membership->post_content, true );
-		$enabled            = $membership_content['status'] == 'true';
+		$enabled            = isset( $membership_content['status'] ) && 'true' == $membership_content['status'];
 		$actions            = '<div class="ur-status-toggle ur-d-flex ur-align-items-center visible" style="gap: 5px">';
 		$actions           .= '<div class="ur-toggle-section">';
 		$actions           .= '<span class="user-registration-toggle-form">';
@@ -180,9 +180,10 @@ class ListTable extends \UR_List_Table {
 	 */
 	public function column_membership_type( $membership ) {
 		$data         = json_decode( wp_unslash( $membership->post_content ), true );
-		$status_class = ( 'free' == $data['type'] ? 'user-registration-badge user-registration-badge--success-subtle' : ( 'paid' == $data['type'] ? 'user-registration-badge user-registration-badge--secondary-subtle' : 'user-registration-badge user-registration-badge--danger-subtle' ) );
+		$type         = isset( $data['type'] ) ? $data['type'] : '';
+		$status_class = ( 'free' == $type ? 'user-registration-badge user-registration-badge--success-subtle' : ( 'paid' == $type ? 'user-registration-badge user-registration-badge--secondary-subtle' : 'user-registration-badge user-registration-badge--danger-subtle' ) );
 
-		return sprintf( '<span class="%s">%s</span>', $status_class, esc_html( $data['type'] ) );
+		return sprintf( '<span class="%s">%s</span>', $status_class, esc_html( $type ) );
 	}
 
 	/**

--- a/modules/membership/includes/Admin/Services/MembershipService.php
+++ b/modules/membership/includes/Admin/Services/MembershipService.php
@@ -272,7 +272,7 @@ class MembershipService {
 		foreach ( $memberships as $key => $membership ) {
 			$membership_post_content = json_decode( wp_unslash( $membership['post_content'] ), true );
 
-			if ( ! $membership_post_content['status'] ) {
+			if ( empty( $membership_post_content ) || empty( $membership_post_content['status'] ) ) {
 				unset( $memberships[ $key ] );
 				continue;
 			}

--- a/modules/membership/includes/Admin/Views/membership-groups-create.php
+++ b/modules/membership/includes/Admin/Views/membership-groups-create.php
@@ -87,7 +87,7 @@ if ( ! empty( $membership_group['post_content'] ) ) {
 			<div id="ur-membership-group-create-form" class="user-registration-card">
 				<div class="user-registration-card__body">
 					<div id="ur-membership-main-fields">
-						<!--					membership group name-->
+						<!--membership group name-->
 						<div class="ur-membership-input-container ur-d-flex ur-p-1" style="gap:20px;">
 							<div class="ur-label" style="width: 62%">
 								<label
@@ -165,7 +165,7 @@ if ( ! empty( $membership_group['post_content'] ) ) {
 								</div>
 							</div>
 						</div>
-						<div class="ur-membership-input-container ur-d-flex ur-p-1 ur-mt-3 <?php echo ! UR_PRO_ACTIVE ? 'upgradable-type' : ''; ?>" style="gap:20px" >
+						<div class="ur-membership-input-container ur-d-flex ur-p-1 ur-mt-3 <?php echo ( ! UR_PRO_ACTIVE || ! urm_check_if_plus_and_above_plan() ) ? 'upgradable-type' : ''; ?>" style="gap:20px" >
 							<div class="ur-label" style="width: 62%;">
 									<label class="ur-membership-group-enable-multiple-memberships"
 										for="ur-membership-group-multiple-memberships">
@@ -186,7 +186,20 @@ if ( ! empty( $membership_group['post_content'] ) ) {
 									<?php echo UR_PRO_ACTIVE && urm_check_if_plus_and_above_plan() ? '' : 'disabled'; ?>
 									>
 									<span class="slider round"></span>
-									<?php ur_render_premium_feature_gate();?>
+									<?php
+									if ( ! UR_PRO_ACTIVE ) {
+										ur_render_premium_feature_gate();
+									} elseif ( ! urm_check_if_plus_and_above_plan() ) {
+										ur_render_premium_feature_gate(
+											array(
+												'plan_gated' => true,
+												'template_id' => 'ur-plan-feature-plus',
+												'title' => esc_html__( 'This feature is available on the Plus plan and above. Upgrade your plan to unlock it.', 'user-registration' ),
+												'button_text' => esc_html__( 'Upgrade Plan', 'user-registration' ),
+											)
+										);
+									}
+									?>
 								</span>
 							</div>
 						</div>
@@ -194,7 +207,7 @@ if ( ! empty( $membership_group['post_content'] ) ) {
 						$upgrade_style = ( ! isset( $membership_group['mode'] ) || ( isset( $membership_group['mode'] ) && ( empty( $membership_group['mode'] ) || 'upgrade' === $membership_group['mode'] ) ) ) ? '' : 'display:none;';
 						?>
 						<div class="ur-membership-enable-upgrade-container" style="<?php echo esc_attr( $upgrade_style ); ?>">
-							<div class="ur-membership-input-container ur-d-flex ur-p-1 ur-mt-3  <?php echo ! UR_PRO_ACTIVE ? 'upgradable-type' : ''; ?>" style="gap:20px">
+							<div class="ur-membership-input-container ur-d-flex ur-p-1 ur-mt-3  <?php echo ( ! UR_PRO_ACTIVE || ! urm_check_if_plus_and_above_plan() ) ? 'upgradable-type' : ''; ?>" style="gap:20px">
 								<div class="ur-label" style="width: 62%;">
 										<label class="ur-membership-group-enable-upgrade"
 												for="ur-membership-group-upgrade"><?php esc_html_e( 'Upgrade action', 'user-registration' ); ?>
@@ -214,7 +227,20 @@ if ( ! empty( $membership_group['post_content'] ) ) {
 											<?php echo UR_PRO_ACTIVE && urm_check_if_plus_and_above_plan() ? '' : 'disabled'; ?>
 											>
 										<span class="slider round"></span>
-										<?php ur_render_premium_feature_gate(); ?>
+										<?php
+										if ( ! UR_PRO_ACTIVE ) {
+											ur_render_premium_feature_gate();
+										} elseif ( ! urm_check_if_plus_and_above_plan() ) {
+											ur_render_premium_feature_gate(
+												array(
+													'plan_gated'  => true,
+													'template_id' => 'ur-plan-feature-plus',
+													'title'       => esc_html__( 'This feature is available on the Plus plan and above. Upgrade your plan to unlock it.', 'user-registration' ),
+													'button_text' => esc_html__( 'Upgrade Plan', 'user-registration' ),
+												)
+											);
+										}
+										?>
 									</span>
 								</div>
 							</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Jira: [UR-4695](https://themegrill.atlassian.net/browse/UR-4695)

On the Membership Group create/edit screen, the **Allow multiple memberships** and **Upgrade action** toggles are only functional on the Plus plan and above. On a Personal (below-Plus) Pro license the toggles were rendered `disabled` but showed **no upgrade indicator or notice** — because `ur_render_premium_feature_gate()` returned early whenever `UR_PRO_ACTIVE` was true, and the disable check failed only when the plan was below Plus. So Personal users saw a dead toggle with no explanation and assumed the feature was broken.

Changes:

- Extended `ur_render_premium_feature_gate()` / `ur_render_premium_feature_gate_template()` with an opt-in `plan_gated` flag plus configurable `title` / `button_text`, so the pro-icon + hover tooltip can render even when Pro is active but the plan requirement isn't met. Defaults are unchanged, so existing callers behave exactly as before.
- Wired both group toggles to show the pro-icon and an "Available on the Plus plan and above" tooltip (with an **Upgrade Plan** button) when the plan is below Plus, and applied the existing `upgradable-type` dimmed styling to those rows. The toggles remain `disabled` — only the missing feedback was added. Backend enforcement is unchanged (it already blocked these correctly).
- Also fixed pre-existing PHP `Trying to access array offset on null` warnings surfaced in the debug log when a membership's `post_content` is empty/invalid JSON, in `MembershipService::prepare_membership_data()` and the membership `ListTable` status/type columns (defensive `isset`/`empty` guards; behavior preserved).

### How to test the changes in this Pull Request:

1. Activate a **Personal** (below-Plus) license with the `membership-groups` module enabled.
2. Go to **User Registration → Membership → Groups → Add/Edit group**.
3. Confirm both **Allow multiple memberships** and **Upgrade action** toggles are disabled, show the pro-icon, and reveal an upgrade tooltip ("This feature is available on the Plus plan and above." + **Upgrade Plan** button) on hover.
4. Regression: with a **Plus/Professional** license the toggles are enabled/interactive with no gate icon; with the **free (non-Pro)** plugin the original "Upgrade to Pro" tooltip still shows.
5. Confirm the membership list screen and group services no longer emit `Trying to access array offset on null` warnings in `wp-content/debug.log`.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry
> UR-4695 Fix - Show upgrade prompt for Plus-gated membership group toggles on lower plans

[UR-4695]: https://themegrill.atlassian.net/browse/UR-4695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ