### PR TITLE
UR-4219 Fix - user_ip_address smart tag empty for IPv6 forwarded addresses

### DIFF
--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -6009,7 +6009,10 @@ if ( ! function_exists( 'ur_get_ip_address' ) ) {
 		} elseif ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) { // WPCS: input var ok, CSRF ok.
 			// Proxy servers can send through this header like this: X-Forwarded-For: client1, proxy1, proxy2
 			// Make sure we always only send through the first IP in the list which should always be the client IP.
-			return (string) rest_is_ip_address( trim( current( preg_split( '/[,:]/', sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) ) ) ) ); // WPCS: input var ok, CSRF ok.
+			$forwarded_ip = trim( current( preg_split( '/,/', sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) ) ) ); // WPCS: input var ok, CSRF ok.
+			// Remove the port from '<IPv4>:<port>', '[<IPv6>]' and '[<IPv6>]:<port>' while leaving bare IPv4/IPv6 intact.
+			$forwarded_ip = preg_replace( '/([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)\:.*|\[([^]]+)\].*/', '$1$2', $forwarded_ip );
+			return (string) rest_is_ip_address( $forwarded_ip );
 		} elseif ( isset( $_SERVER['REMOTE_ADDR'] ) ) { // @codingStandardsIgnoreLine
 			return sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ); // @codingStandardsIgnoreLine
 		}
@@ -6399,7 +6402,10 @@ if ( ! function_exists( 'ur_get_ip_address' ) ) {
 		} elseif ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) { // WPCS: input var ok, CSRF ok.
 			// Proxy servers can send through this header like this: X-Forwarded-For: client1, proxy1, proxy2.
 			// Make sure we always only send through the first IP in the list which should always be the client IP.
-			return (string) rest_is_ip_address( trim( current( preg_split( '/[,:]/', sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) ) ) ) ); // WPCS: input var ok, CSRF ok.
+			$forwarded_ip = trim( current( preg_split( '/,/', sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) ) ) ); // WPCS: input var ok, CSRF ok.
+			// Remove the port from '<IPv4>:<port>', '[<IPv6>]' and '[<IPv6>]:<port>' while leaving bare IPv4/IPv6 intact.
+			$forwarded_ip = preg_replace( '/([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)\:.*|\[([^]]+)\].*/', '$1$2', $forwarded_ip );
+			return (string) rest_is_ip_address( $forwarded_ip );
 		} elseif ( isset( $_SERVER['REMOTE_ADDR'] ) ) { // @codingStandardsIgnoreLine
 			return sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ); // @codingStandardsIgnoreLine
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`ur_get_ip_address()` read the client IP from the `X-Forwarded-For` header using `preg_split( '/[,:]/', ... )`. Splitting on `:` shreds IPv6 addresses (e.g. `::1`, `2001:db8::1`) â€” `current()` returns just the first fragment, `rest_is_ip_address()` rejects it, and the function returns an **empty string**.

As a result, any feature that relies on the client IP breaks whenever the IP reaches WordPress via `X-Forwarded-For` as IPv6 (common behind Nginx reverse proxies, Cloudflare, and local dev environments). The most visible symptom: the **`{{user_ip_address}}` smart tag renders blank** (e.g. when used as a field Default Value). IPv4 was unaffected, which made it look intermittent.

The colon in the split was originally meant to strip a `:port` suffix, but doing it in the same `preg_split` also destroys legitimate IPv6 colons. This PR adopts the same two-step approach used by WooCommerce's `WC_Geolocation::get_ip_address()`:

1. Split on `,` only to take the first (client) IP from the list.
2. Strip the port with an IPv6-aware regex that handles `<IPv4>:<port>`, `[<IPv6>]` and `[<IPv6>]:<port>`, while leaving bare IPv4/IPv6 untouched.

Applied to both copies of the function in `includes/functions-ur-core.php`.

Ref: UR-4219

### How to test the changes in this Pull Request:

1. On an environment where the visitor IP arrives via `X-Forwarded-For` as IPv6 (e.g. a reverse proxy, or locally force `$_SERVER['HTTP_X_FORWARDED_FOR'] = '::1'` with `HTTP_X_REAL_IP` unset).
2. Add a Text field to a registration form and set its **Default Value** to the `{{user_ip_address}}` smart tag.
3. View the form on the frontend.
   * **Before:** the field is empty.
   * **After:** the field is pre-filled with the visitor's IP (e.g. `::1`).

Verified matrix (`X-Forwarded-For` â†’ result): `::1` â†’ `::1`; `2001:db8::1, 70.41.3.18` â†’ `2001:db8::1`; `[2001:db8::1]:443` â†’ `2001:db8::1`; `1.2.3.4:5678` â†’ `1.2.3.4`; `203.0.113.5, 70.41.3.18` â†’ `203.0.113.5`. Every value the old code handled correctly is unchanged; only the broken IPv6 cases are fixed.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

Fix - `{{user_ip_address}}` smart tag returned empty for IPv6 visitor addresses.
