### PR TITLE
UR-4721 - Fix - User Registration css loading when elementor active.

### DIFF
--- a/includes/3rd-party/elementor/class-ur-elementor.php
+++ b/includes/3rd-party/elementor/class-ur-elementor.php
@@ -107,7 +107,6 @@ class UR_Elementor {
 	 */
 	public function register_widget_styles() {
 		wp_register_style( 'user-registration-general', UR()->plugin_url() . '/assets/css/user-registration.css', array(), UR()->version );
-		wp_enqueue_style( 'user-registration-general' );
 	}
 
 	/**

--- a/includes/3rd-party/elementor/widgets/class-ur-widgets-edit-password.php
+++ b/includes/3rd-party/elementor/widgets/class-ur-widgets-edit-password.php
@@ -85,6 +85,10 @@ class UR_Elementor_Widget_Edit_Password extends Widget_Base {
 		$shortcode = sprintf( apply_filters( 'user_registration_elementor_shortcode_edit_password', $shortcode, $settings ) );
 		return $shortcode;
 	}
+	public function get_style_depends() {
+		return array( 'user-registration-general' );
+	}
+
 	/**
 	 * Render widget output.
 	 */

--- a/includes/3rd-party/elementor/widgets/class-ur-widgets-edit-profile.php
+++ b/includes/3rd-party/elementor/widgets/class-ur-widgets-edit-profile.php
@@ -90,6 +90,10 @@ class UR_Elementor_Widget_Edit_Profile extends Widget_Base {
 		$shortcode = sprintf( apply_filters( 'user_registration_elementor_shortcode_edit_profile', $shortcode, $settings ) );
 		return $shortcode;
 	}
+	public function get_style_depends() {
+		return array( 'user-registration-general' );
+	}
+
 	/**
 	 * Render widget output.
 	 *

--- a/includes/3rd-party/elementor/widgets/class-ur-widgets-login.php
+++ b/includes/3rd-party/elementor/widgets/class-ur-widgets-login.php
@@ -99,6 +99,10 @@ class UR_Elementor_Widget_Login extends Widget_Base {
 		$shortcode = sprintf( apply_filters( 'user_registration_elementor_shortcode_login_form', $shortcode, $settings ) );
 		return $shortcode;
 	}
+	public function get_style_depends() {
+		return array( 'user-registration-general' );
+	}
+
 	/**
 	 * Render widget output.
 	 *

--- a/includes/3rd-party/elementor/widgets/class-ur-widgets-membership-listing.php
+++ b/includes/3rd-party/elementor/widgets/class-ur-widgets-membership-listing.php
@@ -260,6 +260,10 @@ class UR_Elementor_Widget_Membership_Listing extends Widget_Base {
 		do_action( 'user_registration_elementor_membership_listing_style', $this );
 	}
 
+	public function get_style_depends() {
+		return array( 'user-registration-general' );
+	}
+
 	/**
 	 * Render widget output.
 	 */

--- a/includes/3rd-party/elementor/widgets/class-ur-widgets-myaccount.php
+++ b/includes/3rd-party/elementor/widgets/class-ur-widgets-myaccount.php
@@ -88,6 +88,10 @@ class UR_Elementor_Widget_MyAccount extends Widget_Base {
 		$shortcode = sprintf( apply_filters( 'user_registration_elementor_shortcode_my_account', $shortcode, $settings ) );
 		return $shortcode;
 	}
+	public function get_style_depends() {
+		return array( 'user-registration-general' );
+	}
+
 	/**
 	 * Render widget output.
 	 */

--- a/includes/3rd-party/elementor/widgets/class-ur-widgets-popup.php
+++ b/includes/3rd-party/elementor/widgets/class-ur-widgets-popup.php
@@ -109,6 +109,10 @@ class UR_Elementor_Widget_Popup extends Widget_Base {
 
 		return implode( '', $shortcode );
 	}
+	public function get_style_depends() {
+		return array( 'user-registration-general' );
+	}
+
 	/**
 	 * Render widget output.
 	 */

--- a/includes/3rd-party/elementor/widgets/class-ur-widgets-profile-details.php
+++ b/includes/3rd-party/elementor/widgets/class-ur-widgets-profile-details.php
@@ -86,6 +86,10 @@ class UR_Elementor_Widget_View_Details extends Widget_Base {
 		return $shortcode;
 	}
 
+	public function get_style_depends() {
+		return array( 'user-registration-general' );
+	}
+
 	/**
 	 * Render widget output.
 	 */

--- a/includes/3rd-party/elementor/widgets/class-ur-widgets-registration.php
+++ b/includes/3rd-party/elementor/widgets/class-ur-widgets-registration.php
@@ -111,6 +111,10 @@ class UR_Elementor_Widget_Registration extends Widget_Base {
 		$shortcode   = sprintf( apply_filters( 'user_registration_elementor_shortcode_registration_form', $shortcode, $settings ) );
 		return $shortcode;
 	}
+	public function get_style_depends() {
+		return array( 'user-registration-general' );
+	}
+
 	/**
 	 * Render widget output.
 	 */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When elementor active the user-registration.css was loading in the frontend everywhere this fixes the issue.

Closes # .

### How to test the changes in this Pull Request:

1.Create a page with elementor and another without elementor.
2.The css must not load on either of the page.
3. Again add UR form in both pages and check again if the css loads correctly or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - User Registration css loading when elementor active.
