### PR TITLE
UR-4604 Fix - Misleading membership field warning on registration page selection

### DIFF
--- a/modules/membership/includes/Admin/Services/MembershipService.php
+++ b/modules/membership/includes/Admin/Services/MembershipService.php
@@ -548,8 +548,13 @@ class MembershipService {
 			}
 		}
 
-		$response['status']           = $membership_field_exists;
-		$response['message']          = ! $membership_field_exists ? __( 'The selected page consist a User Registration & Membership Form but no membership field.', 'user-registration' ) : '';
+		// Warn only when at least one active membership exists, since the field is
+		// pointless with none (see UR-4604).
+		$active_memberships_count = count( ( new MembershipRepository() )->get_all_membership() );
+		$show_notice              = ! $membership_field_exists && $active_memberships_count >= 1;
+
+		$response['status']           = ! $show_notice;
+		$response['message']          = $show_notice ? __( 'The selected page consist a User Registration & Membership Form but no membership field.', 'user-registration' ) : '';
 		$response['disable_save_btn'] = 'no';
 
 		return $response;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- The "no membership field" notice on the member registration page selection was shown even when no active membership exists, where a membership field is unnecessary.
- The notice now appears only when at least one active membership exists.

Closes UR-4604 .

### How to test the changes in this Pull Request:

1. With **0** active membership, select a registration page whose form has no membership field — no notice is shown and the setting saves.
2. With **1 or more** active memberships, select the same page — the notice is shown (save still allowed).
3. Select a page whose form has a membership field — no notice in either case.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Misleading missing membership field notice shown on registration page selection when no active membership exists.
