### PR TITLE
UR-4727 Fix - Stripe membership confirmation blocked by 'not allowed to edit this user' leaving order stuck Pending

### DIFF
--- a/modules/membership/includes/AJAX.php
+++ b/modules/membership/includes/AJAX.php
@@ -858,21 +858,12 @@ class AJAX {
 	}
 
 	/**
-	 * Verify that a logged-out payment-confirmation request genuinely belongs to
-	 * the browser that created this pending registration.
+	 * Verify a logged-out payment confirmation belongs to the browser that created
+	 * this pending registration: the cookie must match the signup transient, or
+	 * (UR-4727) the server-recomputed HMAC when the transient was cleared mid-flow.
 	 *
-	 * Primary check: the per-registration transient set at signup matches the
-	 * browser cookie. Fallback (UR-4727): if that transient was already consumed
-	 * or deleted by another step while the browser is still logged out — e.g.
-	 * auto-login (MembersService::login_member) or the Stripe failure webhooks
-	 * (handle_invoice_payment_failed / handle_failed_payment_intent) — accept the
-	 * request when the cookie matches the server-recomputed HMAC, i.e. the same
-	 * value login_member() validates against. That HMAC depends on
-	 * wp_salt( 'auth' ), so a third party cannot forge it, and the pending-order
-	 * gate in the callers still blocks replays after the order is no longer pending.
-	 *
-	 * @param int $member_id Member/user ID whose pending payment is being confirmed.
-	 * @return bool True when the request is bound to this member's registration session.
+	 * @param int $member_id Pending member/user ID.
+	 * @return bool
 	 */
 	private static function verify_pending_member_session( $member_id ) {
 		$cookie_key   = 'urm_pending_login_' . $member_id;

--- a/modules/membership/includes/AJAX.php
+++ b/modules/membership/includes/AJAX.php
@@ -857,6 +857,42 @@ class AJAX {
 		}
 	}
 
+	/**
+	 * Verify that a logged-out payment-confirmation request genuinely belongs to
+	 * the browser that created this pending registration.
+	 *
+	 * Primary check: the per-registration transient set at signup matches the
+	 * browser cookie. Fallback (UR-4727): if that transient was already consumed
+	 * or deleted by another step while the browser is still logged out — e.g.
+	 * auto-login (MembersService::login_member) or the Stripe failure webhooks
+	 * (handle_invoice_payment_failed / handle_failed_payment_intent) — accept the
+	 * request when the cookie matches the server-recomputed HMAC, i.e. the same
+	 * value login_member() validates against. That HMAC depends on
+	 * wp_salt( 'auth' ), so a third party cannot forge it, and the pending-order
+	 * gate in the callers still blocks replays after the order is no longer pending.
+	 *
+	 * @param int $member_id Member/user ID whose pending payment is being confirmed.
+	 * @return bool True when the request is bound to this member's registration session.
+	 */
+	private static function verify_pending_member_session( $member_id ) {
+		$cookie_key   = 'urm_pending_login_' . $member_id;
+		$cookie_token = isset( $_COOKIE[ $cookie_key ] ) ? wp_unslash( $_COOKIE[ $cookie_key ] ) : '';
+
+		if ( empty( $cookie_token ) ) {
+			return false;
+		}
+
+		$saved_hash = get_transient( $cookie_key );
+		if ( ! empty( $saved_hash ) && hash_equals( (string) $saved_hash, (string) $cookie_token ) ) {
+			return true;
+		}
+
+		// Fallback: transient gone but the cookie still proves this browser registered.
+		$expected_hash = hash_hmac( 'sha256', (string) $member_id, wp_salt( 'auth' ) );
+
+		return hash_equals( $expected_hash, (string) $cookie_token );
+	}
+
 	public static function confirm_payment() {
 
 		ur_membership_verify_nonce( 'urm_confirm_payment' );
@@ -903,9 +939,7 @@ class AJAX {
 			}
 		} else {
 			// Nopriv: bind to the registration session that created this pending member.
-			$saved_hash   = get_transient( 'urm_pending_login_' . $member_id );
-			$cookie_token = isset( $_COOKIE[ 'urm_pending_login_' . $member_id ] ) ? wp_unslash( $_COOKIE[ 'urm_pending_login_' . $member_id ] ) : '';
-			if ( empty( $saved_hash ) || empty( $cookie_token ) || ! hash_equals( (string) $saved_hash, (string) $cookie_token ) ) {
+			if ( ! self::verify_pending_member_session( $member_id ) ) {
 				wp_send_json_error(
 					array(
 						'message' => __( 'You are not allowed to edit this user.', 'user-registration' ),
@@ -1154,9 +1188,7 @@ class AJAX {
 			}
 		} else {
 			// Nopriv: bind to the registration session that created this pending member.
-			$saved_hash   = get_transient( 'urm_pending_login_' . $member_id );
-			$cookie_token = isset( $_COOKIE[ 'urm_pending_login_' . $member_id ] ) ? wp_unslash( $_COOKIE[ 'urm_pending_login_' . $member_id ] ) : '';
-			if ( empty( $saved_hash ) || empty( $cookie_token ) || ! hash_equals( (string) $saved_hash, (string) $cookie_token ) ) {
+			if ( ! self::verify_pending_member_session( $member_id ) ) {
 				wp_send_json_error(
 					array(
 						'message' => __( 'You are not allowed to edit this user.', 'user-registration' ),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Jira: [UR-4727](https://themegrill.atlassian.net/browse/UR-4727)

The nopriv guard on `confirm_payment()` / `create_stripe_subscription()` requires the `urm_pending_login_{id}` transient, but that transient is deleted mid-flow by `login_member()` and the Stripe failure webhooks. When it's gone while the browser is still logged out (e.g. a failure webhook during 3DS), the valid cookie is rejected → confirmation aborts before `update_order()` → the order/subscription stay **Pending** (course shows Restricted) even though Stripe charged, and the user sees "You are not allowed to edit this user."

**Fix:** new helper `AJAX::verify_pending_member_session()` on both nopriv blocks — keeps the transient+cookie check, and when the transient is missing falls back to the cookie vs server-recomputed `hash_hmac('sha256', $id, wp_salt('auth'))` (same value `login_member()` uses). Can't be forged without the salt; the pending-order gate still blocks replays. Server-side only.

Closes # .

### How to test the changes in this Pull Request:

1. Register (logged out) for a Stripe **subscription** plan with 3DS card `4000 0025 0000 3155`.
2. Clear `urm_pending_login_{new_user_id}` between the `create_stripe_subscription` and `confirm_payment` requests (simulates the failure webhook / `login_member`).
3. Complete 3DS. **Before:** "not allowed to edit this user", order stuck Pending. **After:** order completes, subscription active. Normal flow and no-/forged-cookie rejection are unchanged.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)

### Changelog entry

Fix - Stripe membership subscription stuck in Pending with a false "not allowed to edit this user" error.


[UR-4727]: https://themegrill.atlassian.net/browse/UR-4727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ